### PR TITLE
Add config option item dislocator sound

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
@@ -271,8 +271,7 @@ public class ConfigHandler {
                     Configuration.CATEGORY_GENERAL,
                     "Item Dislocator Disable Sound",
                     false,
-                    "Disable item dislocator sound")
-                    .getBoolean(false);
+                    "Disable item dislocator sound").getBoolean(false);
             disableLog = config.get(
                     Configuration.CATEGORY_GENERAL,
                     "Disable Log",

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
@@ -51,6 +51,7 @@ public class ConfigHandler {
     public static boolean enableFlight;
     private static String[] itemDislocatorBlacklist;
     public static Map<String, Integer> itemDislocatorBlacklistMap = new HashMap<String, Integer>();
+    public static boolean itemDislocatorDisableSound;
 
     // spawner
     public static String[] spawnerList;
@@ -266,6 +267,12 @@ public class ConfigHandler {
                     Configuration.CATEGORY_GENERAL,
                     new String[] { "appliedenergistics2:item.ItemCrystalSeed" },
                     "A list of items of items that should be ignored by the item dislocator. Use the items registry name e.g. minecraft:apple you can also add a meta value like so minecraft:wool|4");
+            itemDislocatorDisableSound = config.get(
+                    Configuration.CATEGORY_GENERAL,
+                    "Item Dislocator Disable Sound",
+                    false,
+                    "Disable item dislocator sound")
+                    .getBoolean(false);
             disableLog = config.get(
                     Configuration.CATEGORY_GENERAL,
                     "Disable Log",

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
@@ -121,7 +121,7 @@ public class Magnet extends ItemDE {
                         entity.posY - 0.6,
                         entity.posZ - 0.2 + (world.rand.nextDouble() * 0.4));
             }
-            if (playSound) {
+            if (playSound && !ConfigHandler.itemDislocatorDisableSound) {
                 world.playSoundAtEntity(
                         entity,
                         "random.orb",


### PR DESCRIPTION
Backport of upstream https://github.com/Draconic-Inc/Draconic-Evolution/commit/4570abbc71c720940493dd0cfdcc20e59b24fb5a

When combined with the voiding drop filter, the item dislocator plays a sound for every single item in a stack picked up. This adds a config option to disable the sound entirely