### PR TITLE
Keybinds

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/client/handler/ClientEventHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/handler/ClientEventHandler.java
@@ -109,7 +109,7 @@ public class ClientEventHandler {
     @SideOnly(Side.CLIENT)
     public void renderGameOverlayEvent(final RenderGameOverlayEvent.Post event) {
         if (event.type == RenderGameOverlayEvent.ElementType.ALL) {
-            statusDisplayManager.drawItemStack();
+            statusDisplayManager.drawItemStack(event.resolution);
         }
     }
 

--- a/src/main/java/com/brandon3055/draconicevolution/client/handler/ItemDisplayManager.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/handler/ItemDisplayManager.java
@@ -35,22 +35,16 @@ public final class ItemDisplayManager {
         }
     }
 
-    public void drawItemStack() {
+    public void drawItemStack(ScaledResolution resolution) {
         if (ticksCounter > 0 && itemStack != null && itemStack.getItem() != null) {
             GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
             GL11.glEnable(GL12.GL_RESCALE_NORMAL);
             RenderHelper.enableGUIStandardItemLighting();
 
             GL11.glPushMatrix();
-
-            final Minecraft mc = Minecraft.getMinecraft();
-            final ScaledResolution res = new ScaledResolution(mc, mc.displayWidth, mc.displayHeight);
-            final int y = res.getScaledHeight();
-
+            final int y = resolution.getScaledHeight();
             GL11.glTranslatef(7.0f, y * 0.25f, 0);
-
             renderItem.renderItemAndEffectIntoGUI(fontRenderer, textureManager, itemStack, 0, 0);
-
             GL11.glPopMatrix();
 
             RenderHelper.disableStandardItemLighting();

--- a/src/main/java/com/brandon3055/draconicevolution/client/keybinding/KeyBindings.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/keybinding/KeyBindings.java
@@ -21,8 +21,8 @@ public final class KeyBindings {
 
     static {
         placeItem = new KeyBinding("key.placeItem", Keyboard.KEY_P, References.MODNAME);
-        toolConfig = new KeyBinding("key.toolConfig", Keyboard.KEY_C, References.MODNAME);
-        toolProfileChange = new KeyBinding("key.toolProfileChange", Keyboard.KEY_BACKSLASH, References.MODNAME);
+        toolConfig = new KeyBinding("key.toolConfig", Keyboard.KEY_NONE, References.MODNAME);
+        toolProfileChange = new KeyBinding("key.toolProfileChange", Keyboard.KEY_NONE, References.MODNAME);
         toggleFlight = new KeyBinding("key.toggleFlight", Keyboard.KEY_NONE, References.MODNAME);
         toggleMagnet = new KeyBinding("key.toggleMagnet", Keyboard.KEY_NONE, References.MODNAME);
     }

--- a/src/main/java/com/brandon3055/draconicevolution/client/keybinding/KeyInputHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/keybinding/KeyInputHandler.java
@@ -29,8 +29,9 @@ public class KeyInputHandler {
     @SideOnly(Side.CLIENT)
     @SubscribeEvent
     public void onKeyInput(InputEvent.KeyInputEvent event) {
-        if (KeyBindings.placeItem.isPressed()) handlePlaceItemKey();
-        else if (KeyBindings.toolConfig.isPressed()) {
+        if (KeyBindings.placeItem.isPressed()) {
+            handlePlaceItemKey();
+        } else if (KeyBindings.toolConfig.isPressed()) {
             DraconicEvolution.network.sendToServer(new ButtonPacket(ButtonPacket.ID_TOOLCONFIG, false));
         } else if (KeyBindings.toolProfileChange.isPressed()
                 && Minecraft.getMinecraft().thePlayer != null
@@ -50,19 +51,17 @@ public class KeyInputHandler {
             if (player.capabilities.allowFlying) {
                 if (player.capabilities.isFlying) {
                     player.capabilities.isFlying = false;
-                    player.sendPlayerAbilities();
                 } else {
                     player.capabilities.isFlying = true;
                     if (player.onGround) {
                         player.setPosition(player.posX, player.posY + 0.05D, player.posZ);
                         player.motionY = 0;
                     }
-                    player.sendPlayerAbilities();
                 }
+                player.sendPlayerAbilities();
             }
         } else if (KeyBindings.toggleMagnet.isPressed()) {
             EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-
             if (player.inventory.hasItem(ModItems.magnet)) {
                 DraconicEvolution.network.sendToServer(new MagnetTogglePacket());
             }
@@ -73,16 +72,18 @@ public class KeyInputHandler {
         EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;
         WorldClient world = Minecraft.getMinecraft().theWorld;
         MovingObjectPosition mop = ToolHandler.raytraceFromEntity(world, player, 4.5D);
-        if (mop != null)
+        if (mop != null) {
             DraconicEvolution.network.sendToServer(
                     new PlacedItemPacket((byte) mop.sideHit, mop.blockX, mop.blockY, mop.blockZ));
+        }
     }
 
     @SideOnly(Side.CLIENT)
     @SubscribeEvent
     public void onMouseInput(InputEvent.MouseInputEvent event) {
-        if (KeyBindings.placeItem.isPressed()) handlePlaceItemKey();
-        else if (KeyBindings.toolConfig.isPressed()) {
+        if (KeyBindings.placeItem.isPressed()) {
+            handlePlaceItemKey();
+        } else if (KeyBindings.toolConfig.isPressed()) {
             DraconicEvolution.network.sendToServer(new ButtonPacket(ButtonPacket.ID_TOOLCONFIG, false));
         } else if (KeyBindings.toolProfileChange.isPressed() && Minecraft.getMinecraft().thePlayer != null) {
             DraconicEvolution.network.sendToServer(new ButtonPacket(ButtonPacket.ID_TOOL_PROFILE_CHANGE, false));
@@ -107,7 +108,7 @@ public class KeyInputHandler {
                 player.inventory.currentItem = previouseSlot(1, player.inventory.currentItem);
                 DraconicEvolution.network.sendToServer(new TeleporterPacket(TeleporterPacket.SCROLL, -1, false));
             }
-        } else if (change < 0) {
+        } else {
             ItemStack item = player.inventory.getStackInSlot(previouseSlot(-1, player.inventory.currentItem));
             if (item != null && item.getItem().equals(ModItems.teleporterMKII)) {
                 player.inventory.currentItem = previouseSlot(-1, player.inventory.currentItem);


### PR DESCRIPTION
* unbind some keybinds by default
* use resolution of the event for rendering istead of creating a new one


The goal is to unbind all keys that are not used from the start of the game in the GTNH modpack to avoid all the current keybinds conflict and leave to the user the choice of the keybinds they want.