### PR TITLE
Limit max amount of stacks that can be attracted by magnet at the same time

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
@@ -50,6 +50,7 @@ public class ConfigHandler {
     public static boolean enableFlight;
     private static String[] itemDislocatorBlacklist;
     public static Map<String, Integer> itemDislocatorBlacklistMap = new HashMap<String, Integer>();
+    public static int magnetStackLimit;
 
     //spawner
     public static String[] spawnerList;
@@ -125,7 +126,7 @@ public class ConfigHandler {
             itemDislocatorBlacklist = config.getStringList("Item Dislocator Blacklist", Configuration.CATEGORY_GENERAL, new String[]{"appliedenergistics2:item.ItemCrystalSeed"}, "A list of items of items that should be ignored by the item dislocator. Use the items registry name e.g. minecraft:apple you can also add a meta value like so minecraft:wool|4");
             disableLog = config.get(Configuration.CATEGORY_GENERAL, "Disable Log", false, "If you are having issued with console spam that you cant fix setting this to true will disable all log output from Draconic Evolution (Not recommended)").getBoolean(false);
             enableFlight = config.get(Configuration.CATEGORY_GENERAL, "Enable Flight", true, "Set this to false to disable flight given by draconic armor.").getBoolean(true);
-
+            magnetStackLimit = config.get(Configuration.CATEGORY_GENERAL, "Magnet Stack Limit", 30, "Limit how much stacks might be attracted at the same time, high values can cause both server and client lag").getInt();
 
             //Spawner
             spawnerListType = config.get("spawner", "listType", false, "Sets weather the spawner list is a white list or a black list (true = white list false = black list)").getBoolean(false);

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
@@ -25,6 +25,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerPickupXpEvent;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Created by brandon3055 on 9/3/2016.
@@ -80,10 +81,11 @@ public class Magnet extends ItemDE {
             int range = stack.getItemDamage() == 0 ? 8 : 32;
 
             List<EntityItem> items = world.getEntitiesWithinAABB(EntityItem.class, AxisAlignedBB.getBoundingBox(entity.posX, entity.posY, entity.posZ, entity.posX, entity.posY, entity.posZ).expand(range, range, range));
+            List<EntityItem> nearestItems = items.stream().limit(ConfigHandler.magnetStackLimit).collect(Collectors.toList());
 
             boolean flag = false;
 
-            for (EntityItem item : items) {
+            for (EntityItem item : nearestItems) {
                 if (item.getEntityItem() == null) {
                     continue;
                 }


### PR DESCRIPTION
Large amounts of items that gets teleported around can cause both client and server lag, and obviously you don't need to attract 5M items to yourself at the same time.