### PR TITLE
Consume 64 ender pearls at once

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/GUITeleporter.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/GUITeleporter.java
@@ -29,12 +29,14 @@ import com.brandon3055.draconicevolution.common.handler.ConfigHandler;
 import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.network.TeleporterPacket;
 
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
 public class GUITeleporter extends GuiScreen {
 
+    private static final int pearlsWithShift = Loader.isModLoaded("dreamcraft") ? 64 : 16;
     private final int xSize = 182;
     private final int ySize = 141;
     private ResourceLocation guiTexture = new ResourceLocation(
@@ -533,9 +535,10 @@ public class GUITeleporter extends GuiScreen {
                 if ((!Keyboard.isKeyDown(42)) && (!Keyboard.isKeyDown(54))) {
                     DraconicEvolution.network.sendToServer(new TeleporterPacket(TeleporterPacket.ADDFUEL, 1, false));
                     this.fuel += ConfigHandler.teleporterUsesPerPearl;
-                } else if (hasPearls(16)) {
-                    DraconicEvolution.network.sendToServer(new TeleporterPacket(TeleporterPacket.ADDFUEL, 16, false));
-                    this.fuel += ConfigHandler.teleporterUsesPerPearl * 16;
+                } else if (hasPearls(pearlsWithShift)) {
+                    DraconicEvolution.network
+                            .sendToServer(new TeleporterPacket(TeleporterPacket.ADDFUEL, pearlsWithShift, false));
+                    this.fuel += ConfigHandler.teleporterUsesPerPearl * pearlsWithShift;
                 } else player.addChatMessage(new ChatComponentTranslation("msg.teleporterOutOfPearls.txt"));
             } else player.addChatMessage(new ChatComponentTranslation("msg.teleporterOutOfPearls.txt"));
         }

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/GUITeleporter.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/GUITeleporter.java
@@ -36,7 +36,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 @SideOnly(Side.CLIENT)
 public class GUITeleporter extends GuiScreen {
 
-    private static final int pearlsWithShift = Loader.isModLoaded("dreamcraft") ? 64 : 16;
+    private static final int PEARLS_WITH_SHIFT = Loader.isModLoaded("dreamcraft") ? 64 : 16;
     private final int xSize = 182;
     private final int ySize = 141;
     private ResourceLocation guiTexture = new ResourceLocation(
@@ -535,10 +535,10 @@ public class GUITeleporter extends GuiScreen {
                 if ((!Keyboard.isKeyDown(42)) && (!Keyboard.isKeyDown(54))) {
                     DraconicEvolution.network.sendToServer(new TeleporterPacket(TeleporterPacket.ADDFUEL, 1, false));
                     this.fuel += ConfigHandler.teleporterUsesPerPearl;
-                } else if (hasPearls(pearlsWithShift)) {
+                } else if (hasPearls(PEARLS_WITH_SHIFT)) {
                     DraconicEvolution.network
-                            .sendToServer(new TeleporterPacket(TeleporterPacket.ADDFUEL, pearlsWithShift, false));
-                    this.fuel += ConfigHandler.teleporterUsesPerPearl * pearlsWithShift;
+                            .sendToServer(new TeleporterPacket(TeleporterPacket.ADDFUEL, PEARLS_WITH_SHIFT, false));
+                    this.fuel += ConfigHandler.teleporterUsesPerPearl * PEARLS_WITH_SHIFT;
                 } else player.addChatMessage(new ChatComponentTranslation("msg.teleporterOutOfPearls.txt"));
             } else player.addChatMessage(new ChatComponentTranslation("msg.teleporterOutOfPearls.txt"));
         }


### PR DESCRIPTION
Since we changed enderpearl stacksize to 64, I made it so Enchanced Draconic Dislocator when holding shift consume 64 pearls as fuel instead of 16, it doesnt change balance only makes it faster to refuel it.