### PR TITLE
Code cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1684218858
+//version: 1685785062
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -1276,12 +1276,14 @@ tasks.register('faq') {
     description = 'Prints frequently asked questions about building a project'
 
     doLast {
-        print("If your build fails to fetch dependencies, they might have been deleted and replaced by newer " +
-            "versions.\nCheck if the versions you try to fetch are still on the distributing sites.\n" +
-            "The links can be found in repositories.gradle and build.gradle:repositories, " +
-            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.\n\n" +
+        print("If your build fails to fetch dependencies, run './gradlew updateDependencies'. " +
+            "Or you can manually check if the versions are still on the distributing sites - " +
+            "the links can be found in repositories.gradle and build.gradle:repositories, " +
+            "but not build.gradle:buildscript.repositories - those ones are for gradle plugin metadata.\n\n" +
             "If your build fails to recognize the syntax of new Java versions, enable Jabel in your " +
-            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties.")
+            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties. " +
+            "However, keep in mind that Jabel enables only syntax features, but not APIs that were introduced in " +
+            "Java 9 or later.")
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1683373797
+//version: 1684218858
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -69,7 +69,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.7'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.14'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")
@@ -569,9 +569,10 @@ repositories {
 
 def mixinProviderGroup = "io.github.legacymoddingmc"
 def mixinProviderModule = "unimixins"
-def mixinProviderVersion = "0.1.6"
+def mixinProviderVersion = "0.1.7.1"
 def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
 def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
+ext.mixinProviderSpec = mixinProviderSpec
 
 dependencies {
     if (usesMixins.toBoolean()) {
@@ -729,7 +730,7 @@ dependencies {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.8')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.13')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
@@ -821,6 +822,18 @@ public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
             !file.path.contains("2.9.4-nightly-20150209") // Remove lwjgl2
         }
         this.classpath(project.java17DependenciesCfg)
+    }
+
+    public void setup(Project project) {
+        super.setup(project)
+        if (project.usesMixins.toBoolean()) {
+            this.extraJvmArgs.addAll(project.provider(() -> {
+                def mixinCfg = project.configurations.detachedConfiguration(project.dependencies.create(project.mixinProviderSpec))
+                mixinCfg.canBeConsumed = false
+                mixinCfg.transitive = false
+                enableHotswap ? ["-javaagent:" + mixinCfg.singleFile.absolutePath] : []
+            }))
+        }
     }
 }
 
@@ -1266,7 +1279,9 @@ tasks.register('faq') {
         print("If your build fails to fetch dependencies, they might have been deleted and replaced by newer " +
             "versions.\nCheck if the versions you try to fetch are still on the distributing sites.\n" +
             "The links can be found in repositories.gradle and build.gradle:repositories, " +
-            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.")
+            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.\n\n" +
+            "If your build fails to recognize the syntax of new Java versions, enable Jabel in your " +
+            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties.")
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:OpenComputers:1.9.5-GTNH:api") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.3.50-GTNH:dev") {
+    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.3.53-GTNH:dev") {
         transitive = false
     }
     compileOnly("com.github.GTNewHorizons:CodeChickenLib:1.1.8:dev") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,8 @@ forgeVersion = 10.13.4.1614
 # Do you need to test how your custom blocks interacts with a player that is not the owner? -> leave name empty
 developmentEnvironmentUserName = Developer
 
+enableModernJavaSyntax = true
+
 # Define a source file of your project with:
 # public static final String VERSION = "GRADLETOKEN_VERSION";
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's

--- a/src/main/java/com/brandon3055/draconicevolution/client/ClientProxy.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/ClientProxy.java
@@ -333,7 +333,7 @@ public class ClientProxy extends CommonProxy {
             beam.setDead();
             return null;
         } else {
-            beam.update(render);
+            beam.update();
         }
         return beam;
     }

--- a/src/main/java/com/brandon3055/draconicevolution/client/ReactorSound.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/ReactorSound.java
@@ -12,52 +12,44 @@ import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.rea
  */
 public class ReactorSound extends PositionedSound implements ITickableSound {
 
-    private static ResourceLocation sound = new ResourceLocation(References.RESOURCESPREFIX + "coreSound");
-    public boolean donePlaying = false;
-    private TileReactorCore tile;
+    private static final ResourceLocation sound = new ResourceLocation(References.RESOURCESPREFIX + "coreSound");
+    public boolean isDonePlaying = false;
+    private final TileReactorCore core;
 
-    public ReactorSound(TileReactorCore tile) {
+    public ReactorSound(TileReactorCore core) {
         super(sound);
-        this.tile = tile;
-        this.xPosF = (float) tile.xCoord + 0.5F;
-        this.yPosF = (float) tile.yCoord + 0.5F;
-        this.zPosF = (float) tile.zCoord + 0.5F;
+        this.core = core;
+        this.xPosF = (float) core.xCoord + 0.5F;
+        this.yPosF = (float) core.yCoord + 0.5F;
+        this.zPosF = (float) core.zCoord + 0.5F;
         this.repeat = true;
         this.volume = 1.5F;
     }
 
     @Override
     public boolean isDonePlaying() {
-        return donePlaying;
+        return isDonePlaying;
     }
 
     @Override
     public void update() {
-
-        volume = (tile.renderSpeed - 0.5F) * 2F;
-        if (tile.reactionTemperature > 8000) {
-            volume += (float) ((tile.reactionTemperature - 8000D) / 1000D);
+        volume = (core.renderSpeed - 0.5F) * 2F;
+        if (core.reactionTemperature > 8000) {
+            volume += (float) ((core.reactionTemperature - 8000D) / 1000D);
         }
-        if (tile.reactionTemperature > 2000 && tile.maxFieldCharge > 0
-                && tile.fieldCharge < (tile.maxFieldCharge * 0.2D)) {
-            volume += 2D - ((tile.fieldCharge / tile.maxFieldCharge) * 10D);
+        if (core.reactionTemperature > 2000 && core.maxFieldCharge > 0
+                && core.fieldCharge < (core.maxFieldCharge * 0.2D)) {
+            volume += 2D - ((core.fieldCharge / core.maxFieldCharge) * 10D);
         }
-        if (tile.reactionTemperature > 2000 && tile.reactorFuel + tile.convertedFuel > 0
-                && tile.reactorFuel < (double) (tile.reactorFuel + tile.convertedFuel) * 0.2D) {
-            volume += 2D - ((tile.reactorFuel / (tile.reactorFuel + tile.convertedFuel)) * 10D);
+        if (core.reactionTemperature > 2000 && core.reactorFuel + core.convertedFuel > 0
+                && core.reactorFuel < (double) (core.reactorFuel + core.convertedFuel) * 0.2D) {
+            volume += 2D - ((float) core.reactorFuel / (core.reactorFuel + core.convertedFuel)) * 10D;
         }
 
         field_147663_c = 0.5F + volume / 2F;
 
-        if (tile.isInvalid() || !tile.getWorldObj().getChunkFromBlockCoords(tile.xCoord, tile.zCoord).isChunkLoaded) { // ||
-                                                                                                                       // player
-                                                                                                                       // ==
-                                                                                                                       // null
-                                                                                                                       // ||
-                                                                                                                       // tile.getDistanceFrom(player.posX,
-                                                                                                                       // player.posY,
-            // player.posZ) > 512){
-            donePlaying = true;
+        if (core.isInvalid() || !core.getWorldObj().getChunkFromBlockCoords(core.xCoord, core.zCoord).isChunkLoaded) {
+            isDonePlaying = true;
             repeat = false;
         }
     }

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIParticleGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIParticleGenerator.java
@@ -209,7 +209,11 @@ public class GUIParticleGenerator extends GuiScreen {
         drawTexturedModalRect(posX, posY, 0, 0, xSize, ySize);
 
         if (page == 1) {
-            fontRendererObj.drawStringWithShadow("Particle Generator", posX + 60, posY + 5, 0x00FFFF);
+            fontRendererObj.drawStringWithShadow(
+                    StatCollector.translateToLocal("gui.de.particleGenerator.main.title"),
+                    posX + 60,
+                    posY + 5,
+                    0x00FFFF);
             for (int column = 0; column < 2; column++) {
                 for (int row = 0; row < 8; row++) {
                     IProperty property = properties.get(row + column * 10);
@@ -221,7 +225,11 @@ public class GUIParticleGenerator extends GuiScreen {
             }
         }
         if (page == 2) {
-            fontRendererObj.drawStringWithShadow("Particle Generator", posX + 60, posY + 5, 0x00FFFF);
+            fontRendererObj.drawStringWithShadow(
+                    StatCollector.translateToLocal("gui.de.particleGenerator.main.title"),
+                    posX + 60,
+                    posY + 5,
+                    0x00FFFF);
             for (int row = 0; row < 6; row++) {
                 IProperty property = properties.get(row + 20);
                 property.drawLabel(fontRendererObj, posX + 30, posY + 20 + row * 22);
@@ -233,22 +241,34 @@ public class GUIParticleGenerator extends GuiScreen {
             }
         }
         if (page == 3) {
-            fontRendererObj.drawStringWithShadow("Beam Generator", posX + 65, posY + 5, 0x00FFFF);
+            fontRendererObj.drawStringWithShadow(
+                    StatCollector.translateToLocal("gui.de.particleGenerator.beam.title"),
+                    posX + 65,
+                    posY + 5,
+                    0x00FFFF);
             for (int row = 0; row < 8; row++) {
                 IProperty property = properties.get(row + 40);
                 property.drawLabel(fontRendererObj, posX + 30, posY + 20 + row * 22);
             }
         }
         if (page == 10) {
-            fontRendererObj.drawStringWithShadow("Information", posX + 75, posY + 5, 0x00FFFF);
+            fontRendererObj.drawStringWithShadow(
+                    StatCollector.translateToLocal("gui.de.particleGenerator.info.title"),
+                    posX + 75,
+                    posY + 5,
+                    0x00FFFF);
             fontRendererObj.drawSplitString(infoText[infoPage], posX + 5, posY + 20, 200, 0x000000);
             fontRendererObj.drawSplitString("Page: " + (infoPage + 1), posX + 88, posY + 180, 200, 0xFF0000);
         }
 
-        fontRendererObj.drawStringWithShadow("Hold:", posX + 215, posY + 11, 0xFFFFFF);
-        fontRendererObj.drawStringWithShadow("Shift +- 10", posX + 215, posY + 21, 0xFFFFFF);
-        fontRendererObj.drawStringWithShadow("Ctrl +- 50", posX + 215, posY + 31, 0xFFFFFF);
-        fontRendererObj.drawStringWithShadow("Shift+Ctrl +- 100", posX + 215, posY + 41, 0xFFFFFF);
+        fontRendererObj.drawStringWithShadow(
+                StatCollector.translateToLocal("gui.de.particleGenerator.hold.name"),
+                posX + 215,
+                posY + 11,
+                0xFFFFFF);
+        fontRendererObj.drawStringWithShadow("Shift: +-10", posX + 215, posY + 21, 0xFFFFFF);
+        fontRendererObj.drawStringWithShadow("Ctrl: +-50", posX + 215, posY + 31, 0xFFFFFF);
+        fontRendererObj.drawStringWithShadow("Shift+Ctrl: +-100", posX + 215, posY + 41, 0xFFFFFF);
 
         super.drawScreen(x, y, partialTicks);
     }

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIParticleGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIParticleGenerator.java
@@ -10,7 +10,9 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.StatCollector;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
@@ -48,7 +50,7 @@ public class GUIParticleGenerator extends GuiScreen {
 
         public IntegerProperty(int page, String label, int value, int minimumValue, int maximumValue) {
             this.page = page;
-            this.label = label;
+            this.label = StatCollector.translateToLocal("gui.de.particleGenerator." + label);
             this.value = value;
             this.minimumValue = minimumValue;
             this.maximumValue = maximumValue;
@@ -101,7 +103,7 @@ public class GUIParticleGenerator extends GuiScreen {
 
         public FloatProperty(int page, String label, float value, float minimumValue, float maximumValue, float scale) {
             this.page = page;
-            this.label = label;
+            this.label = StatCollector.translateToLocal("gui.de.particleGenerator." + label);
             this.value = value;
             this.minimumValue = minimumValue;
             this.maximumValue = maximumValue;
@@ -181,33 +183,22 @@ public class GUIParticleGenerator extends GuiScreen {
         updateScreen();
     }
 
-    private static final String[] InfoText = {
-            "The Particle Generator is a decorative device that allows you to create your own custom particle effects.                                                                 "
-                    + "It is fairly easy you use this device you simply adjust the fields (variables) in the interface to change how the generated particles look and behave.                                                                                            "
-                    + "This block is a work in progress and new features and particles are likely to be added in future versions.                                                         "
-                    + "The following is a list of all of the fields in the interface and what they do.",
-            "The first thing to note is that most fields have a random modifier which will add a random number between 0 and whatever max (or min) value you give it to the field.                                                                                      "
-                    + "-The first 3 fields (Red, Green & Blue) control the colour of the particle. Most people should be familiar with this colour system if not google RGB colours. Note: the max value for each colour can not go higher then 255 so the colour field limits the random modifier e.g. if the colour field is set to 255 and the random modifier is set to 20 the result will always be 255",
-            "-The next 3 fields (Motion X, Y & Z) control the direction and speed of the particle                                                                                            "
-                    + "-The \"Life\" field sets how long (in ticks) before the particle despawns.                                                       "
-                    + "-The \"Size\" field sets the size of the particle.                                                                                           "
-                    + "-The next 3 fields (Spawn X, Y & Z) Sets the spawn location of the particle (relative to the location of the particle generator)",
-            "-The \"Delay\" field sets the delay (in ticks) between each particle spawn e.g. 1=20/s, 20=1/s, 100=1/5s                                                                    "
-                    + "-The \"Fade\" field sets how long (in ticks) it takes the particle to fade out of existance. Note: This adds to the life of the particle                                                                                  "
-                    + "-The \"Gravity\" field sets how the particle is affected by gravity.                                                              "
-                    + "-\"Block Collision\" Toggles weather or not the particle will collide with blocks                                                     "
-                    + "-\"Particle Selected\" Switches between the different particles available.",
-            EnumChatFormatting.DARK_RED + "              Redstone Control"
+    private static final String[] infoText = {
+            StringEscapeUtils.unescapeJava(StatCollector.translateToLocal("gui.de.particleGenerator.info.1")),
+            StringEscapeUtils.unescapeJava(StatCollector.translateToLocal("gui.de.particleGenerator.info.2")),
+            StringEscapeUtils.unescapeJava(StatCollector.translateToLocal("gui.de.particleGenerator.info.3")),
+            StringEscapeUtils.unescapeJava(StatCollector.translateToLocal("gui.de.particleGenerator.info.4")),
+            EnumChatFormatting.DARK_RED
+                    + StringEscapeUtils
+                            .unescapeJava(StatCollector.translateToLocal("gui.de.particleGenerator.info.5.title"))
                     + EnumChatFormatting.BLACK
-                    + "\nBy default a redstone signal is required for the generator to run."
-                    + "\n\nHowever if you shift right click the generator with an empty hand it will switch to inverted mode."
-                    + "\nThe redstone mode is indicated by the 8 cubes at the corners of the block.",
-            EnumChatFormatting.DARK_RED + "              Computer Control"
+                    + StringEscapeUtils.unescapeJava(StatCollector.translateToLocal("gui.de.particleGenerator.info.5")),
+            EnumChatFormatting.DARK_RED
+                    + StringEscapeUtils
+                            .unescapeJava(StatCollector.translateToLocal("gui.de.particleGenerator.info.6.title"))
                     + EnumChatFormatting.BLACK
-                    + "\nThe Generator can be controlled via a computer"
-                    + "\nIt exposes a relatively straight forward API:"
-                    + "\n\n  setGeneratorProperty(property, value)\n  getGeneratorState()\n  resetGeneratorState()"
-                    + "\n\nGenerator state is obtained as a whole from getGeneratorState, whereas properties are modified one at a time using setGeneratorProperty. Property names are strings and mostly correspond to button labels in the GUI." };
+                    + StringEscapeUtils.unescapeJava(StatCollector.translateToLocal("gui.de.particleGenerator.info.6")),
+            StringEscapeUtils.escapeJava(StatCollector.translateToLocal("gui.de.particleGenerator.info.7")) };
 
     @Override
     public void drawScreen(int x, int y, float partialTicks) {
@@ -250,7 +241,7 @@ public class GUIParticleGenerator extends GuiScreen {
         }
         if (page == 10) {
             fontRendererObj.drawStringWithShadow("Information", posX + 75, posY + 5, 0x00FFFF);
-            fontRendererObj.drawSplitString(InfoText[infoPage], posX + 5, posY + 20, 200, 0x000000);
+            fontRendererObj.drawSplitString(infoText[infoPage], posX + 5, posY + 20, 200, 0x000000);
             fontRendererObj.drawSplitString("Page: " + (infoPage + 1), posX + 88, posY + 180, 200, 0xFF0000);
         }
 
@@ -270,12 +261,26 @@ public class GUIParticleGenerator extends GuiScreen {
         buttonList.clear();
 
         // Navigation
-        buttonList.add(previousPage = new GuiButton(100, posX - 47, posY + 177, 47, 20, "<==="));
-        buttonList.add(nextPage = new GuiButton(101, posX + 213, posY + 177, 47, 20, "===>"));
-        buttonList.add(showInfo = new GuiButton(102, posX - 21, posY + 3, 20, 20, "i"));
-        buttonList.add(hideInfo = new GuiButton(103, posX - 31, posY + 23, 30, 20, "Back"));
-        buttonList.add(previousInfoPage = new GuiButton(104, posX + 4, posY + 174, 80, 20, "Previous page"));
-        buttonList.add(nextInfoPage = new GuiButton(105, posX + 128, posY + 174, 80, 20, "Next page"));
+        buttonList.add(previousPage = new GuiButton(100, posX - 20, posY + 177, 20, 20, "<"));
+        buttonList.add(nextPage = new GuiButton(101, posX + 213, posY + 177, 20, 20, ">"));
+        buttonList.add(
+                showInfo = new GuiButton(
+                        102,
+                        posX - 21,
+                        posY + 3,
+                        20,
+                        20,
+                        StatCollector.translateToLocal("gui.de.particleGenerator.info.name")));
+        buttonList.add(
+                hideInfo = new GuiButton(
+                        103,
+                        posX - 31,
+                        posY + 23,
+                        30,
+                        20,
+                        StatCollector.translateToLocal("gui.de.particleGenerator.back.name")));
+        buttonList.add(previousInfoPage = new GuiButton(104, posX + 4, posY + 174, 30, 20, "<-"));
+        buttonList.add(nextInfoPage = new GuiButton(105, posX + 178, posY + 174, 30, 20, "->"));
 
         // First page
         for (int column = 0; column < 2; column++) {
@@ -298,11 +303,30 @@ public class GUIParticleGenerator extends GuiScreen {
             property.createButtons(buttonList, posX + 116, posY + 19 + row * 22, propertyId);
         }
         buttonList.add(
-                collisionToggle = new GuiButton(110, posX + 105, posY + 19 + 3 * 22, 102, 20, "Block Collision: "));
+                collisionToggle = new GuiButton(
+                        110,
+                        posX + 105,
+                        posY + 19 + 3 * 22,
+                        102,
+                        20,
+                        StatCollector.translateToLocal("gui.de.particleGenerator.blockCollision.name")));
         buttonList.add(
-                particleSelector = new GuiButton(111, posX + 105, posY + 19 + 4 * 22, 102, 20, "Particle Selected: "));
+                particleSelector = new GuiButton(
+                        111,
+                        posX + 105,
+                        posY + 19 + 4 * 22,
+                        102,
+                        20,
+                        StatCollector.translateToLocal("gui.de.particleGenerator.particleSelected.name")));
 
-        buttonList.add(particleToggle = new GuiButton(112, posX + 105, posY + 19 + 5 * 22, 102, 20, "Enabled: "));
+        buttonList.add(
+                particleToggle = new GuiButton(
+                        112,
+                        posX + 105,
+                        posY + 19 + 5 * 22,
+                        102,
+                        20,
+                        StatCollector.translateToLocal("gui.de.particleGenerator.enabled.name")));
 
         // Third page
         for (int row = 0; row < 8; row++) {
@@ -310,10 +334,30 @@ public class GUIParticleGenerator extends GuiScreen {
             IProperty property = properties.get(propertyId);
             property.createButtons(buttonList, posX + 5, posY + 19 + row * 22, propertyId);
         }
-        buttonList.add(beamToggle = new GuiButton(120, posX + 105, posY + 19, 102, 20, "Enabled: "));
-        buttonList.add(coreRenderToggle = new GuiButton(121, posX + 105, posY + 41, 102, 20, "Render Core: "));
         buttonList.add(
-                settingsSaver = new GuiButton(127, posX + 105, posY + 19 + 7 * 22, 102, 20, "Take note of values"));
+                beamToggle = new GuiButton(
+                        120,
+                        posX + 105,
+                        posY + 19,
+                        102,
+                        20,
+                        StatCollector.translateToLocal("gui.de.particleGenerator.enabled.name")));
+        buttonList.add(
+                coreRenderToggle = new GuiButton(
+                        121,
+                        posX + 105,
+                        posY + 41,
+                        102,
+                        20,
+                        StatCollector.translateToLocal("gui.de.particleGenerator.renderCore.name")));
+        buttonList.add(
+                settingsSaver = new GuiButton(
+                        127,
+                        posX + 105,
+                        posY + 19 + 7 * 22,
+                        102,
+                        20,
+                        StatCollector.translateToLocal("gui.de.particleGenerator.saveSettings.name")));
 
         updateButtons();
     }
@@ -328,50 +372,46 @@ public class GUIParticleGenerator extends GuiScreen {
         }
         short packetData = 0;
         switch (button.id) {
-            case 100:
+            case 100 -> {
                 page = Math.max(page - 1, 1);
                 packetData = (short) page;
-                break;
-            case 101:
+            }
+            case 101 -> {
                 page = Math.min(page + 1, 3);
                 packetData = (short) page;
-                break;
-            case 102:
+            }
+            case 102 -> {
                 page = 10;
                 packetData = (short) page;
-                break;
-            case 103:
+            }
+            case 103 -> {
                 page = 1;
                 packetData = (short) page;
-                break;
-            case 104:
-                infoPage = Math.max(infoPage - 1, 0);
-                break;
-            case 105:
-                infoPage = Math.min(infoPage + 1, InfoText.length - 1);
-                break;
-            case 110:
+            }
+            case 104 -> infoPage = Math.max(infoPage - 1, 0);
+            case 105 -> infoPage = Math.min(infoPage + 1, infoText.length - 1);
+            case 110 -> {
                 canParticleCollide = !canParticleCollide;
                 packetData = (short) (canParticleCollide ? 1 : 0);
-                break;
-            case 111:
+            }
+            case 111 -> {
                 selectedParticle = selectedParticle < TileParticleGenerator.MAXIMUM_PARTICLE_INDEX
                         ? selectedParticle + 1
                         : 1;
                 packetData = (short) selectedParticle;
-                break;
-            case 112:
+            }
+            case 112 -> {
                 isParticlesEnabled = !isParticlesEnabled;
                 packetData = (short) (isParticlesEnabled ? 1 : 0);
-                break;
-            case 120:
+            }
+            case 120 -> {
                 isBeamEnabled = !isBeamEnabled;
                 packetData = (short) (isBeamEnabled ? 1 : 0);
-                break;
-            case 121:
+            }
+            case 121 -> {
                 shouldRenderCore = !shouldRenderCore;
                 packetData = (short) (shouldRenderCore ? 1 : 0);
-                break;
+            }
         }
         updateButtons();
         DraconicEvolution.network.sendToServer(
@@ -418,48 +458,48 @@ public class GUIParticleGenerator extends GuiScreen {
     }
 
     private void syncWithServer() {
-        properties.put(0, new IntegerProperty(1, "Red:", particleGenerator.red, 0, 255));
-        properties.put(1, new IntegerProperty(1, "Green:", particleGenerator.green, 0, 255));
-        properties.put(2, new IntegerProperty(1, "Blue:", particleGenerator.blue, 0, 255));
-        properties.put(3, new FloatProperty(1, "Motion X:", particleGenerator.motionX, -5F, 5F, 1000F));
-        properties.put(4, new FloatProperty(1, "Motion Y:", particleGenerator.motionY, -5F, 5F, 1000F));
-        properties.put(5, new FloatProperty(1, "Motion Z:", particleGenerator.motionZ, -5F, 5F, 1000F));
-        properties.put(6, new FloatProperty(1, "Scale:", particleGenerator.scale, 0.01F, 50F, 100F));
-        properties.put(7, new IntegerProperty(1, "Life (T):", particleGenerator.life, 0, 1000));
+        properties.put(0, new IntegerProperty(1, "red.name", particleGenerator.red, 0, 255));
+        properties.put(1, new IntegerProperty(1, "green.name", particleGenerator.green, 0, 255));
+        properties.put(2, new IntegerProperty(1, "blue.name", particleGenerator.blue, 0, 255));
+        properties.put(3, new FloatProperty(1, "motionX.name", particleGenerator.motionX, -5F, 5F, 1000F));
+        properties.put(4, new FloatProperty(1, "motionY.name", particleGenerator.motionY, -5F, 5F, 1000F));
+        properties.put(5, new FloatProperty(1, "motionZ.name", particleGenerator.motionZ, -5F, 5F, 1000F));
+        properties.put(6, new FloatProperty(1, "scale.name", particleGenerator.scale, 0.01F, 50F, 100F));
+        properties.put(7, new IntegerProperty(1, "life.name", particleGenerator.life, 0, 1000));
 
-        properties.put(10, new IntegerProperty(1, "Random:", particleGenerator.randomRed, 0, 255));
-        properties.put(11, new IntegerProperty(1, "Random:", particleGenerator.randomGreen, 0, 255));
-        properties.put(12, new IntegerProperty(1, "Random:", particleGenerator.randomBlue, 0, 255));
-        properties.put(13, new FloatProperty(1, "Random:", particleGenerator.randomMotionX, -5F, 5F, 1000F));
-        properties.put(14, new FloatProperty(1, "Random:", particleGenerator.randomMotionY, -5F, 5F, 1000F));
-        properties.put(15, new FloatProperty(1, "Random:", particleGenerator.randomMotionZ, -5F, 5F, 1000F));
-        properties.put(16, new FloatProperty(1, "Random:", particleGenerator.randomScale, 0F, 50F, 100F));
-        properties.put(17, new IntegerProperty(1, "Random:", particleGenerator.randomLife, 0, 1000));
+        properties.put(10, new IntegerProperty(1, "random.name", particleGenerator.randomRed, 0, 255));
+        properties.put(11, new IntegerProperty(1, "random.name", particleGenerator.randomGreen, 0, 255));
+        properties.put(12, new IntegerProperty(1, "random.name", particleGenerator.randomBlue, 0, 255));
+        properties.put(13, new FloatProperty(1, "random.name", particleGenerator.randomMotionX, -5F, 5F, 1000F));
+        properties.put(14, new FloatProperty(1, "random.name", particleGenerator.randomMotionY, -5F, 5F, 1000F));
+        properties.put(15, new FloatProperty(1, "random.name", particleGenerator.randomMotionZ, -5F, 5F, 1000F));
+        properties.put(16, new FloatProperty(1, "random.name", particleGenerator.randomScale, 0F, 50F, 100F));
+        properties.put(17, new IntegerProperty(1, "random.name", particleGenerator.randomLife, 0, 1000));
 
-        properties.put(20, new FloatProperty(2, "Spawn X:", particleGenerator.spawnX, -50F, 50F, 10F));
-        properties.put(21, new FloatProperty(2, "Spawn Y:", particleGenerator.spawnY, -50F, 50F, 10F));
-        properties.put(22, new FloatProperty(2, "Spawn Z:", particleGenerator.spawnZ, -50F, 50F, 10F));
-        properties.put(23, new IntegerProperty(2, "Delay:", particleGenerator.spawnRate, 1, 200));
-        properties.put(24, new IntegerProperty(2, "Fade:", particleGenerator.fade, 0, 100));
-        properties.put(25, new FloatProperty(2, "Gravity:", particleGenerator.gravity, -5F, 5F, 1000F));
+        properties.put(20, new FloatProperty(2, "spawnX.name", particleGenerator.spawnX, -50F, 50F, 10F));
+        properties.put(21, new FloatProperty(2, "spawnY.name", particleGenerator.spawnY, -50F, 50F, 10F));
+        properties.put(22, new FloatProperty(2, "spawnZ.name", particleGenerator.spawnZ, -50F, 50F, 10F));
+        properties.put(23, new IntegerProperty(2, "delay.name", particleGenerator.spawnRate, 1, 200));
+        properties.put(24, new IntegerProperty(2, "fade.name", particleGenerator.fade, 0, 100));
+        properties.put(25, new FloatProperty(2, "gravity.name", particleGenerator.gravity, -5F, 5F, 1000F));
 
-        properties.put(30, new FloatProperty(2, "Random:", particleGenerator.randomSpawnX, -50F, 50F, 10F));
-        properties.put(31, new FloatProperty(2, "Random:", particleGenerator.randomSpawnY, -50F, 50F, 10F));
-        properties.put(32, new FloatProperty(2, "Random:", particleGenerator.randomSpawnZ, -50F, 50F, 10F));
+        properties.put(30, new FloatProperty(2, "random.name", particleGenerator.randomSpawnX, -50F, 50F, 10F));
+        properties.put(31, new FloatProperty(2, "random.name", particleGenerator.randomSpawnY, -50F, 50F, 10F));
+        properties.put(32, new FloatProperty(2, "random.name", particleGenerator.randomSpawnZ, -50F, 50F, 10F));
 
         page = particleGenerator.page;
         canParticleCollide = particleGenerator.canParticleCollide;
         selectedParticle = particleGenerator.selectedParticle;
         isParticlesEnabled = particleGenerator.isParticlesEnabled;
 
-        properties.put(40, new IntegerProperty(3, "Red:", particleGenerator.beamRed, 0, 255));
-        properties.put(41, new IntegerProperty(3, "Green:", particleGenerator.beamGreen, 0, 255));
-        properties.put(42, new IntegerProperty(3, "Blue:", particleGenerator.beamBlue, 0, 255));
-        properties.put(43, new FloatProperty(3, "Pitch:", particleGenerator.beamPitch, -180F, 180F, 10F));
-        properties.put(44, new FloatProperty(3, "Yaw:", particleGenerator.beamYaw, -180F, 180F, 10F));
-        properties.put(45, new FloatProperty(3, "Rotation:", particleGenerator.beamRotation, -1F, 1F, 100F));
-        properties.put(46, new FloatProperty(3, "Scale:", particleGenerator.beamScale, 0F, 5F, 100F));
-        properties.put(47, new FloatProperty(3, "Length:", particleGenerator.beamLength, 0F, 320F, 100F));
+        properties.put(40, new IntegerProperty(3, "red.name", particleGenerator.beamRed, 0, 255));
+        properties.put(41, new IntegerProperty(3, "green.name", particleGenerator.beamGreen, 0, 255));
+        properties.put(42, new IntegerProperty(3, "blue.name", particleGenerator.beamBlue, 0, 255));
+        properties.put(43, new FloatProperty(3, "pitch.name", particleGenerator.beamPitch, -180F, 180F, 10F));
+        properties.put(44, new FloatProperty(3, "yaw.name", particleGenerator.beamYaw, -180F, 180F, 10F));
+        properties.put(45, new FloatProperty(3, "rotation.name", particleGenerator.beamRotation, -1F, 1F, 100F));
+        properties.put(46, new FloatProperty(3, "scale.name", particleGenerator.beamScale, 0F, 5F, 100F));
+        properties.put(47, new FloatProperty(3, "length.name", particleGenerator.beamLength, 0F, 320F, 100F));
 
         shouldRenderCore = particleGenerator.shouldRenderCore;
         isBeamEnabled = particleGenerator.isBeamEnabled;
@@ -476,23 +516,33 @@ public class GUIParticleGenerator extends GuiScreen {
             showInfo.visible = false;
             hideInfo.visible = true;
             previousInfoPage.visible = infoPage > 0;
-            nextInfoPage.visible = infoPage < InfoText.length - 1;
+            nextInfoPage.visible = infoPage < infoText.length - 1;
         } else {
             showInfo.visible = true;
             hideInfo.visible = false;
             previousInfoPage.visible = false;
             nextInfoPage.visible = false;
         }
+        final String onLabel = StatCollector.translateToLocal("gui.de.on.txt");
+        final String offLabel = StatCollector.translateToLocal("gui.de.off.txt");
         collisionToggle.visible = page == 2;
-        collisionToggle.displayString = "Block Collision: " + (canParticleCollide ? "on" : "off");
+        collisionToggle.displayString = StatCollector.translateToLocalFormatted(
+                "gui.de.particleGenerator.blockCollision.name",
+                canParticleCollide ? onLabel : offLabel);
         particleSelector.visible = page == 2;
-        particleSelector.displayString = "Particle Selected: " + selectedParticle;
+        particleSelector.displayString = StatCollector
+                .translateToLocalFormatted("gui.de.particleGenerator.particleSelected.name", selectedParticle);
         particleToggle.visible = page == 2;
-        particleToggle.displayString = "Enabled: " + (isParticlesEnabled ? "on" : "off");
+        particleToggle.displayString = StatCollector.translateToLocalFormatted(
+                "gui.de.particleGenerator.enabled.name",
+                isParticlesEnabled ? onLabel : offLabel);
         beamToggle.visible = page == 3;
-        beamToggle.displayString = "Enabled: " + (isBeamEnabled ? "on" : "off");
+        beamToggle.displayString = StatCollector
+                .translateToLocalFormatted("gui.de.particleGenerator.enabled.name", isBeamEnabled ? onLabel : offLabel);
         coreRenderToggle.visible = page == 3;
-        coreRenderToggle.displayString = "Render Core: " + (shouldRenderCore ? "on" : "off");
+        coreRenderToggle.displayString = StatCollector.translateToLocalFormatted(
+                "gui.de.particleGenerator.renderCore.name",
+                shouldRenderCore ? onLabel : offLabel);
         settingsSaver.visible = page == 3;
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIParticleGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIParticleGenerator.java
@@ -258,7 +258,12 @@ public class GUIParticleGenerator extends GuiScreen {
                     posY + 5,
                     0x00FFFF);
             fontRendererObj.drawSplitString(infoText[infoPage], posX + 5, posY + 20, 200, 0x000000);
-            fontRendererObj.drawSplitString("Page: " + (infoPage + 1), posX + 88, posY + 180, 200, 0xFF0000);
+            fontRendererObj.drawSplitString(
+                    StatCollector.translateToLocalFormatted("gui.de.particleGenerator.page.name", infoPage + 1),
+                    posX + 88,
+                    posY + 180,
+                    200,
+                    0xFF0000);
         }
 
         fontRendererObj.drawStringWithShadow(

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIParticleGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIParticleGenerator.java
@@ -1,9 +1,13 @@
 package com.brandon3055.draconicevolution.client.gui;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.ResourceLocation;
 
@@ -17,78 +21,171 @@ import com.brandon3055.draconicevolution.common.tileentities.TileParticleGenerat
 
 public class GUIParticleGenerator extends GuiScreen {
 
+    private interface IProperty {
+
+        void increaseValue(int amount);
+
+        void decreaseValue(int amount);
+
+        short getSyncValue();
+
+        void createButtons(List<GuiButton> buttons, int x, int y, int propertyId);
+
+        void updateButtons(int page);
+
+        void drawLabel(FontRenderer fontRenderer, int x, int y);
+    }
+
+    private static class IntegerProperty implements IProperty {
+
+        private final int page;
+        private final String label;
+        private final int minimumValue;
+        private final int maximumValue;
+        private int value;
+        private GuiButton increaseButton;
+        private GuiButton decreaseButton;
+
+        public IntegerProperty(int page, String label, int value, int minimumValue, int maximumValue) {
+            this.page = page;
+            this.label = label;
+            this.value = value;
+            this.minimumValue = minimumValue;
+            this.maximumValue = maximumValue;
+        }
+
+        @Override
+        public void increaseValue(int amount) {
+            value = Math.min(value + amount, maximumValue);
+        }
+
+        @Override
+        public void decreaseValue(int amount) {
+            value = Math.max(value - amount, minimumValue);
+        }
+
+        @Override
+        public short getSyncValue() {
+            return (short) value;
+        }
+
+        @Override
+        public void createButtons(List<GuiButton> buttons, int x, int y, int propertyId) {
+            buttons.add(increaseButton = new GuiButton(propertyId * 2, x, y, 20, 20, "+"));
+            buttons.add(decreaseButton = new GuiButton(propertyId * 2 + 1, x + 71, y, 20, 20, "-"));
+        }
+
+        @Override
+        public void updateButtons(int page) {
+            increaseButton.visible = this.page == page;
+            decreaseButton.visible = this.page == page;
+        }
+
+        @Override
+        public void drawLabel(FontRenderer fontRenderer, int x, int y) {
+            fontRenderer.drawString(label, x, y, 0x000000);
+            fontRenderer.drawString(String.valueOf(value), x, y + 10, 0x000000);
+        }
+    }
+
+    private static class FloatProperty implements IProperty {
+
+        private final int page;
+        private final String label;
+        private final float minimumValue;
+        private final float maximumValue;
+        private final float scale;
+        private float value;
+        private GuiButton increaseButton;
+        private GuiButton decreaseButton;
+
+        public FloatProperty(int page, String label, float value, float minimumValue, float maximumValue, float scale) {
+            this.page = page;
+            this.label = label;
+            this.value = value;
+            this.minimumValue = minimumValue;
+            this.maximumValue = maximumValue;
+            this.scale = scale;
+        }
+
+        @Override
+        public void increaseValue(int amount) {
+            value = Math.min(value + (float) amount / scale, maximumValue);
+        }
+
+        @Override
+        public void decreaseValue(int amount) {
+            value = Math.max(value - (float) amount / scale, minimumValue);
+        }
+
+        @Override
+        public short getSyncValue() {
+            return (short) (value * scale);
+        }
+
+        @Override
+        public void createButtons(List<GuiButton> buttons, int x, int y, int propertyId) {
+            buttons.add(increaseButton = new GuiButton(propertyId * 2, x, y, 20, 20, "+"));
+            buttons.add(decreaseButton = new GuiButton(propertyId * 2 + 1, x + 71, y, 20, 20, "-"));
+        }
+
+        @Override
+        public void updateButtons(int page) {
+            increaseButton.visible = this.page == page;
+            decreaseButton.visible = this.page == page;
+        }
+
+        @Override
+        public void drawLabel(FontRenderer fontRenderer, int x, int y) {
+            float roundedValue = Math.round(value * scale) / scale;
+            fontRenderer.drawString(label, x, y, 0x000000);
+            fontRenderer.drawString(String.valueOf(roundedValue), x, y + 10, 0x000000);
+        }
+    }
+
     private final int xSize = 212;
     private final int ySize = 198;
-    private ResourceLocation guiTexture = new ResourceLocation(
+    private final ResourceLocation guiTexture = new ResourceLocation(
             References.MODID.toLowerCase(),
             "textures/gui/ParticleGenerator.png");
     private int page = 1;
     private int infoPage = 0;
-    private boolean hasInitialized = false;
 
-    // Particle variables
-    private boolean particles_enabled = true;
+    private boolean canParticleCollide = false;
+    private int selectedParticle = 1;
+    private boolean isParticlesEnabled = true;
 
-    private int red = 0;
-    private int green = 0;
-    private int blue = 0;
-    private int random_red = 0;
-    private int random_green = 0;
-    private int random_blue = 0;
-    private float motion_x = 0F;
-    private float motion_y = 0F;
-    private float motion_z = 0F;
-    private float random_motion_x = 0F;
-    private float random_motion_y = 0F;
-    private float random_motion_z = 0F;
-    private float scale = 0F;
-    private float random_scale = 0F;
-    private int life = 0;
-    private int random_life = 0;
-    private float spawn_x = 0F;
-    private float spawn_y = 0F;
-    private float spawn_z = 0F;
-    private float random_spawn_x = 0F;
-    private float random_spawn_y = 0F;
-    private float random_spawn_z = 0F;
-    private int fade = 0;
-    private int spawn_rate = 0;
-    private boolean collide = false;
-    private int selected_particle = 1;
-    private int selected_max = 3;
-    private float gravity = 0F;
+    private boolean isBeamEnabled = false;
+    private boolean shouldRenderCore = false;
 
-    // Beam variables
-    private boolean beam_enabled = false;
-    private boolean render_core = false;
+    private final TileParticleGenerator particleGenerator;
+    private final Map<Integer, IProperty> properties;
+    private GuiButton previousPage;
+    private GuiButton nextPage;
+    private GuiButton previousInfoPage;
+    private GuiButton nextInfoPage;
+    private GuiButton showInfo;
+    private GuiButton hideInfo;
+    private GuiButton collisionToggle;
+    private GuiButton particleToggle;
+    private GuiButton particleSelector;
+    private GuiButton beamToggle;
+    private GuiButton coreRenderToggle;
+    private GuiButton settingsSaver;
 
-    private int beam_red = 0;
-    private int beam_green = 0;
-    private int beam_blue = 0;
-    private float beam_scale = 0F;
-    private float beam_pitch = 0F;
-    private float beam_yaw = 0F;
-    private float beam_length = 0F;
-    private float beam_rotation = 0F;
-
-    // Buttons
-
-    // Info Page
-    // particle selection
-
-    private TileParticleGenerator tile;
-
-    public GUIParticleGenerator(TileParticleGenerator tile, EntityPlayer player) {
+    public GUIParticleGenerator(TileParticleGenerator particleGenerator) {
         super();
-        this.tile = tile;
+        this.particleGenerator = particleGenerator;
+        this.properties = new HashMap<>();
         syncWithServer();
+        this.updateScreen();
     }
 
-    String[] InfoText = { ""
-            + "The Particle Generator is a decorative device that allows you to create your own custom particle effects.                                                                 "
-            + "It is fairly easy you use this device you simply adjust the fields (variables) in the interface to change how the generated particles look and behave.                                                                                            "
-            + "This block is a work in progress and new features and particles are likely to be added in future versions.                                                         "
-            + "The following is a list of all of the fields in the interface and what they do.",
+    private static final String[] InfoText = {
+            "The Particle Generator is a decorative device that allows you to create your own custom particle effects.                                                                 "
+                    + "It is fairly easy you use this device you simply adjust the fields (variables) in the interface to change how the generated particles look and behave.                                                                                            "
+                    + "This block is a work in progress and new features and particles are likely to be added in future versions.                                                         "
+                    + "The following is a list of all of the fields in the interface and what they do.",
             "The first thing to note is that most fields have a random modifier which will add a random number between 0 and whatever max (or min) value you give it to the field.                                                                                      "
                     + "-The first 3 fields (Red, Green & Blue) control the colour of the particle. Most people should be familiar with this colour system if not google RGB colours. Note: the max value for each colour can not go higher then 255 so the colour field limits the random modifier e.g. if the colour field is set to 255 and the random modifier is set to 20 the result will always be 255",
             "-The next 3 fields (Motion X, Y & Z) control the direction and speed of the particle                                                                                            "
@@ -96,7 +193,7 @@ public class GUIParticleGenerator extends GuiScreen {
                     + "-The \"Size\" field sets the size of the particle.                                                                                           "
                     + "-The next 3 fields (Spawn X, Y & Z) Sets the spawn location of the particle (relative to the location of the particle generator)",
             "-The \"Delay\" field sets the delay (in ticks) between each particle spawn e.g. 1=20/s, 20=1/s, 100=1/5s                                                                    "
-                    + "-The \"Fade\" field sets how long (in ticks) it takes the partile to fade out of existance. Note: This adds to the life of the particle                                                                                  "
+                    + "-The \"Fade\" field sets how long (in ticks) it takes the particle to fade out of existance. Note: This adds to the life of the particle                                                                                  "
                     + "-The \"Gravity\" field sets how the particle is affected by gravity.                                                              "
                     + "-\"Block Collision\" Toggles weather or not the particle will collide with blocks                                                     "
                     + "-\"Particle Selected\" Switches between the different particles available.",
@@ -112,22 +209,47 @@ public class GUIParticleGenerator extends GuiScreen {
                     + "\n\n  setGeneratorProperty(property, value)\n  getGeneratorState()\n  resetGeneratorState()"
                     + "\n\nGenerator state is obtained as a whole from getGeneratorState, whereas properties are modified one at a time using setGeneratorProperty. Property names are strings and mostly correspond to button labels in the GUI." };
 
-    // @formatter:off
     @Override
-    public void drawScreen(int x, int y, float f) {
+    public void drawScreen(int x, int y, float partialTicks) {
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         Minecraft.getMinecraft().renderEngine.bindTexture(guiTexture);
         int posX = (this.width - xSize) / 2;
         int posY = (this.height - ySize) / 2;
         drawTexturedModalRect(posX, posY, 0, 0, xSize, ySize);
-        if (page < 3) fontRendererObj.drawStringWithShadow("Particle Generator", posX + 60, posY + 5, 0x00FFFF);
-        else if (page < 10) fontRendererObj.drawStringWithShadow("Beam Generator", posX + 65, posY + 5, 0x00FFFF);
-        else fontRendererObj.drawStringWithShadow("Information", posX + 75, posY + 5, 0x00FFFF);
 
-        if (page == 1) page1Txt();
-        else if (page == 2) page2Txt();
-        else if (page == 3) page3Txt();
-        else if (page == 10) {
+        if (page == 1) {
+            fontRendererObj.drawStringWithShadow("Particle Generator", posX + 60, posY + 5, 0x00FFFF);
+            for (int column = 0; column < 2; column++) {
+                for (int row = 0; row < 8; row++) {
+                    IProperty property = properties.get(row + column * 10);
+                    property.drawLabel(fontRendererObj, posX + 30 + column * 111, posY + 20 + row * 22);
+                }
+            }
+            for (int row = 0; row < 8; row++) {
+                fontRendererObj.drawStringWithShadow(" + ", posX + 98, posY + 25 + row * 22, 0xFFFFFF);
+            }
+        }
+        if (page == 2) {
+            fontRendererObj.drawStringWithShadow("Particle Generator", posX + 60, posY + 5, 0x00FFFF);
+            for (int row = 0; row < 6; row++) {
+                IProperty property = properties.get(row + 20);
+                property.drawLabel(fontRendererObj, posX + 30, posY + 20 + row * 22);
+            }
+            for (int row = 0; row < 3; row++) {
+                IProperty property = properties.get(row + 30);
+                property.drawLabel(fontRendererObj, posX + 141, posY + 20 + row * 22);
+                fontRendererObj.drawStringWithShadow(" + ", posX + 98, posY + 25 + row * 22, 0xFFFFFF);
+            }
+        }
+        if (page == 3) {
+            fontRendererObj.drawStringWithShadow("Beam Generator", posX + 65, posY + 5, 0x00FFFF);
+            for (int row = 0; row < 8; row++) {
+                IProperty property = properties.get(row + 40);
+                property.drawLabel(fontRendererObj, posX + 30, posY + 20 + row * 22);
+            }
+        }
+        if (page == 10) {
+            fontRendererObj.drawStringWithShadow("Information", posX + 75, posY + 5, 0x00FFFF);
             fontRendererObj.drawSplitString(InfoText[infoPage], posX + 5, posY + 20, 200, 0x000000);
             fontRendererObj.drawSplitString("Page: " + (infoPage + 1), posX + 88, posY + 180, 200, 0xFF0000);
         }
@@ -137,314 +259,158 @@ public class GUIParticleGenerator extends GuiScreen {
         fontRendererObj.drawStringWithShadow("Ctrl +- 50", posX + 215, posY + 31, 0xFFFFFF);
         fontRendererObj.drawStringWithShadow("Shift+Ctrl +- 100", posX + 215, posY + 41, 0xFFFFFF);
 
-        super.drawScreen(x, y, f);
-    }
-    // @formatter:on
-
-    @Override
-    protected void mouseClicked(int x, int y, int button) {
-        super.mouseClicked(x, y, button);
+        super.drawScreen(x, y, partialTicks);
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void initGui() {
         int posX = (this.width - xSize) / 2;
         int posY = (this.height - ySize) / 2;
         buttonList.clear();
 
-        if (page < 10) {
-            buttonList.add(new GuiButton(33, posX + 213, posY + 177, 47, 20, "===>"));
-            buttonList.add(new GuiButton(32, posX - 47, posY + 177, 47, 20, "<==="));
+        // Navigation
+        buttonList.add(previousPage = new GuiButton(100, posX - 47, posY + 177, 47, 20, "<==="));
+        buttonList.add(nextPage = new GuiButton(101, posX + 213, posY + 177, 47, 20, "===>"));
+        buttonList.add(showInfo = new GuiButton(102, posX - 21, posY + 3, 20, 20, "i"));
+        buttonList.add(hideInfo = new GuiButton(103, posX - 31, posY + 23, 30, 20, "Back"));
+        buttonList.add(previousInfoPage = new GuiButton(104, posX + 4, posY + 174, 80, 20, "Previous page"));
+        buttonList.add(nextInfoPage = new GuiButton(105, posX + 128, posY + 174, 80, 20, "Next page"));
+
+        // First page
+        for (int column = 0; column < 2; column++) {
+            for (int row = 0; row < 8; row++) {
+                int propertyId = row + column * 10;
+                IProperty property = properties.get(propertyId);
+                property.createButtons(buttonList, posX + 5 + column * 111, posY + 19 + row * 22, propertyId);
+            }
         }
 
-        if (page == 1) page1Buttons();
-        else if (page == 2) page2Buttons();
-        else if (page == 3) page3Buttons();
-        else if (page == 10) {
-            buttonList.add(new GuiButton(57, posX + 4, posY + 174, 80, 20, "Previous page"));
-            buttonList.add(new GuiButton(56, posX + 128, posY + 174, 80, 20, "Next page"));
+        // Second page
+        for (int row = 0; row < 6; row++) {
+            int propertyId = row + 20;
+            IProperty property = properties.get(propertyId);
+            property.createButtons(buttonList, posX + 5, posY + 19 + row * 22, propertyId);
         }
+        for (int row = 0; row < 3; row++) {
+            int propertyId = row + 30;
+            IProperty property = properties.get(propertyId);
+            property.createButtons(buttonList, posX + 116, posY + 19 + row * 22, propertyId);
+        }
+        buttonList.add(
+                collisionToggle = new GuiButton(110, posX + 105, posY + 19 + 3 * 22, 102, 20, "Block Collision: "));
+        buttonList.add(
+                particleSelector = new GuiButton(111, posX + 105, posY + 19 + 4 * 22, 102, 20, "Particle Selected: "));
 
-        if (page < 10) buttonList.add(new GuiButton(54, posX - 21, posY + 3, 20, 20, "i"));
-        else buttonList.add(new GuiButton(55, posX - 31, posY + 23, 30, 20, "Back"));
+        buttonList.add(particleToggle = new GuiButton(112, posX + 105, posY + 19 + 5 * 22, 102, 20, "Enabled: "));
+
+        // Third page
+        for (int row = 0; row < 8; row++) {
+            int propertyId = row + 40;
+            IProperty property = properties.get(propertyId);
+            property.createButtons(buttonList, posX + 5, posY + 19 + row * 22, propertyId);
+        }
+        buttonList.add(beamToggle = new GuiButton(120, posX + 105, posY + 19, 102, 20, "Enabled: "));
+        buttonList.add(coreRenderToggle = new GuiButton(121, posX + 105, posY + 41, 102, 20, "Render Core: "));
+        buttonList.add(
+                settingsSaver = new GuiButton(127, posX + 105, posY + 19 + 7 * 22, 102, 20, "Take note of values"));
+
+        updateButtons();
     }
 
     @Override
     protected void actionPerformed(GuiButton button) {
-        if (button.id < 100) particleActions(button);
-        else beamActions(button);
+        if (button.id < 100) {
+            int propertyId = button.id / 2;
+            boolean shouldIncrease = button.id % 2 == 0;
+            modifyProperty(propertyId, shouldIncrease);
+            return;
+        }
+        short packetData = 0;
+        switch (button.id) {
+            case 100:
+                page = Math.max(page - 1, 1);
+                packetData = (short) page;
+                break;
+            case 101:
+                page = Math.min(page + 1, 3);
+                packetData = (short) page;
+                break;
+            case 102:
+                page = 10;
+                packetData = (short) page;
+                break;
+            case 103:
+                page = 1;
+                packetData = (short) page;
+                break;
+            case 104:
+                infoPage = Math.max(infoPage - 1, 0);
+                break;
+            case 105:
+                infoPage = Math.min(infoPage + 1, InfoText.length - 1);
+                break;
+            case 110:
+                canParticleCollide = !canParticleCollide;
+                packetData = (short) (canParticleCollide ? 1 : 0);
+                break;
+            case 111:
+                selectedParticle = selectedParticle < TileParticleGenerator.MAXIMUM_PARTICLE_INDEX
+                        ? selectedParticle + 1
+                        : 1;
+                packetData = (short) selectedParticle;
+                break;
+            case 112:
+                isParticlesEnabled = !isParticlesEnabled;
+                packetData = (short) (isParticlesEnabled ? 1 : 0);
+                break;
+            case 120:
+                isBeamEnabled = !isBeamEnabled;
+                packetData = (short) (isBeamEnabled ? 1 : 0);
+                break;
+            case 121:
+                shouldRenderCore = !shouldRenderCore;
+                packetData = (short) (shouldRenderCore ? 1 : 0);
+                break;
+        }
+        updateButtons();
+        DraconicEvolution.network.sendToServer(
+                new ParticleGenPacket(
+                        (byte) button.id,
+                        packetData,
+                        particleGenerator.xCoord,
+                        particleGenerator.yCoord,
+                        particleGenerator.zCoord));
     }
 
-    private void particleActions(GuiButton button) {
-        int value = 1;
-        float value_F;
-        short packetValue = 0;
-        if (Keyboard.isKeyDown(42) || Keyboard.isKeyDown(54)) value = 10;
-        if (Keyboard.isKeyDown(29) || Keyboard.isKeyDown(157)) value = 50;
-        if ((Keyboard.isKeyDown(29) || Keyboard.isKeyDown(157)) && (Keyboard.isKeyDown(42) || Keyboard.isKeyDown(54)))
-            value = 100;
-
-        value_F = (value) / 1000F;
-
-        switch (button.id) {
-            case 0: // Red +
-                red = (red + value) > 255 ? 255 : red + value;
-                packetValue = (short) red;
-                break;
-            case 1: // Green +
-                green = (green + value) > 255 ? 255 : green + value;
-                packetValue = (short) green;
-                break;
-            case 2: // Blue +
-                blue = (blue + value) > 255 ? 255 : blue + value;
-                packetValue = (short) blue;
-                break;
-            case 3: // MX +
-                motion_x = (motion_x + value_F) > 5F ? 5F : motion_x + value_F;
-                packetValue = (short) (motion_x * 1000F);
-                break;
-            case 4: // MY +
-                motion_y = (motion_y + value_F) > 5F ? 5F : motion_y + value_F;
-                packetValue = (short) (motion_y * 1000F);
-                break;
-            case 5: // MZ +
-                motion_z = (motion_z + value_F) > 5F ? 5F : motion_z + value_F;
-                packetValue = (short) (motion_z * 1000F);
-                break;
-            case 6: // Red -
-                red = (red - value) < 0 ? 0 : red - value;
-                packetValue = (short) red;
-                break;
-            case 7: // Green -
-                green = (green - value) < 0 ? 0 : green - value;
-                packetValue = (short) green;
-                break;
-            case 8: // Blue -
-                blue = (blue - value) < 0 ? 0 : blue - value;
-                packetValue = (short) blue;
-                break;
-            case 9: // MX -
-                motion_x = (motion_x - value_F) < -5F ? -5F : motion_x - value_F;
-                packetValue = (short) (motion_x * 1000F);
-                break;
-            case 10: // MY -
-                motion_y = (motion_y - value_F) < -5F ? -5F : motion_y - value_F;
-                packetValue = (short) (motion_y * 1000F);
-                break;
-            case 11: // MZ -
-                motion_z = (motion_z - value_F) < -5F ? -5F : motion_z - value_F;
-                packetValue = (short) (motion_z * 1000F);
-                break;
-            case 12: // RRed +
-                random_red = (random_red + value) > 255 ? 255 : random_red + value;
-                packetValue = (short) random_red;
-                break;
-            case 13: // RGreen +
-                random_green = (random_green + value) > 255 ? 255 : random_green + value;
-                packetValue = (short) random_green;
-                break;
-            case 14: // RBlue +
-                random_blue = (random_blue + value) > 255 ? 255 : random_blue + value;
-                packetValue = (short) random_blue;
-                break;
-            case 15: // RMX +
-                random_motion_x = (random_motion_x + value_F) > 5F ? 5F : random_motion_x + value_F;
-                packetValue = (short) (random_motion_x * 1000F);
-                break;
-            case 16: // RMY +
-                random_motion_y = (random_motion_y + value_F) > 5F ? 5F : random_motion_y + value_F;
-                packetValue = (short) (random_motion_y * 1000F);
-                break;
-            case 17: // RMZ +
-                random_motion_z = (random_motion_z + value_F) > 5F ? 5F : random_motion_z + value_F;
-                packetValue = (short) (random_motion_z * 1000F);
-                break;
-            case 18: // RRed -
-                random_red = (random_red - value) < 0 ? 0 : random_red - value;
-                packetValue = (short) random_red;
-                break;
-            case 19: // RGreen -
-                random_green = (random_green - value) < 0 ? 0 : random_green - value;
-                packetValue = (short) random_green;
-                break;
-            case 20: // RBlue -
-                random_blue = (random_blue - value) < 0 ? 0 : random_blue - value;
-                packetValue = (short) random_blue;
-                break;
-            case 21: // RMX -
-                random_motion_x = (random_motion_x - value_F) < -5F ? -5F : random_motion_x - value_F;
-                packetValue = (short) (random_motion_x * 1000F);
-                break;
-            case 22: // RMY -
-                random_motion_y = (random_motion_y - value_F) < -5F ? -5F : random_motion_y - value_F;
-                packetValue = (short) (random_motion_y * 1000F);
-                break;
-            case 23: // RMZ -
-                random_motion_z = (random_motion_z - value_F) < -5F ? -5F : random_motion_z - value_F;
-                packetValue = (short) (random_motion_z * 1000F);
-                break;
-            case 24: // Life +
-                life = (life + value) > 1000 ? 1000 : life + value;
-                packetValue = (short) life;
-                break;
-            case 25: // Life -
-                life = (life - value) < 0 ? 0 : life - value;
-                packetValue = (short) life;
-                break;
-            case 26: // RLife +
-                random_life = (random_life + value) > 1000 ? 1000 : random_life + value;
-                packetValue = (short) random_life;
-                break;
-            case 27: // RLife -
-                random_life = (random_life - value) < 0 ? 0 : random_life - value;
-                packetValue = (short) random_life;
-                break;
-            case 28: // Size +
-                scale = (scale + value_F * 10F) > 50F ? 50F : scale + value_F * 10F;
-                packetValue = (short) (scale * 100F);
-                break;
-            case 29: // Size -
-                scale = (scale - value_F * 10F) < 0.01F ? 0.01F : scale - value_F * 10F;
-                packetValue = (short) (scale * 100F);
-                break;
-            case 30: // RSize +
-                random_scale = (random_scale + value_F * 10F) > 50F ? 50F : random_scale + value_F * 10F;
-                packetValue = (short) (random_scale * 100F);
-                break;
-            case 31: // RSize -
-                random_scale = (random_scale - value_F * 10F) < 0.0F ? 0.0F : random_scale - value_F * 10F;
-                packetValue = (short) (random_scale * 100F);
-                break;
-            case 32: // Page 2
-                if (page > 1) page--;
-                packetValue = (short) page;
-                initGui();
-                break;
-            case 33: // Page 1
-                if (page < 3) page++;
-                initGui();
-                packetValue = (short) page;
-                break;
-            case 34: // SX +
-                spawn_x = (spawn_x + value_F * 100F) > 50F ? 50F : spawn_x + value_F * 100F;
-                packetValue = (short) (spawn_x * 100F);
-                break;
-            case 35: // SX -
-                spawn_x = (spawn_x - value_F * 100F) < -50F ? -50F : spawn_x - value_F * 100F;
-                packetValue = (short) (spawn_x * 100F);
-                break;
-            case 36: // RSX +
-                random_spawn_x = (random_spawn_x + value_F * 100F) > 50F ? 50F : random_spawn_x + value_F * 100F;
-                packetValue = (short) (random_spawn_x * 100F);
-                break;
-            case 37: // RSX -
-                random_spawn_x = (random_spawn_x - value_F * 100F) < -50F ? -50F : random_spawn_x - value_F * 100F;
-                packetValue = (short) (random_spawn_x * 100F);
-                break;
-            case 38: // SY +
-                spawn_y = (spawn_y + value_F * 100F) > 50F ? 50F : spawn_y + value_F * 100F;
-                packetValue = (short) (spawn_y * 100F);
-                break;
-            case 39: // SY -
-                spawn_y = (spawn_y - value_F * 100F) < -50F ? -50F : spawn_y - value_F * 100F;
-                packetValue = (short) (spawn_y * 100F);
-                break;
-            case 40: // RSY +
-                random_spawn_y = (random_spawn_y + value_F * 100F) > 50F ? 50F : random_spawn_y + value_F * 100F;
-                packetValue = (short) (random_spawn_y * 100F);
-                break;
-            case 41: // RSY -
-                random_spawn_y = (random_spawn_y - value_F * 100F) < -50F ? -50F : random_spawn_y - value_F * 100F;
-                packetValue = (short) (random_spawn_y * 100F);
-                break;
-            case 42: // SZ +
-                spawn_z = (spawn_z + value_F * 100F) > 50F ? 50F : spawn_z + value_F * 100F;
-                packetValue = (short) (spawn_z * 100F);
-                break;
-            case 43: // SZ -
-                spawn_z = (spawn_z - value_F * 100F) < -50F ? -50F : spawn_z - value_F * 100F;
-                packetValue = (short) (spawn_z * 100F);
-                break;
-            case 44: // RSZ +
-                random_spawn_z = (random_spawn_z + value_F * 100F) > 50F ? 50F : random_spawn_z + value_F * 100F;
-                packetValue = (short) (random_spawn_z * 100F);
-                break;
-            case 45: // RSZ -
-                random_spawn_z = (random_spawn_z - value_F * 100F) < -50F ? -50F : random_spawn_z - value_F * 100F;
-                packetValue = (short) (random_spawn_z * 100F);
-                break;
-            case 46: // Delay +
-                spawn_rate = (spawn_rate + value) > 200 ? 200 : spawn_rate + value;
-                packetValue = (short) spawn_rate;
-                break;
-            case 47: // Delay -
-                spawn_rate = (spawn_rate - value) < 1 ? 1 : spawn_rate - value;
-                packetValue = (short) spawn_rate;
-                break;
-            case 48: // Fade +
-                fade = (fade + value) > 100 ? 100 : fade + value;
-                packetValue = (short) fade;
-                break;
-            case 49: // Fade -
-                fade = (fade - value) < 0 ? 0 : fade - value;
-                packetValue = (short) fade;
-                break;
-            case 50: // Toggle Collision
-                collide = !collide;
-                packetValue = (short) (collide ? 1 : 0);
-                initGui();
-                break;
-            case 51: // cycle particle selection
-                selected_particle = selected_particle < selected_max ? selected_particle + 1 : 1;
-                packetValue = (short) selected_particle;
-                initGui();
-                break;
-            case 52: // RSZ +
-                gravity = (gravity + value_F) > 5F ? 5F : gravity + value_F;
-                packetValue = (short) (gravity * 1000F);
-                break;
-            case 53: // RSZ -
-                gravity = (gravity - value_F) < -5F ? -5F : gravity - value_F;
-                packetValue = (short) (gravity * 1000F);
-                break;
-            case 54: // Info Page
-                page = 10;
-                initGui();
-                packetValue = (short) page;
-                break;
-            case 55: // Back Page
-                page = 1;
-                initGui();
-                packetValue = (short) page;
-                break;
-            case 56: // Info Next Page
-                if (infoPage < 5) infoPage++;
-                else initGui();
-                break;
-            case 57: // Info Previous Page
-                if (infoPage > 0) infoPage--;
-                else initGui();
-                break;
-            case 58: // particles Enabled
-                particles_enabled = !particles_enabled;
-                packetValue = particles_enabled ? (byte) 1 : (byte) 0;
-                initGui();
-                break;
+    private void modifyProperty(int propertyId, boolean shouldIncrease) {
+        boolean isShiftPressed = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
+        boolean isControlPressed = Keyboard.isKeyDown(Keyboard.KEY_LCONTROL)
+                || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL);
+        int amount = 1;
+        if (isShiftPressed) {
+            amount = 10;
+        }
+        if (isControlPressed) {
+            amount = 50;
+        }
+        if (isShiftPressed && isControlPressed) {
+            amount = 100;
+        }
+        IProperty property = properties.get(propertyId);
+        if (shouldIncrease) {
+            property.increaseValue(amount);
+        } else {
+            property.decreaseValue(amount);
         }
         DraconicEvolution.network.sendToServer(
-                new ParticleGenPacket((byte) button.id, packetValue, tile.xCoord, tile.yCoord, tile.zCoord));
+                new ParticleGenPacket(
+                        (byte) propertyId,
+                        property.getSyncValue(),
+                        particleGenerator.xCoord,
+                        particleGenerator.yCoord,
+                        particleGenerator.zCoord));
     }
-
-    @Override
-    public void keyTyped(char key, int keyN) {
-        if ((key == 'e') || key == '') {
-            this.mc.displayGuiScreen(null);
-            this.mc.setIngameFocus();
-        }
-    }
-
-    @Override
-    public void updateScreen() {}
 
     @Override
     public boolean doesGuiPauseGame() {
@@ -452,392 +418,81 @@ public class GUIParticleGenerator extends GuiScreen {
     }
 
     private void syncWithServer() {
-        red = tile.red;
-        green = tile.green;
-        blue = tile.blue;
-        random_red = tile.random_red;
-        random_green = tile.random_green;
-        random_blue = tile.random_blue;
-        motion_x = tile.motion_x;
-        motion_y = tile.motion_y;
-        motion_z = tile.motion_z;
-        random_motion_x = tile.random_motion_x;
-        random_motion_y = tile.random_motion_y;
-        random_motion_z = tile.random_motion_z;
-        scale = tile.scale;
-        random_scale = tile.random_scale;
-        life = tile.life;
-        random_life = tile.random_life;
-        spawn_x = tile.spawn_x;
-        spawn_y = tile.spawn_y;
-        spawn_z = tile.spawn_z;
-        random_spawn_x = tile.random_spawn_x;
-        random_spawn_y = tile.random_spawn_y;
-        random_spawn_z = tile.random_spawn_z;
-        page = tile.page;
-        spawn_rate = tile.spawn_rate;
-        collide = tile.collide;
-        fade = tile.fade;
-        selected_particle = tile.selected_particle;
-        gravity = tile.gravity;
-        particles_enabled = tile.particles_enabled;
+        properties.put(0, new IntegerProperty(1, "Red:", particleGenerator.red, 0, 255));
+        properties.put(1, new IntegerProperty(1, "Green:", particleGenerator.green, 0, 255));
+        properties.put(2, new IntegerProperty(1, "Blue:", particleGenerator.blue, 0, 255));
+        properties.put(3, new FloatProperty(1, "Motion X:", particleGenerator.motionX, -5F, 5F, 1000F));
+        properties.put(4, new FloatProperty(1, "Motion Y:", particleGenerator.motionY, -5F, 5F, 1000F));
+        properties.put(5, new FloatProperty(1, "Motion Z:", particleGenerator.motionZ, -5F, 5F, 1000F));
+        properties.put(6, new FloatProperty(1, "Scale:", particleGenerator.scale, 0.01F, 50F, 100F));
+        properties.put(7, new IntegerProperty(1, "Life (T):", particleGenerator.life, 0, 1000));
 
-        render_core = tile.render_core;
-        beam_enabled = tile.beam_enabled;
-        beam_red = tile.beam_red;
-        beam_green = tile.beam_green;
-        beam_blue = tile.beam_blue;
-        beam_scale = tile.beam_scale;
-        beam_pitch = tile.beam_pitch;
-        beam_yaw = tile.beam_yaw;
-        beam_length = tile.beam_length;
-        beam_rotation = tile.beam_rotation;
+        properties.put(10, new IntegerProperty(1, "Random:", particleGenerator.randomRed, 0, 255));
+        properties.put(11, new IntegerProperty(1, "Random:", particleGenerator.randomGreen, 0, 255));
+        properties.put(12, new IntegerProperty(1, "Random:", particleGenerator.randomBlue, 0, 255));
+        properties.put(13, new FloatProperty(1, "Random:", particleGenerator.randomMotionX, -5F, 5F, 1000F));
+        properties.put(14, new FloatProperty(1, "Random:", particleGenerator.randomMotionY, -5F, 5F, 1000F));
+        properties.put(15, new FloatProperty(1, "Random:", particleGenerator.randomMotionZ, -5F, 5F, 1000F));
+        properties.put(16, new FloatProperty(1, "Random:", particleGenerator.randomScale, 0.01F, 50F, 100F));
+        properties.put(17, new IntegerProperty(1, "Random:", particleGenerator.randomLife, 0, 1000));
+
+        properties.put(20, new FloatProperty(2, "Spawn X:", particleGenerator.spawnX, -50F, 50F, 10F));
+        properties.put(21, new FloatProperty(2, "Spawn Y:", particleGenerator.spawnY, -50F, 50F, 10F));
+        properties.put(22, new FloatProperty(2, "Spawn Z:", particleGenerator.spawnZ, -50F, 50F, 10F));
+        properties.put(23, new IntegerProperty(2, "Delay:", particleGenerator.spawnRate, 1, 200));
+        properties.put(24, new IntegerProperty(2, "Fade:", particleGenerator.fade, 0, 100));
+        properties.put(25, new FloatProperty(2, "Gravity:", particleGenerator.gravity, -5F, 5F, 1000F));
+
+        properties.put(30, new FloatProperty(2, "Random:", particleGenerator.randomSpawnX, -50F, 50F, 10F));
+        properties.put(31, new FloatProperty(2, "Random:", particleGenerator.randomSpawnY, -50F, 50F, 10F));
+        properties.put(32, new FloatProperty(2, "Random:", particleGenerator.randomSpawnZ, -50F, 50F, 10F));
+
+        page = particleGenerator.page;
+        canParticleCollide = particleGenerator.canParticleCollide;
+        selectedParticle = particleGenerator.selectedParticle;
+        isParticlesEnabled = particleGenerator.isParticlesEnabled;
+
+        properties.put(40, new IntegerProperty(3, "Red:", particleGenerator.beamRed, 0, 255));
+        properties.put(41, new IntegerProperty(3, "Green:", particleGenerator.beamGreen, 0, 255));
+        properties.put(42, new IntegerProperty(3, "Blue:", particleGenerator.beamBlue, 0, 255));
+        properties.put(43, new FloatProperty(3, "Pitch:", particleGenerator.beamPitch, -180F, 180F, 10F));
+        properties.put(44, new FloatProperty(3, "Yaw:", particleGenerator.beamYaw, -180F, 180F, 10F));
+        properties.put(45, new FloatProperty(3, "Rotation:", particleGenerator.beamRotation, -1F, 1F, 100F));
+        properties.put(46, new FloatProperty(3, "Scale:", particleGenerator.beamScale, 0F, 5F, 100F));
+        properties.put(47, new FloatProperty(3, "Length:", particleGenerator.beamLength, 0F, 320F, 100F));
+
+        shouldRenderCore = particleGenerator.shouldRenderCore;
+        isBeamEnabled = particleGenerator.isBeamEnabled;
     }
 
-    // @formatter:off
-    private void page1Txt() {
-        int posX = (this.width - xSize) / 2;
-        int posY = (this.height - ySize) / 2;
-
-        String motionX = String.valueOf(Math.round(motion_x * 1000F) / 1000F);
-        String motionY = String.valueOf(Math.round(motion_y * 1000F) / 1000F);
-        String motionZ = String.valueOf(Math.round(motion_z * 1000F) / 1000F);
-        String random_motionX = String.valueOf(Math.round(random_motion_x * 1000F) / 1000F);
-        String random_motionY = String.valueOf(Math.round(random_motion_y * 1000F) / 1000F);
-        String random_motionZ = String.valueOf(Math.round(random_motion_z * 1000F) / 1000F);
-        String scale1 = String.valueOf(Math.round(scale * 100F) / 100F);
-        String random_scale1 = String.valueOf(Math.round(random_scale * 100F) / 100F);
-
-        int col1 = posX + 30;
-        int col2 = posX + 141;
-        int ln1 = 20;
-        int ln2 = 30;
-
-        fontRendererObj.drawString("Red:", col1, posY + ln1 + 0 * 22, 0x000000, false);
-        fontRendererObj.drawString(String.valueOf(red), col1, posY + ln2 + 0 * 22, 0x000000, false);
-        fontRendererObj.drawString("Green:", col1, posY + ln1 + 1 * 22, 0x000000, false);
-        fontRendererObj.drawString(String.valueOf(green), col1, posY + ln2 + 1 * 22, 0x000000, false);
-        fontRendererObj.drawString("Blue:", col1, posY + ln1 + 2 * 22, 0x000000, false);
-        fontRendererObj.drawString(String.valueOf(blue), col1, posY + ln2 + 2 * 22, 0x000000, false);
-        fontRendererObj.drawString("Motion X:", col1, posY + ln1 + 3 * 22, 0x000000, false);
-        fontRendererObj.drawString(motionX, col1, posY + ln2 + 3 * 22, 0x000000, false);
-        fontRendererObj.drawString("Motion Y:", col1, posY + ln1 + 4 * 22, 0x000000, false);
-        fontRendererObj.drawString(motionY, col1, posY + ln2 + 4 * 22, 0x000000, false);
-        fontRendererObj.drawString("Motion Z:", col1, posY + ln1 + 5 * 22, 0x000000, false);
-        fontRendererObj.drawString(motionZ, col1, posY + ln2 + 5 * 22, 0x000000, false);
-        fontRendererObj.drawString("Life:", col1, posY + ln1 + 6 * 22, 0x000000, false);
-        fontRendererObj.drawString("" + life + " T", col1, posY + ln2 + 6 * 22, 0x000000, false);
-        fontRendererObj.drawString("Size:", col1, posY + ln1 + 7 * 22, 0x000000, false);
-        fontRendererObj.drawString("" + scale1, col1, posY + ln2 + 7 * 22, 0x000000, false);
-
-        for (int i = 0; i < 8; i++)
-            fontRendererObj.drawStringWithShadow("(+)", posX + 98, posY + 25 + i * 22, 0xFFFFFF);
-
-        fontRendererObj.drawString("Random:0", col2, posY + ln1 + 0 * 22, 0x000000, false);
-        fontRendererObj.drawString("> " + random_red, col2, posY + ln2 + 0 * 22, 0x000000, false);
-        fontRendererObj.drawString("Random:0", col2, posY + ln1 + 1 * 22, 0x000000, false);
-        fontRendererObj.drawString("> " + random_green, col2, posY + ln2 + 1 * 22, 0x000000, false);
-        fontRendererObj.drawString("Random:0", col2, posY + ln1 + 2 * 22, 0x000000, false);
-        fontRendererObj.drawString("> " + random_blue, col2, posY + ln2 + 2 * 22, 0x000000, false);
-        fontRendererObj.drawString("Random:0", col2, posY + ln1 + 3 * 22, 0x000000, false);
-        fontRendererObj.drawString("> " + random_motionX, col2, posY + ln2 + 3 * 22, 0x000000, false);
-        fontRendererObj.drawString("Random:0", col2, posY + ln1 + 4 * 22, 0x000000, false);
-        fontRendererObj.drawString("> " + random_motionY, col2, posY + ln2 + 4 * 22, 0x000000, false);
-        fontRendererObj.drawString("Random:0", col2, posY + ln1 + 5 * 22, 0x000000, false);
-        fontRendererObj.drawString("> " + random_motionZ, col2, posY + ln2 + 5 * 22, 0x000000, false);
-        fontRendererObj.drawString("Random:0", col2, posY + ln1 + 6 * 22, 0x000000, false);
-        fontRendererObj.drawString("> " + random_life, col2, posY + ln2 + 6 * 22, 0x000000, false);
-        fontRendererObj.drawString("Random:0", col2, posY + ln1 + 7 * 22, 0x000000, false);
-        fontRendererObj.drawString("> " + random_scale1, col2, posY + ln2 + 7 * 22, 0x000000, false);
-    }
-
-    private void page1Buttons() {
-        int posX = (this.width - xSize) / 2;
-        int posY = (this.height - ySize) / 2;
-        int DX1 = 5;
-        int DX2 = DX1 + 71;
-        int DX3 = DX2 + 40;
-        int DX4 = DX3 + 71;
-        int y1 = 19;
-
-        buttonList.add(new GuiButton(0, posX + DX1, posY + y1 + 0 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(1, posX + DX1, posY + y1 + 1 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(2, posX + DX1, posY + y1 + 2 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(3, posX + DX1, posY + y1 + 3 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(4, posX + DX1, posY + y1 + 4 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(5, posX + DX1, posY + y1 + 5 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(24, posX + DX1, posY + y1 + 6 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(28, posX + DX1, posY + y1 + 7 * 22, 20, 20, "+"));
-
-        buttonList.add(new GuiButton(6, posX + DX2, posY + y1 + 0 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(7, posX + DX2, posY + y1 + 1 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(8, posX + DX2, posY + y1 + 2 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(9, posX + DX2, posY + y1 + 3 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(10, posX + DX2, posY + y1 + 4 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(11, posX + DX2, posY + y1 + 5 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(25, posX + DX2, posY + y1 + 6 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(29, posX + DX2, posY + y1 + 7 * 22, 20, 20, "-"));
-
-        buttonList.add(new GuiButton(12, posX + DX3, posY + y1 + 0 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(13, posX + DX3, posY + y1 + 1 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(14, posX + DX3, posY + y1 + 2 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(15, posX + DX3, posY + y1 + 3 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(16, posX + DX3, posY + y1 + 4 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(17, posX + DX3, posY + y1 + 5 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(26, posX + DX3, posY + y1 + 6 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(30, posX + DX3, posY + y1 + 7 * 22, 20, 20, "+"));
-
-        buttonList.add(new GuiButton(18, posX + DX4, posY + y1 + 0 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(19, posX + DX4, posY + y1 + 1 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(20, posX + DX4, posY + y1 + 2 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(21, posX + DX4, posY + y1 + 3 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(22, posX + DX4, posY + y1 + 4 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(23, posX + DX4, posY + y1 + 5 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(27, posX + DX4, posY + y1 + 6 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(31, posX + DX4, posY + y1 + 7 * 22, 20, 20, "-"));
-    }
-
-    private void page2Txt() {
-        int posX = (this.width - xSize) / 2;
-        int posY = (this.height - ySize) / 2;
-
-        int col1 = posX + 30;
-        int col2 = posX + 141;
-        int ln1 = 20;
-        int ln2 = 30;
-
-        String spawn_X = String.valueOf(Math.round(spawn_x * 10F) / 10F);
-        String spawn_Y = String.valueOf(Math.round(spawn_y * 10F) / 10F);
-        String spawn_Z = String.valueOf(Math.round(spawn_z * 10F) / 10F);
-        String random_spawn_X = String.valueOf(Math.round(random_spawn_x * 10F) / 10F);
-        String random_spawn_Y = String.valueOf(Math.round(random_spawn_y * 10F) / 10F);
-        String random_spawn_Z = String.valueOf(Math.round(random_spawn_z * 10F) / 10F);
-        String Gravity = String.valueOf(Math.round(gravity * 1000F) / 1000F);
-
-        fontRendererObj.drawString("Spawn X:", col1, posY + ln1 + 0 * 22, 0x000000, false);
-        fontRendererObj.drawString(spawn_X, col1, posY + ln2 + 0 * 22, 0x000000, false);
-        fontRendererObj.drawString("Spawn Y:", col1, posY + ln1 + 1 * 22, 0x000000, false);
-        fontRendererObj.drawString(spawn_Y, col1, posY + ln2 + 1 * 22, 0x000000, false);
-        fontRendererObj.drawString("Spawn Z:", col1, posY + ln1 + 2 * 22, 0x000000, false);
-        fontRendererObj.drawString(spawn_Z, col1, posY + ln2 + 2 * 22, 0x000000, false);
-
-        for (int i = 0; i < 3; i++)
-            fontRendererObj.drawStringWithShadow("(+)", posX + 98, posY + 25 + i * 22, 0xFFFFFF);
-
-        fontRendererObj.drawString("Random:0", col2, posY + ln1 + 0 * 22, 0x000000, false);
-        fontRendererObj.drawString("> " + random_spawn_X, col2, posY + ln2 + 0 * 22, 0x000000, false);
-        fontRendererObj.drawString("Random:0", col2, posY + ln1 + 1 * 22, 0x000000, false);
-        fontRendererObj.drawString("> " + random_spawn_Y, col2, posY + ln2 + 1 * 22, 0x000000, false);
-        fontRendererObj.drawString("Random:0", col2, posY + ln1 + 2 * 22, 0x000000, false);
-        fontRendererObj.drawString("> " + random_spawn_Z, col2, posY + ln2 + 2 * 22, 0x000000, false);
-
-        fontRendererObj.drawString("Delay:", col1, posY + ln1 + 3 * 22, 0x000000, false);
-        fontRendererObj.drawString("" + spawn_rate, col1, posY + ln2 + 3 * 22, 0x000000, false);
-        fontRendererObj.drawString("Fade:", col1, posY + ln1 + 4 * 22, 0x000000, false);
-        fontRendererObj.drawString("" + fade, col1, posY + ln2 + 4 * 22, 0x000000, false);
-        fontRendererObj.drawString("Gravity:", col1, posY + ln1 + 5 * 22, 0x000000, false);
-        fontRendererObj.drawString(Gravity, col1, posY + ln2 + 5 * 22, 0x000000, false);
-    }
-
-    private void page2Buttons() {
-        int posX = (this.width - xSize) / 2;
-        int posY = (this.height - ySize) / 2;
-        int DX1 = 5;
-        int DX2 = DX1 + 71;
-        int DX3 = DX2 + 40;
-        int DX4 = DX3 + 71;
-        int y1 = 19;
-
-        buttonList.add(new GuiButton(34, posX + DX1, posY + y1 + 0 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(38, posX + DX1, posY + y1 + 1 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(42, posX + DX1, posY + y1 + 2 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(46, posX + DX1, posY + y1 + 3 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(48, posX + DX1, posY + y1 + 4 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(52, posX + DX1, posY + y1 + 5 * 22, 20, 20, "+"));
-
-        buttonList.add(new GuiButton(35, posX + DX2, posY + y1 + 0 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(39, posX + DX2, posY + y1 + 1 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(43, posX + DX2, posY + y1 + 2 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(47, posX + DX2, posY + y1 + 3 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(49, posX + DX2, posY + y1 + 4 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(53, posX + DX2, posY + y1 + 5 * 22, 20, 20, "-"));
-
-        buttonList.add(new GuiButton(36, posX + DX3, posY + y1 + 0 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(40, posX + DX3, posY + y1 + 1 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(44, posX + DX3, posY + y1 + 2 * 22, 20, 20, "+"));
-
-        buttonList.add(new GuiButton(37, posX + DX4, posY + y1 + 0 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(41, posX + DX4, posY + y1 + 1 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(45, posX + DX4, posY + y1 + 2 * 22, 20, 20, "-"));
-
-        buttonList.add(new GuiButton(
-                50, posX + DX3 - 11, posY + y1 + 3 * 22, 102, 20, "Block Collision: " + (collide ? "on" : "off")));
-        buttonList.add(new GuiButton(
-                51, posX + DX3 - 11, posY + y1 + 4 * 22, 102, 20, "Particle Selected: " + selected_particle));
-
-        buttonList.add(new GuiButton(
-                58, posX + DX3 - 11, posY + y1 + 5 * 22, 102, 20, "Enabled: " + (particles_enabled ? "on" : "off")));
-    }
-
-    private void page3Txt() {
-        int posX = (this.width - xSize) / 2;
-        int posY = (this.height - ySize) / 2;
-
-        int col1 = posX + 30;
-        int col2 = posX + 141;
-        int ln1 = 20;
-        int ln2 = 30;
-
-        String pitch = String.valueOf(Math.round(beam_pitch * 100F) / 100F);
-        String yaw = String.valueOf(Math.round(beam_yaw * 100F) / 100F);
-        String length = String.valueOf(Math.round(beam_length * 100F) / 100F);
-        String rotation = String.valueOf(Math.round(beam_rotation * 100F) / 100F);
-        String scale = String.valueOf(Math.round(beam_scale * 100F) / 100F);
-
-        fontRendererObj.drawString("Red:", col1, posY + ln1 + 0 * 22, 0x000000, false);
-        fontRendererObj.drawString(String.valueOf(beam_red), col1, posY + ln2 + 0 * 22, 0x000000, false);
-        fontRendererObj.drawString("Green:", col1, posY + ln1 + 1 * 22, 0x000000, false);
-        fontRendererObj.drawString(String.valueOf(beam_green), col1, posY + ln2 + 1 * 22, 0x000000, false);
-        fontRendererObj.drawString("Blue:", col1, posY + ln1 + 2 * 22, 0x000000, false);
-        fontRendererObj.drawString(String.valueOf(beam_blue), col1, posY + ln2 + 2 * 22, 0x000000, false);
-
-        fontRendererObj.drawString("Y Rot:", col1, posY + ln1 + 3 * 22, 0x000000, false);
-        fontRendererObj.drawString(pitch, col1, posY + ln2 + 3 * 22, 0x000000, false);
-        fontRendererObj.drawString("Z,X Rot:", col1, posY + ln1 + 4 * 22, 0x000000, false);
-        fontRendererObj.drawString(yaw, col1, posY + ln2 + 4 * 22, 0x000000, false);
-        fontRendererObj.drawString("Length:", col1, posY + ln1 + 5 * 22, 0x000000, false);
-        fontRendererObj.drawString(length, col1, posY + ln2 + 5 * 22, 0x000000, false);
-        fontRendererObj.drawString("Rotation:", col1, posY + ln1 + 6 * 22, 0x000000, false);
-        fontRendererObj.drawString(rotation, col1, posY + ln2 + 6 * 22, 0x000000, false);
-        fontRendererObj.drawString("Scale:", col1, posY + ln1 + 7 * 22, 0x000000, false);
-        fontRendererObj.drawString(scale, col1, posY + ln2 + 7 * 22, 0x000000, false);
-    }
-
-    private void page3Buttons() {
-        int posX = (this.width - xSize) / 2;
-        int posY = (this.height - ySize) / 2;
-        int DX1 = 5; // x pos for row 1,2,3,4
-        int DX2 = DX1 + 71;
-        int DX3 = DX2 + 40;
-        int DX4 = DX3 + 71;
-        int y1 = 19;
-
-        buttonList.add(new GuiButton(100, posX + DX1, posY + y1 + 0 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(101, posX + DX1, posY + y1 + 1 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(102, posX + DX1, posY + y1 + 2 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(103, posX + DX1, posY + y1 + 3 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(104, posX + DX1, posY + y1 + 4 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(105, posX + DX1, posY + y1 + 5 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(106, posX + DX1, posY + y1 + 6 * 22, 20, 20, "+"));
-        buttonList.add(new GuiButton(107, posX + DX1, posY + y1 + 7 * 22, 20, 20, "+"));
-
-        buttonList.add(new GuiButton(108, posX + DX2, posY + y1 + 0 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(109, posX + DX2, posY + y1 + 1 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(110, posX + DX2, posY + y1 + 2 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(111, posX + DX2, posY + y1 + 3 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(112, posX + DX2, posY + y1 + 4 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(113, posX + DX2, posY + y1 + 5 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(114, posX + DX2, posY + y1 + 6 * 22, 20, 20, "-"));
-        buttonList.add(new GuiButton(115, posX + DX2, posY + y1 + 7 * 22, 20, 20, "-"));
-
-        buttonList.add(new GuiButton(
-                116, posX + DX3 - 11, posY + y1 + 0 * 22, 102, 20, "Enabled: " + (beam_enabled ? "on" : "off")));
-        buttonList.add(new GuiButton(
-                117, posX + DX3 - 11, posY + y1 + 1 * 22, 102, 20, "Render Core: " + (render_core ? "on" : "off")));
-
-        buttonList.add(new GuiButton(127, posX + DX3 - 11, posY + y1 + 7 * 22, 102, 20, "Take note of values"));
-    }
-
-    private void beamActions(GuiButton button) {
-        int value = 1;
-        float value_F;
-        short packetValue = 0;
-        if (Keyboard.isKeyDown(42) || Keyboard.isKeyDown(54)) value = 10;
-        if (Keyboard.isKeyDown(29) || Keyboard.isKeyDown(157)) value = 100;
-        if ((Keyboard.isKeyDown(29) || Keyboard.isKeyDown(157)) && (Keyboard.isKeyDown(42) || Keyboard.isKeyDown(54)))
-            value = 1000;
-
-        value_F = (value) / 100F;
-
-        switch (button.id) {
-            case 100: // beam red +
-                beam_red = (beam_red + value) > 255 ? 255 : beam_red + value;
-                packetValue = (short) beam_red;
-                break;
-            case 101: // beam green +
-                beam_green = (beam_green + value) > 255 ? 255 : beam_green + value;
-                packetValue = (short) beam_green;
-                break;
-            case 102: // beam blue +
-                beam_blue = (beam_blue + value) > 255 ? 255 : beam_blue + value;
-                packetValue = (short) beam_blue;
-                break;
-            case 103: // beam pitch +
-                beam_pitch = (beam_pitch + value_F) > 180F ? 180F : beam_pitch + value_F;
-                packetValue = (short) (beam_pitch * 100F);
-                break;
-            case 104: // beam yaw +
-                beam_yaw = (beam_yaw + value_F) > 180F ? 180F : beam_yaw + value_F;
-                packetValue = (short) (beam_yaw * 100F);
-                break;
-            case 105: // beam length +
-                beam_length = (beam_length + value_F) > 320F ? 320F : beam_length + value_F;
-                packetValue = (short) (beam_length * 100F);
-                break;
-            case 106: // beam rotation +
-                beam_rotation = (beam_rotation + value_F) > 1F ? 1F : beam_rotation + value_F;
-                packetValue = (short) (beam_rotation * 100F);
-                break;
-            case 107: // beam scale +
-                beam_scale = (beam_scale + value_F) > 5F ? 5F : beam_scale + value_F;
-                packetValue = (short) (beam_scale * 100F);
-                break;
-            case 108: // beam red -
-                beam_red = (beam_red - value) < 0 ? 0 : beam_red - value;
-                packetValue = (short) beam_red;
-                break;
-            case 109: // beam green -
-                beam_green = (beam_green - value) < 0 ? 0 : beam_green - value;
-                packetValue = (short) beam_green;
-                break;
-            case 110: // beam blue -
-                beam_blue = (beam_blue - value) < 0 ? 0 : beam_blue - value;
-                packetValue = (short) beam_blue;
-                break;
-            case 111: // beam pitch -
-                beam_pitch = (beam_pitch - value_F) < -180F ? -180F : beam_pitch - value_F;
-                packetValue = (short) (beam_pitch * 100F);
-                break;
-            case 112: // beam yaw -
-                beam_yaw = (beam_yaw - value_F) < -180F ? -180F : beam_yaw - value_F;
-                packetValue = (short) (beam_yaw * 100F);
-                break;
-            case 113: // beam length -
-                beam_length = (beam_length - value_F) < -0F ? -0F : beam_length - value_F;
-                packetValue = (short) (beam_length * 100F);
-                break;
-            case 114: // beam rotation -
-                beam_rotation = (beam_rotation - value_F) < -1F ? -1F : beam_rotation - value_F;
-                packetValue = (short) (beam_rotation * 100F);
-                break;
-            case 115: // beam scale -
-                beam_scale = (beam_scale - value_F) < -0F ? -0F : beam_scale - value_F;
-                packetValue = (short) (beam_scale * 100F);
-                break;
-            case 116: // beam enabled
-                beam_enabled = !beam_enabled;
-                packetValue = beam_enabled ? (byte) 1 : (byte) 0;
-                initGui();
-                break;
-            case 117: // beam enabled
-                render_core = !render_core;
-                packetValue = render_core ? (byte) 1 : (byte) 0;
-                initGui();
-                break;
+    private void updateButtons() {
+        for (IProperty property : properties.values()) {
+            property.updateButtons(page);
         }
-        DraconicEvolution.network.sendToServer(
-                new ParticleGenPacket((byte) button.id, packetValue, tile.xCoord, tile.yCoord, tile.zCoord));
-    }
-    // @formatter:on
 
+        previousPage.visible = page > 1 && page <= 3;
+        nextPage.visible = page < 3;
+        if (page == 10) {
+            showInfo.visible = false;
+            hideInfo.visible = true;
+            previousInfoPage.visible = infoPage > 0;
+            nextInfoPage.visible = infoPage < InfoText.length - 1;
+        } else {
+            showInfo.visible = true;
+            hideInfo.visible = false;
+            previousInfoPage.visible = false;
+            nextInfoPage.visible = false;
+        }
+        collisionToggle.visible = page == 2;
+        collisionToggle.displayString = "Block Collision: " + (canParticleCollide ? "on" : "off");
+        particleSelector.visible = page == 2;
+        particleSelector.displayString = "Particle Selected: " + selectedParticle;
+        particleToggle.visible = page == 2;
+        particleToggle.displayString = "Enabled: " + (isParticlesEnabled ? "on" : "off");
+        beamToggle.visible = page == 3;
+        beamToggle.displayString = "Enabled: " + (isBeamEnabled ? "on" : "off");
+        coreRenderToggle.visible = page == 3;
+        coreRenderToggle.displayString = "Render Core: " + (shouldRenderCore ? "on" : "off");
+        settingsSaver.visible = page == 3;
+    }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIParticleGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIParticleGenerator.java
@@ -178,7 +178,7 @@ public class GUIParticleGenerator extends GuiScreen {
         this.particleGenerator = particleGenerator;
         this.properties = new HashMap<>();
         syncWithServer();
-        this.updateScreen();
+        updateScreen();
     }
 
     private static final String[] InfoText = {
@@ -433,7 +433,7 @@ public class GUIParticleGenerator extends GuiScreen {
         properties.put(13, new FloatProperty(1, "Random:", particleGenerator.randomMotionX, -5F, 5F, 1000F));
         properties.put(14, new FloatProperty(1, "Random:", particleGenerator.randomMotionY, -5F, 5F, 1000F));
         properties.put(15, new FloatProperty(1, "Random:", particleGenerator.randomMotionZ, -5F, 5F, 1000F));
-        properties.put(16, new FloatProperty(1, "Random:", particleGenerator.randomScale, 0.01F, 50F, 100F));
+        properties.put(16, new FloatProperty(1, "Random:", particleGenerator.randomScale, 0F, 50F, 100F));
         properties.put(17, new IntegerProperty(1, "Random:", particleGenerator.randomLife, 0, 1000));
 
         properties.put(20, new FloatProperty(2, "Spawn X:", particleGenerator.spawnX, -50F, 50F, 10F));

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIPlayerDetector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIPlayerDetector.java
@@ -1,12 +1,12 @@
 package com.brandon3055.draconicevolution.client.gui;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiTextField;
 import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
 
@@ -25,78 +25,75 @@ import cpw.mods.fml.relauncher.SideOnly;
 @SideOnly(Side.CLIENT)
 public class GUIPlayerDetector extends GuiContainer {
 
-    public EntityPlayer player;
-    private TilePlayerDetectorAdvanced detector;
-    public boolean showInvSlots = true;
-    private boolean editMode = false;
+    private static final ResourceLocation Texture = new ResourceLocation(
+            References.MODID.toLowerCase(),
+            "textures/gui/PlayerDetector.png");
+
+    private final ContainerPlayerDetector container;
+    private boolean isInEditMode = false;
     private int range = 0;
-    private int maxRange = 20;
-    private boolean whitelist = false;
-    private boolean initScedualed = false;
+    private boolean isInWhitelistMode = false;
+    private boolean isOutputInverted = false;
+    private boolean isInitScheduled = false;
     private int initTick = 0;
-    private String[] names = new String[42];
+    private final String[] names = new String[42];
     private GuiTextField selectedNameText;
-    private int selected = -1;
-    private boolean outputInverted = false;
+    private int selectedMameIndex = -1;
 
-    public GUIPlayerDetector(InventoryPlayer invPlayer, TilePlayerDetectorAdvanced detector) {
-        super(detector.getGuiContainer(invPlayer));
-        this.inventorySlots = new ContainerPlayerDetector(invPlayer, detector, this);
-
-        for (int i = 0; i < names.length; i++) names[i] = "";
+    public GUIPlayerDetector(InventoryPlayer playerInventory, TilePlayerDetectorAdvanced detector) {
+        super(detector.getGuiContainer(playerInventory));
+        container = (ContainerPlayerDetector) inventorySlots;
+        Arrays.fill(names, "");
 
         xSize = 176;
         ySize = 198;
 
-        this.detector = detector;
-        this.player = invPlayer.player;
         syncWithServer();
     }
 
-    private static final ResourceLocation texture = new ResourceLocation(
-            References.MODID.toLowerCase(),
-            "textures/gui/PlayerDetector.png");
-
     @Override
-    protected void drawGuiContainerBackgroundLayer(float f, int x, int y) {
+    protected void drawGuiContainerBackgroundLayer(float partialTicks, int x, int y) {
         GL11.glColor4f(1, 1, 1, 1);
 
-        Minecraft.getMinecraft().getTextureManager().bindTexture(texture);
+        Minecraft.getMinecraft().getTextureManager().bindTexture(Texture);
         drawTexturedModalRect(guiLeft, guiTop, 0, 0, xSize, ySize);
-        if (editMode) {
+        if (isInEditMode) {
             drawTexturedModalRect(guiLeft + 3, guiTop + ySize / 2, 3, 3, xSize - 6, (ySize / 2) - 3);
             drawNameChart(x, y);
         }
-
-        if (showInvSlots) drawTexturedModalRect(guiLeft + 142, guiTop + 19, xSize, 0, 23, 41);
+        if (container.shouldShowInventory()) {
+            drawTexturedModalRect(guiLeft + 142, guiTop + 19, xSize, 0, 23, 41);
+        }
     }
 
     @Override
     protected void drawGuiContainerForegroundLayer(int x, int y) {
-        drawGuiText(x, y);
+        drawGuiText();
     }
 
     @Override
-    public void drawScreen(int x, int y, float p_73863_3_) {
-        super.drawScreen(x, y, p_73863_3_);
-        ArrayList<String> lines = new ArrayList<String>();
+    public void drawScreen(int x, int y, float partialTicks) {
+        super.drawScreen(x, y, partialTicks);
+        ArrayList<String> lines = new ArrayList<>();
         lines.add("Camouflage");
-        if ((x - guiLeft > 142 && x - guiLeft < 160) && (y - guiTop > 19 && y - guiTop < 37) && showInvSlots)
+        if ((x - guiLeft > 142 && x - guiLeft < 160) && (y - guiTop > 19 && y - guiTop < 37)
+                && container.shouldShowInventory()) {
             drawHoveringText(lines, x, y, fontRendererObj);
+        }
     }
 
     @Override
     public void initGui() {
         super.initGui();
         buttonList.clear();
-        if (!editMode) {
-            String wt = whitelist ? "White List" : "Black List";
-            int centre = width / 2;
-            buttonList.add(new GuiButton(0, centre - 20 - 20, guiTop + 20, 20, 20, "+"));
-            buttonList.add(new GuiButton(1, centre + 20, guiTop + 20, 20, 20, "-"));
-            buttonList.add(new GuiButton(3, centre - 40, guiTop + 45, 60, 20, wt));
-            buttonList.add(new GuiButton(4, centre + 20, guiTop + 45, 20, 20, "!"));
-            buttonList.add(new GuiButton(6, centre - 40, guiTop + 70, 80, 20, "Invert Output"));
+        if (!isInEditMode) {
+            String mode = isInWhitelistMode ? "White List" : "Black List";
+            int center = width / 2;
+            buttonList.add(new GuiButton(0, center - 20 - 20, guiTop + 20, 20, 20, "+"));
+            buttonList.add(new GuiButton(1, center + 20, guiTop + 20, 20, 20, "-"));
+            buttonList.add(new GuiButton(3, center - 40, guiTop + 45, 60, 20, mode));
+            buttonList.add(new GuiButton(4, center + 20, guiTop + 45, 20, 20, "!"));
+            buttonList.add(new GuiButton(6, center - 40, guiTop + 70, 80, 20, "Invert Output"));
         } else {
             buttonList.add(new GuiButton(5, guiLeft - 40, guiTop + ySize - 20, 40, 20, "Back"));
         }
@@ -106,112 +103,108 @@ public class GUIPlayerDetector extends GuiContainer {
         selectedNameText.setDisabledTextColour(-1);
         selectedNameText.setEnableBackgroundDrawing(true);
         selectedNameText.setMaxStringLength(40);
-        selectedNameText.setVisible(editMode);
-
-        // ID
-        // buttonList.add(new GuiButton(0, guiLeft + 85, guiTop , 85, 20, "sgASGgs"));
-
-        // syncWithServer();
+        selectedNameText.setVisible(isInEditMode);
     }
 
     @Override
     protected void actionPerformed(GuiButton button) {
         switch (button.id) {
             case 0: // Range +
-                range = (range < maxRange) ? range + 1 : maxRange;
+                range = Math.min(range + 1, TilePlayerDetectorAdvanced.MAXIMUM_RANGE);
                 DraconicEvolution.network.sendToServer(new PlayerDetectorButtonPacket((byte) 0, (byte) range));
                 break;
             case 1: // Range -
-                range = (range > 1) ? range - 1 : 1;
+                range = Math.max(range - 1, TilePlayerDetectorAdvanced.MINIMUM_RANGE);
                 DraconicEvolution.network.sendToServer(new PlayerDetectorButtonPacket((byte) 0, (byte) range));
                 break;
-            case 3: // White List -
-                initScedualed = true;
-                editMode = true;
-                showInvSlots = false;
-                ((ContainerPlayerDetector) this.inventorySlots).updateContainerSlots();
+            case 3: // Edit Whitelist/Blacklist
+                isInitScheduled = true;
+                isInEditMode = true;
+                container.setShouldShowInventory(false);
                 break;
-            case 4: // Toggle White List -
-                whitelist = !whitelist;
-                initScedualed = true;
-                byte val = (byte) (whitelist ? 1 : 0);
-                DraconicEvolution.network.sendToServer(new PlayerDetectorButtonPacket((byte) 1, val));
+            case 4: // Toggle Whitelist/Blacklist mode
+                isInitScheduled = true;
+                isInWhitelistMode = !isInWhitelistMode;
+                byte whitelistMode = (byte) (isInWhitelistMode ? 1 : 0);
+                DraconicEvolution.network.sendToServer(new PlayerDetectorButtonPacket((byte) 1, whitelistMode));
                 break;
-            case 5: // Back -
-                editMode = false;
-                showInvSlots = true;
-                ((ContainerPlayerDetector) this.inventorySlots).updateContainerSlots();
-                initScedualed = true;
+            case 5: // Back
+                isInitScheduled = true;
+                isInEditMode = false;
+                container.setShouldShowInventory(true);
                 break;
-            case 6: // Back -
-                outputInverted = !outputInverted;
-                initScedualed = true;
-                byte val2 = (byte) (outputInverted ? 1 : 0);
-                DraconicEvolution.network.sendToServer(new PlayerDetectorButtonPacket((byte) 2, val2));
+            case 6: // Invert Output
+                isInitScheduled = true;
+                isOutputInverted = !isOutputInverted;
+                byte outputMode = (byte) (isOutputInverted ? 1 : 0);
+                DraconicEvolution.network.sendToServer(new PlayerDetectorButtonPacket((byte) 2, outputMode));
                 break;
         }
-
-        // DraconicEvolution.channelHandler.sendToServer(new ButtonPacket((byte) 0, true));
-
     }
 
     @Override
-    protected void keyTyped(char par1, int par2) {
-        if (this.selectedNameText.textboxKeyTyped(par1, par2)) return;
-        else if (par2 == 28) {
+    protected void keyTyped(char typedChar, int keyCode) {
+        if (this.selectedNameText.textboxKeyTyped(typedChar, keyCode)) {
+            return;
+        }
+        if (keyCode == 28) {
             if (selectedNameText.isFocused()) {
-                names[selected] = selectedNameText.getText();
+                names[selectedMameIndex] = selectedNameText.getText();
                 selectedNameText.setText("");
                 selectedNameText.setFocused(false);
-                DraconicEvolution.network
-                        .sendToServer(new PlayerDetectorStringPacket((byte) selected, names[selected]));
-                selected = -1;
+                DraconicEvolution.network.sendToServer(
+                        new PlayerDetectorStringPacket((byte) selectedMameIndex, names[selectedMameIndex]));
+                selectedMameIndex = -1;
             }
-        } else super.keyTyped(par1, par2);
+        } else {
+            super.keyTyped(typedChar, keyCode);
+        }
     }
 
     @Override
     public void updateScreen() {
-        if (initScedualed) initTick++;
+        if (isInitScheduled) {
+            initTick++;
+        }
         if (initTick > 1) {
             initTick = 0;
-            initScedualed = false;
+            isInitScheduled = false;
             initGui();
         }
         super.updateScreen();
     }
 
     @Override
-    protected void mouseClicked(int x, int y, int par3) {
-        super.mouseClicked(x, y, par3);
-
-        if (editMode) selectName(x - guiLeft, y - guiTop);
-
-        // this.selectedNameText.mouseClicked(x - guiLeft, y - guiTop, par3);
+    protected void mouseClicked(int x, int y, int mouseButton) {
+        super.mouseClicked(x, y, mouseButton);
+        if (isInEditMode) {
+            selectName(x - guiLeft, y - guiTop);
+        }
     }
 
-    private void drawGuiText(int rawX, int rawY) {
-        if (!editMode) {
-            drawCenteredString(fontRendererObj, "Advanced Player Detector", xSize / 2, 5, 0x00FFFF);
-
-            fontRendererObj.drawString("Range:", 73, 21, 0x000000, false);
-            fontRendererObj.drawString("Output Inverted: " + String.valueOf(outputInverted), 33, 97, 0x000000, false);
-            if (range < 10) fontRendererObj.drawString("" + range, 85, 31, 0x000000, false);
-            else fontRendererObj.drawString("" + range, 82, 31, 0x000000, false);
-        } else {
-            if (selected != -1) drawCenteredString(fontRendererObj, "Press Enter to save", xSize / 2, -22, 0xFF0000);
-
-            for (int i = 0; i < 21; i++) {
-                for (int j = 0; j < 2; j++) {
-                    if (i + j * 21 != selected) {
-                        String s = names[i + j * 21];
-                        if (s.length() > 13) s = s.substring(0, 13) + "...";
-                        fontRendererObj.drawString(s, 5 + j * 84, 6 + i * 9, 0x980000);
+    private void drawGuiText() {
+        if (isInEditMode) {
+            if (selectedMameIndex != -1) {
+                drawCenteredString(fontRendererObj, "Press Enter to save", xSize / 2, -22, 0xFF0000);
+            }
+            for (int row = 0; row < 21; row++) {
+                for (int column = 0; column < 2; column++) {
+                    if (row + column * 21 != selectedMameIndex) {
+                        String name = names[row + column * 21];
+                        if (name.length() > 13) {
+                            name = name.substring(0, 13) + "...";
+                        }
+                        fontRendererObj.drawString(name, 5 + column * 84, 6 + row * 9, 0x980000);
                     }
                 }
             }
-        }
+        } else {
+            drawCenteredString(fontRendererObj, "Advanced Player Detector", xSize / 2, 5, 0x00FFFF);
 
+            fontRendererObj.drawString("Range:", 73, 21, 0x000000, false);
+            fontRendererObj.drawString("Output Inverted: " + isOutputInverted, 33, 97, 0x000000, false);
+            fontRendererObj.drawString(String.valueOf(range), range < 10 ? 85 : 82, 31, 0x000000, false);
+        }
         selectedNameText.drawTextBox();
     }
 
@@ -219,39 +212,46 @@ public class GUIPlayerDetector extends GuiContainer {
         int x = rawX - guiLeft;
         int y = rawY - guiTop;
 
-        for (int i = 0; i < 21; i++) {
-            drawTexturedModalRect(guiLeft + 4, guiTop + 4 + i * 9, 0, ySize, 186, 10);
+        for (int row = 0; row < 21; row++) {
+            drawTexturedModalRect(guiLeft + 4, guiTop + 4 + row * 9, 0, ySize, 186, 10);
         }
 
-        for (int i = 0; i < 21; i++) {
-            for (int j = 0; j < 2; j++) {
-                if ((x > 4 + j * 84 && x < (xSize / 2) - 1 + j * 82) && (y > 4 + i * 9 && y < 13 + i * 9)
-                        || i + j * 21 == selected)
-                    drawTexturedModalRect(guiLeft + 5 + j * 84, guiTop + 5 + i * 9, 0, ySize + 10, 82, 8);
+        for (int row = 0; row < 21; row++) {
+            for (int column = 0; column < 2; column++) {
+                if ((x > 4 + column * 84 && x < (xSize / 2) - 1 + column * 82) && (y > 4 + row * 9 && y < 13 + row * 9)
+                        || row + column * 21 == selectedMameIndex)
+                    drawTexturedModalRect(guiLeft + 5 + column * 84, guiTop + 5 + row * 9, 0, ySize + 10, 82, 8);
             }
         }
     }
 
     public void selectName(int x, int y) {
-        if (initScedualed) return;
+        if (isInitScheduled) {
+            return;
+        }
 
-        for (int i = 0; i < 21; i++) {
-            for (int j = 0; j < 2; j++) {
-                if ((x > 4 + j * 84 && x < (xSize / 2) - 1 + j * 82) && (y > 4 + i * 9 && y < 13 + i * 9)) {
-                    selected = i + j * 21;
-                    selectedNameText.setText(names[i + j * 21]);
+        for (int row = 0; row < 21; row++) {
+            for (int column = 0; column < 2; column++) {
+                if ((x > 4 + column * 84 && x < (xSize / 2) - 1 + column * 82)
+                        && (y > 4 + row * 9 && y < 13 + row * 9)) {
+                    selectedMameIndex = row + column * 21;
+                    selectedNameText.setText(names[row + column * 21]);
                     selectedNameText.setFocused(true);
+                    return;
                 }
             }
         }
     }
 
     private void syncWithServer() {
-        this.whitelist = detector.whiteList;
+        TilePlayerDetectorAdvanced detector = container.getDetector();
+        isInWhitelistMode = detector.isInWhiteListMode;
         for (int i = 0; i < detector.names.length; i++) {
-            if (detector.names[i] != null) names[i] = detector.names[i];
+            if (detector.names[i] != null) {
+                names[i] = detector.names[i];
+            }
         }
         range = detector.range;
-        outputInverted = detector.outputInverted;
+        isOutputInverted = detector.isOutputInverted;
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIPlayerDetector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/GUIPlayerDetector.java
@@ -25,7 +25,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 @SideOnly(Side.CLIENT)
 public class GUIPlayerDetector extends GuiContainer {
 
-    private static final ResourceLocation Texture = new ResourceLocation(
+    private static final ResourceLocation texture = new ResourceLocation(
             References.MODID.toLowerCase(),
             "textures/gui/PlayerDetector.png");
 
@@ -55,7 +55,7 @@ public class GUIPlayerDetector extends GuiContainer {
     protected void drawGuiContainerBackgroundLayer(float partialTicks, int x, int y) {
         GL11.glColor4f(1, 1, 1, 1);
 
-        Minecraft.getMinecraft().getTextureManager().bindTexture(Texture);
+        Minecraft.getMinecraft().getTextureManager().bindTexture(texture);
         drawTexturedModalRect(guiLeft, guiTop, 0, 0, xSize, ySize);
         if (isInEditMode) {
             drawTexturedModalRect(guiLeft + 3, guiTop + ySize / 2, 3, 3, xSize - 6, (ySize / 2) - 3);
@@ -83,6 +83,7 @@ public class GUIPlayerDetector extends GuiContainer {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void initGui() {
         super.initGui();
         buttonList.clear();
@@ -109,36 +110,36 @@ public class GUIPlayerDetector extends GuiContainer {
     @Override
     protected void actionPerformed(GuiButton button) {
         switch (button.id) {
-            case 0: // Range +
+            case 0 -> { // Range +
                 range = Math.min(range + 1, TilePlayerDetectorAdvanced.MAXIMUM_RANGE);
                 DraconicEvolution.network.sendToServer(new PlayerDetectorButtonPacket((byte) 0, (byte) range));
-                break;
-            case 1: // Range -
+            }
+            case 1 -> { // Range -
                 range = Math.max(range - 1, TilePlayerDetectorAdvanced.MINIMUM_RANGE);
                 DraconicEvolution.network.sendToServer(new PlayerDetectorButtonPacket((byte) 0, (byte) range));
-                break;
-            case 3: // Edit Whitelist/Blacklist
+            }
+            case 3 -> { // Edit Whitelist/Blacklist
                 isInitScheduled = true;
                 isInEditMode = true;
                 container.setShouldShowInventory(false);
-                break;
-            case 4: // Toggle Whitelist/Blacklist mode
+            }
+            case 4 -> { // Toggle Whitelist/Blacklist mode
                 isInitScheduled = true;
                 isInWhitelistMode = !isInWhitelistMode;
                 byte whitelistMode = (byte) (isInWhitelistMode ? 1 : 0);
                 DraconicEvolution.network.sendToServer(new PlayerDetectorButtonPacket((byte) 1, whitelistMode));
-                break;
-            case 5: // Back
+            }
+            case 5 -> { // Back
                 isInitScheduled = true;
                 isInEditMode = false;
                 container.setShouldShowInventory(true);
-                break;
-            case 6: // Invert Output
+            }
+            case 6 -> { // Invert Output
                 isInitScheduled = true;
                 isOutputInverted = !isOutputInverted;
                 byte outputMode = (byte) (isOutputInverted ? 1 : 0);
                 DraconicEvolution.network.sendToServer(new PlayerDetectorButtonPacket((byte) 2, outputMode));
-                break;
+            }
         }
     }
 

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/GuiHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/GuiHandler.java
@@ -8,9 +8,28 @@ import com.brandon3055.draconicevolution.DraconicEvolution;
 import com.brandon3055.draconicevolution.client.gui.componentguis.GUIManual;
 import com.brandon3055.draconicevolution.client.gui.componentguis.GUIReactor;
 import com.brandon3055.draconicevolution.client.gui.componentguis.GUIToolConfig;
-import com.brandon3055.draconicevolution.common.container.*;
+import com.brandon3055.draconicevolution.common.container.ContainerAdvTool;
+import com.brandon3055.draconicevolution.common.container.ContainerDissEnchanter;
+import com.brandon3055.draconicevolution.common.container.ContainerDraconiumChest;
+import com.brandon3055.draconicevolution.common.container.ContainerEnergyInfuser;
+import com.brandon3055.draconicevolution.common.container.ContainerGenerator;
+import com.brandon3055.draconicevolution.common.container.ContainerGrinder;
+import com.brandon3055.draconicevolution.common.container.ContainerPlayerDetector;
+import com.brandon3055.draconicevolution.common.container.ContainerReactor;
+import com.brandon3055.draconicevolution.common.container.ContainerSunDial;
+import com.brandon3055.draconicevolution.common.container.ContainerUpgradeModifier;
+import com.brandon3055.draconicevolution.common.container.ContainerWeatherController;
 import com.brandon3055.draconicevolution.common.inventory.InventoryTool;
-import com.brandon3055.draconicevolution.common.tileentities.*;
+import com.brandon3055.draconicevolution.common.tileentities.TileDissEnchanter;
+import com.brandon3055.draconicevolution.common.tileentities.TileDraconiumChest;
+import com.brandon3055.draconicevolution.common.tileentities.TileEnergyInfuser;
+import com.brandon3055.draconicevolution.common.tileentities.TileGenerator;
+import com.brandon3055.draconicevolution.common.tileentities.TileGrinder;
+import com.brandon3055.draconicevolution.common.tileentities.TileParticleGenerator;
+import com.brandon3055.draconicevolution.common.tileentities.TilePlayerDetectorAdvanced;
+import com.brandon3055.draconicevolution.common.tileentities.TileSunDial;
+import com.brandon3055.draconicevolution.common.tileentities.TileUpgradeModifier;
+import com.brandon3055.draconicevolution.common.tileentities.TileWeatherController;
 import com.brandon3055.draconicevolution.common.tileentities.gates.TileGate;
 import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor.TileReactorCore;
 
@@ -41,163 +60,145 @@ public class GuiHandler implements IGuiHandler {
     }
 
     @Override
-    public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-        switch (ID) {
-            case GUIID_WEATHER_CONTROLLER:
-                TileEntity weatherController = world.getTileEntity(x, y, z);
-                if (weatherController instanceof TileWeatherController) {
-                    return new ContainerWeatherController(player.inventory, (TileWeatherController) weatherController);
+    public Object getServerGuiElement(int id, EntityPlayer player, World world, int x, int y, int z) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        switch (id) {
+            case GUIID_WEATHER_CONTROLLER -> {
+                if (tile instanceof TileWeatherController weatherController) {
+                    return new ContainerWeatherController(player.inventory, weatherController);
                 }
-                break;
-            case GUIID_SUN_DIAL:
-                TileEntity sunDial = world.getTileEntity(x, y, z);
-                if (sunDial instanceof TileSunDial) {
-                    return new ContainerSunDial(player.inventory, (TileSunDial) sunDial);
+            }
+            case GUIID_SUN_DIAL -> {
+                if (tile instanceof TileSunDial sunDial) {
+                    return new ContainerSunDial(player.inventory, sunDial);
                 }
-                break;
-            case GUIID_GRINDER:
-                TileEntity grinder = world.getTileEntity(x, y, z);
-                if (grinder instanceof TileGrinder) {
-                    return new ContainerGrinder(player.inventory, (TileGrinder) grinder);
+            }
+            case GUIID_GRINDER -> {
+                if (tile instanceof TileGrinder grinder) {
+                    return new ContainerGrinder(player.inventory, grinder);
                 }
-                break;
-            case GUIID_PLAYERDETECTOR:
-                TileEntity detector = world.getTileEntity(x, y, z);
-                if (detector instanceof TilePlayerDetectorAdvanced) {
-                    return new ContainerPlayerDetector(player.inventory, (TilePlayerDetectorAdvanced) detector);
+            }
+            case GUIID_PLAYERDETECTOR -> {
+                if (tile instanceof TilePlayerDetectorAdvanced detector) {
+                    return new ContainerPlayerDetector(player.inventory, detector);
                 }
-                break;
-            case GUIID_ENERGY_INFUSER:
-                TileEntity infuser = world.getTileEntity(x, y, z);
-                if (infuser instanceof TileEnergyInfuser) {
-                    return new ContainerEnergyInfuser(player.inventory, (TileEnergyInfuser) infuser);
+            }
+            case GUIID_ENERGY_INFUSER -> {
+                if (tile instanceof TileEnergyInfuser infuser) {
+                    return new ContainerEnergyInfuser(player.inventory, infuser);
                 }
-                break;
-            case GUIID_GENERATOR:
-                TileEntity generator = world.getTileEntity(x, y, z);
-                if (generator instanceof TileGenerator) {
-                    return new ContainerGenerator(player.inventory, (TileGenerator) generator);
+            }
+            case GUIID_GENERATOR -> {
+                if (tile instanceof TileGenerator generator) {
+                    return new ContainerGenerator(player.inventory, generator);
                 }
-                break;
-            case GUIID_DISSENCHANTER:
-                TileEntity dissenchanter = world.getTileEntity(x, y, z);
-                if (dissenchanter instanceof TileDissEnchanter) {
-                    return new ContainerDissEnchanter(player.inventory, (TileDissEnchanter) dissenchanter);
+            }
+            case GUIID_DISSENCHANTER -> {
+                if (tile instanceof TileDissEnchanter dissenchanter) {
+                    return new ContainerDissEnchanter(player.inventory, dissenchanter);
                 }
-                break;
-            case GUIID_DRACONIC_CHEST:
-                TileEntity containerChest = world.getTileEntity(x, y, z);
-                if (containerChest instanceof TileDraconiumChest) {
-                    return new ContainerDraconiumChest(player.inventory, (TileDraconiumChest) containerChest);
+            }
+            case GUIID_DRACONIC_CHEST -> {
+                if (tile instanceof TileDraconiumChest draconiumChest) {
+                    return new ContainerDraconiumChest(player.inventory, draconiumChest);
                 }
-                break;
-            case GUIID_REACTOR:
-                TileEntity reactor = world.getTileEntity(x, y, z);
-                if (reactor instanceof TileReactorCore) {
-                    return new ContainerReactor(player, (TileReactorCore) reactor);
+            }
+            case GUIID_REACTOR -> {
+                if (tile instanceof TileReactorCore reactorCore) {
+                    return new ContainerReactor(player, reactorCore);
                 }
-                break;
-            case GUIID_TOOL_CONFIG:
+            }
+            case GUIID_TOOL_CONFIG -> {
                 return new ContainerAdvTool(player.inventory, new InventoryTool(player, null));
-            case GUIID_UPGRADE_MODIFIER:
-                TileEntity containerTemp = world.getTileEntity(x, y, z);
-                if (containerTemp instanceof TileUpgradeModifier) {
-                    return new ContainerUpgradeModifier(player.inventory, (TileUpgradeModifier) containerTemp);
+            }
+            case GUIID_UPGRADE_MODIFIER -> {
+                if (tile instanceof TileUpgradeModifier upgradeModifier) {
+                    return new ContainerUpgradeModifier(player.inventory, upgradeModifier);
                 }
-                break;
+            }
         }
 
         return null;
     }
 
     @Override
-    public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-        switch (ID) {
-            case GUIID_WEATHER_CONTROLLER:
-                TileEntity weatherController = world.getTileEntity(x, y, z);
-                if (weatherController instanceof TileWeatherController) {
-                    return new GUIWeatherController(player.inventory, (TileWeatherController) weatherController);
+    public Object getClientGuiElement(int id, EntityPlayer player, World world, int x, int y, int z) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        switch (id) {
+            case GUIID_WEATHER_CONTROLLER -> {
+                if (tile instanceof TileWeatherController weatherController) {
+                    return new GUIWeatherController(player.inventory, weatherController);
                 }
-                break;
-            case GUIID_SUN_DIAL:
-                TileEntity sunDial = world.getTileEntity(x, y, z);
-                if (sunDial instanceof TileSunDial) {
-                    return new GUISunDial(player.inventory, (TileSunDial) sunDial);
+            }
+            case GUIID_SUN_DIAL -> {
+                if (tile instanceof TileSunDial sunDial) {
+                    return new GUISunDial(player.inventory, sunDial);
                 }
-                break;
-            case GUIID_TELEPORTER:
+            }
+            case GUIID_TELEPORTER -> {
                 return new GUITeleporter(player);
-            case GUIID_GRINDER:
-                TileEntity grinder = world.getTileEntity(x, y, z);
-                if (grinder instanceof TileGrinder) {
-                    return new GUIGrinder(player.inventory, (TileGrinder) grinder);
+            }
+            case GUIID_GRINDER -> {
+                if (tile instanceof TileGrinder grinder) {
+                    return new GUIGrinder(player.inventory, grinder);
                 }
-                break;
-            case GUIID_PARTICLEGEN:
-                TileEntity particleGenerator = world.getTileEntity(x, y, z);
-                if (particleGenerator instanceof TileParticleGenerator) {
-                    return new GUIParticleGenerator((TileParticleGenerator) particleGenerator);
+            }
+            case GUIID_PARTICLEGEN -> {
+                if (tile instanceof TileParticleGenerator particleGenerator) {
+                    return new GUIParticleGenerator(particleGenerator);
                 }
-                break;
-            case GUIID_PLAYERDETECTOR:
-                TileEntity detector = world.getTileEntity(x, y, z);
-                if (detector instanceof TilePlayerDetectorAdvanced) {
-                    return new GUIPlayerDetector(player.inventory, (TilePlayerDetectorAdvanced) detector);
+            }
+            case GUIID_PLAYERDETECTOR -> {
+                if (tile instanceof TilePlayerDetectorAdvanced detector) {
+                    return new GUIPlayerDetector(player.inventory, detector);
                 }
-                break;
-            case GUIID_ENERGY_INFUSER:
-                TileEntity infuser = world.getTileEntity(x, y, z);
-                if (infuser instanceof TileEnergyInfuser) {
-                    return new GUIEnergyInfuser(player.inventory, (TileEnergyInfuser) infuser);
+            }
+            case GUIID_ENERGY_INFUSER -> {
+                if (tile instanceof TileEnergyInfuser infuser) {
+                    return new GUIEnergyInfuser(player.inventory, infuser);
                 }
-                break;
-            case GUIID_GENERATOR:
-                TileEntity generator = world.getTileEntity(x, y, z);
-                if (generator instanceof TileGenerator) {
-                    return new GUIGenerator(player.inventory, (TileGenerator) generator);
+            }
+            case GUIID_GENERATOR -> {
+                if (tile instanceof TileGenerator generator) {
+                    return new GUIGenerator(player.inventory, generator);
                 }
-                break;
-            case GUIID_MANUAL:
+            }
+            case GUIID_MANUAL -> {
                 return new GUIManual();
-            case GUIID_DISSENCHANTER:
-                TileEntity dissenchanter = world.getTileEntity(x, y, z);
-                if (dissenchanter instanceof TileDissEnchanter) {
-                    return new GUIDissEnchanter(player.inventory, (TileDissEnchanter) dissenchanter);
+            }
+            case GUIID_DISSENCHANTER -> {
+                if (tile instanceof TileDissEnchanter dissenchanter) {
+                    return new GUIDissEnchanter(player.inventory, dissenchanter);
                 }
-                break;
-            case GUIID_DRACONIC_CHEST:
-                TileEntity containerChest = world.getTileEntity(x, y, z);
-                if (containerChest instanceof TileDraconiumChest) {
-                    return new GUIDraconiumChest(player.inventory, (TileDraconiumChest) containerChest);
+            }
+            case GUIID_DRACONIC_CHEST -> {
+                if (tile instanceof TileDraconiumChest draconiumChest) {
+                    return new GUIDraconiumChest(player.inventory, draconiumChest);
                 }
-                break;
-            case GUIID_REACTOR:
-                TileEntity reactor = world.getTileEntity(x, y, z);
-                if (reactor instanceof TileReactorCore) {
-                    return new GUIReactor(
-                            (TileReactorCore) reactor,
-                            new ContainerReactor(player, (TileReactorCore) reactor));
+            }
+            case GUIID_REACTOR -> {
+                if (tile instanceof TileReactorCore reactorCore) {
+                    return new GUIReactor(reactorCore, new ContainerReactor(player, reactorCore));
                 }
-                break;
-            case GUIID_TOOL_CONFIG:
+            }
+            case GUIID_TOOL_CONFIG -> {
                 return new GUIToolConfig(
                         player,
                         new ContainerAdvTool(player.inventory, new InventoryTool(player, null)));
-            case GUIID_FLOW_GATE:
-                TileEntity gate = world.getTileEntity(x, y, z);
-                if (gate instanceof TileGate) {
-                    return new GUIFlowGate((TileGate) world.getTileEntity(x, y, z));
+            }
+            case GUIID_FLOW_GATE -> {
+                if (tile instanceof TileGate gate) {
+                    return new GUIFlowGate(gate);
                 }
-                break;
-            case GUIID_UPGRADE_MODIFIER:
-                TileEntity containerTemp = world.getTileEntity(x, y, z);
-                if (containerTemp instanceof TileUpgradeModifier) {
+            }
+            case GUIID_UPGRADE_MODIFIER -> {
+                if (tile instanceof TileUpgradeModifier upgradeModifier) {
                     return new GUIUpgradeModifier(
                             player.inventory,
-                            (TileUpgradeModifier) containerTemp,
-                            new ContainerUpgradeModifier(player.inventory, (TileUpgradeModifier) containerTemp));
+                            upgradeModifier,
+                            new ContainerUpgradeModifier(player.inventory, upgradeModifier));
                 }
-                break;
+            }
         }
 
         return null;

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/GuiHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/GuiHandler.java
@@ -44,56 +44,56 @@ public class GuiHandler implements IGuiHandler {
     public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
         switch (ID) {
             case GUIID_WEATHER_CONTROLLER:
-                TileEntity te = world.getTileEntity(x, y, z);
-                if (te != null && te instanceof TileWeatherController) {
-                    return new ContainerWeatherController(player.inventory, (TileWeatherController) te);
+                TileEntity weatherController = world.getTileEntity(x, y, z);
+                if (weatherController instanceof TileWeatherController) {
+                    return new ContainerWeatherController(player.inventory, (TileWeatherController) weatherController);
                 }
                 break;
             case GUIID_SUN_DIAL:
-                TileEntity te1 = world.getTileEntity(x, y, z);
-                if (te1 != null && te1 instanceof TileSunDial) {
-                    return new ContainerSunDial(player.inventory, (TileSunDial) te1);
+                TileEntity sunDial = world.getTileEntity(x, y, z);
+                if (sunDial instanceof TileSunDial) {
+                    return new ContainerSunDial(player.inventory, (TileSunDial) sunDial);
                 }
                 break;
             case GUIID_GRINDER:
-                TileEntity te2 = world.getTileEntity(x, y, z);
-                if (te2 != null && te2 instanceof TileGrinder) {
-                    return new ContainerGrinder(player.inventory, (TileGrinder) te2);
+                TileEntity grinder = world.getTileEntity(x, y, z);
+                if (grinder instanceof TileGrinder) {
+                    return new ContainerGrinder(player.inventory, (TileGrinder) grinder);
                 }
                 break;
             case GUIID_PLAYERDETECTOR:
                 TileEntity detector = world.getTileEntity(x, y, z);
-                if (detector != null && detector instanceof TilePlayerDetectorAdvanced) {
+                if (detector instanceof TilePlayerDetectorAdvanced) {
                     return new ContainerPlayerDetector(player.inventory, (TilePlayerDetectorAdvanced) detector);
                 }
                 break;
             case GUIID_ENERGY_INFUSER:
                 TileEntity infuser = world.getTileEntity(x, y, z);
-                if (infuser != null && infuser instanceof TileEnergyInfuser) {
+                if (infuser instanceof TileEnergyInfuser) {
                     return new ContainerEnergyInfuser(player.inventory, (TileEnergyInfuser) infuser);
                 }
                 break;
             case GUIID_GENERATOR:
                 TileEntity generator = world.getTileEntity(x, y, z);
-                if (generator != null && generator instanceof TileGenerator) {
+                if (generator instanceof TileGenerator) {
                     return new ContainerGenerator(player.inventory, (TileGenerator) generator);
                 }
                 break;
             case GUIID_DISSENCHANTER:
                 TileEntity dissenchanter = world.getTileEntity(x, y, z);
-                if (dissenchanter != null && dissenchanter instanceof TileDissEnchanter) {
+                if (dissenchanter instanceof TileDissEnchanter) {
                     return new ContainerDissEnchanter(player.inventory, (TileDissEnchanter) dissenchanter);
                 }
                 break;
             case GUIID_DRACONIC_CHEST:
                 TileEntity containerChest = world.getTileEntity(x, y, z);
-                if (containerChest != null && containerChest instanceof TileDraconiumChest) {
+                if (containerChest instanceof TileDraconiumChest) {
                     return new ContainerDraconiumChest(player.inventory, (TileDraconiumChest) containerChest);
                 }
                 break;
             case GUIID_REACTOR:
                 TileEntity reactor = world.getTileEntity(x, y, z);
-                if (reactor != null && reactor instanceof TileReactorCore) {
+                if (reactor instanceof TileReactorCore) {
                     return new ContainerReactor(player, (TileReactorCore) reactor);
                 }
                 break;
@@ -101,17 +101,10 @@ public class GuiHandler implements IGuiHandler {
                 return new ContainerAdvTool(player.inventory, new InventoryTool(player, null));
             case GUIID_UPGRADE_MODIFIER:
                 TileEntity containerTemp = world.getTileEntity(x, y, z);
-                if (containerTemp != null && containerTemp instanceof TileUpgradeModifier) {
+                if (containerTemp instanceof TileUpgradeModifier) {
                     return new ContainerUpgradeModifier(player.inventory, (TileUpgradeModifier) containerTemp);
                 }
                 break;
-
-            // case GUIID_CONTAINER_TEMPLATE:
-            // TileEntity containerTemp = world.getTileEntity(x, y, z);
-            // if (containerTemp != null && containerTemp instanceof TileContainerTemplate) {
-            // return new ContainerTemplate(player.inventory, (TileContainerTemplate) containerTemp);
-            // }
-            // break;
         }
 
         return null;
@@ -121,45 +114,46 @@ public class GuiHandler implements IGuiHandler {
     public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
         switch (ID) {
             case GUIID_WEATHER_CONTROLLER:
-                TileEntity te = world.getTileEntity(x, y, z);
-                if (te != null && te instanceof TileWeatherController) {
-                    return new GUIWeatherController(player.inventory, (TileWeatherController) te);
+                TileEntity weatherController = world.getTileEntity(x, y, z);
+                if (weatherController instanceof TileWeatherController) {
+                    return new GUIWeatherController(player.inventory, (TileWeatherController) weatherController);
                 }
                 break;
             case GUIID_SUN_DIAL:
-                TileEntity te1 = world.getTileEntity(x, y, z);
-                if (te1 != null && te1 instanceof TileSunDial) {
-                    return new GUISunDial(player.inventory, (TileSunDial) te1);
+                TileEntity sunDial = world.getTileEntity(x, y, z);
+                if (sunDial instanceof TileSunDial) {
+                    return new GUISunDial(player.inventory, (TileSunDial) sunDial);
                 }
                 break;
             case GUIID_TELEPORTER:
                 return new GUITeleporter(player);
             case GUIID_GRINDER:
-                TileEntity te2 = world.getTileEntity(x, y, z);
-                if (te2 != null && te2 instanceof TileGrinder) {
-                    return new GUIGrinder(player.inventory, (TileGrinder) te2);
+                TileEntity grinder = world.getTileEntity(x, y, z);
+                if (grinder instanceof TileGrinder) {
+                    return new GUIGrinder(player.inventory, (TileGrinder) grinder);
                 }
                 break;
             case GUIID_PARTICLEGEN:
-                TileEntity gen = world.getTileEntity(x, y, z);
-                return (gen != null && gen instanceof TileParticleGenerator)
-                        ? new GUIParticleGenerator((TileParticleGenerator) gen, player)
-                        : null;
+                TileEntity particleGenerator = world.getTileEntity(x, y, z);
+                if (particleGenerator instanceof TileParticleGenerator) {
+                    return new GUIParticleGenerator((TileParticleGenerator) particleGenerator, player);
+                }
+                break;
             case GUIID_PLAYERDETECTOR:
                 TileEntity detector = world.getTileEntity(x, y, z);
-                if (detector != null && detector instanceof TilePlayerDetectorAdvanced) {
+                if (detector instanceof TilePlayerDetectorAdvanced) {
                     return new GUIPlayerDetector(player.inventory, (TilePlayerDetectorAdvanced) detector);
                 }
                 break;
             case GUIID_ENERGY_INFUSER:
                 TileEntity infuser = world.getTileEntity(x, y, z);
-                if (infuser != null && infuser instanceof TileEnergyInfuser) {
+                if (infuser instanceof TileEnergyInfuser) {
                     return new GUIEnergyInfuser(player.inventory, (TileEnergyInfuser) infuser);
                 }
                 break;
             case GUIID_GENERATOR:
                 TileEntity generator = world.getTileEntity(x, y, z);
-                if (generator != null && generator instanceof TileGenerator) {
+                if (generator instanceof TileGenerator) {
                     return new GUIGenerator(player.inventory, (TileGenerator) generator);
                 }
                 break;
@@ -167,21 +161,20 @@ public class GuiHandler implements IGuiHandler {
                 return new GUIManual();
             case GUIID_DISSENCHANTER:
                 TileEntity dissenchanter = world.getTileEntity(x, y, z);
-                if (dissenchanter != null && dissenchanter instanceof TileDissEnchanter) {
+                if (dissenchanter instanceof TileDissEnchanter) {
                     return new GUIDissEnchanter(player.inventory, (TileDissEnchanter) dissenchanter);
                 }
                 break;
             case GUIID_DRACONIC_CHEST:
                 TileEntity containerChest = world.getTileEntity(x, y, z);
-                if (containerChest != null && containerChest instanceof TileDraconiumChest) {
+                if (containerChest instanceof TileDraconiumChest) {
                     return new GUIDraconiumChest(player.inventory, (TileDraconiumChest) containerChest);
                 }
                 break;
             case GUIID_REACTOR:
                 TileEntity reactor = world.getTileEntity(x, y, z);
-                if (reactor != null && reactor instanceof TileReactorCore) {
+                if (reactor instanceof TileReactorCore) {
                     return new GUIReactor(
-                            player,
                             (TileReactorCore) reactor,
                             new ContainerReactor(player, (TileReactorCore) reactor));
                 }
@@ -191,25 +184,20 @@ public class GuiHandler implements IGuiHandler {
                         player,
                         new ContainerAdvTool(player.inventory, new InventoryTool(player, null)));
             case GUIID_FLOW_GATE:
-                return world.getTileEntity(x, y, z) instanceof TileGate
-                        ? new GUIFlowGate((TileGate) world.getTileEntity(x, y, z))
-                        : null;
+                TileEntity gate = world.getTileEntity(x, y, z);
+                if (gate instanceof TileGate) {
+                    return new GUIFlowGate((TileGate) world.getTileEntity(x, y, z));
+                }
+                break;
             case GUIID_UPGRADE_MODIFIER:
                 TileEntity containerTemp = world.getTileEntity(x, y, z);
-                if (containerTemp != null && containerTemp instanceof TileUpgradeModifier) {
+                if (containerTemp instanceof TileUpgradeModifier) {
                     return new GUIUpgradeModifier(
                             player.inventory,
                             (TileUpgradeModifier) containerTemp,
                             new ContainerUpgradeModifier(player.inventory, (TileUpgradeModifier) containerTemp));
                 }
                 break;
-
-            // case GUIID_CONTAINER_TEMPLATE:
-            // TileEntity containerTemp = world.getTileEntity(x, y, z);
-            // if (containerTemp != null && containerTemp instanceof TileContainerTemplate) {
-            // return new GUIContainerTemplate(player.inventory, (TileContainerTemplate) containerTemp);
-            // }
-            // break;
         }
 
         return null;

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/GuiHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/GuiHandler.java
@@ -136,7 +136,7 @@ public class GuiHandler implements IGuiHandler {
             case GUIID_PARTICLEGEN:
                 TileEntity particleGenerator = world.getTileEntity(x, y, z);
                 if (particleGenerator instanceof TileParticleGenerator) {
-                    return new GUIParticleGenerator((TileParticleGenerator) particleGenerator, player);
+                    return new GUIParticleGenerator((TileParticleGenerator) particleGenerator);
                 }
                 break;
             case GUIID_PLAYERDETECTOR:

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/componentguis/GUIReactor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/componentguis/GUIReactor.java
@@ -5,8 +5,8 @@ import java.util.List;
 
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 
 import org.lwjgl.opengl.GL11;
@@ -23,18 +23,19 @@ import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.rea
  */
 public class GUIReactor extends GUIBase {
 
-    private TileReactorCore reactor;
-    private ContainerReactor container;
-    private static boolean showStats = false;
+    private static boolean showStatistics = false;
+    private final TileReactorCore core;
+    private final ContainerReactor container;
 
-    public GUIReactor(EntityPlayer player, TileReactorCore reactor, ContainerReactor container) {
+    public GUIReactor(TileReactorCore core, ContainerReactor container) {
         super(container, 248, 222);
-        this.reactor = reactor;
+        this.core = core;
         this.container = container;
     }
 
     @Override
     protected ComponentCollection assembleComponents() {
+        final ResourceLocation widgets = ResourceHandler.getResource("textures/gui/Widgets.png");
         collection = new ComponentCollection(0, 0, 248, 222, this);
         collection.addComponent(
                 new ComponentTexturedRect(0, 0, xSize, ySize, ResourceHandler.getResource("textures/gui/Reactor.png")));
@@ -50,7 +51,7 @@ public class GUIReactor extends GUIBase {
                         this,
                         "",
                         StatCollector.translateToLocal("button.de.reactorCharge.txt"),
-                        ResourceHandler.getResource("textures/gui/Widgets.png")))
+                        widgets))
                 .setName("CHARGE");
         collection.addComponent(
                 new ComponentTextureButton(
@@ -64,7 +65,7 @@ public class GUIReactor extends GUIBase {
                         this,
                         "",
                         StatCollector.translateToLocal("button.de.reactorStart.txt"),
-                        ResourceHandler.getResource("textures/gui/Widgets.png")))
+                        widgets))
                 .setName("ACTIVATE");
         collection.addComponent(
                 new ComponentTextureButton(
@@ -78,7 +79,7 @@ public class GUIReactor extends GUIBase {
                         this,
                         "",
                         StatCollector.translateToLocal("button.de.reactorStop.txt"),
-                        ResourceHandler.getResource("textures/gui/Widgets.png")))
+                        widgets))
                 .setName("DEACTIVATE");
         collection.addComponent(
                 new ComponentButton(
@@ -95,10 +96,10 @@ public class GUIReactor extends GUIBase {
     }
 
     @Override
-    protected void drawGuiContainerBackgroundLayer(float f, int mouseX, int mouseY) {
-        super.drawGuiContainerBackgroundLayer(f, mouseX, mouseY);
+    protected void drawGuiContainerBackgroundLayer(float partialTicks, int mouseX, int mouseY) {
+        super.drawGuiContainerBackgroundLayer(partialTicks, mouseX, mouseY);
         // Draw I/O Slots
-        if (reactor.reactorState == TileReactorCore.STATE_OFFLINE) {
+        if (core.reactorState == TileReactorCore.STATE_OFFLINE) {
             RenderHelper.enableGUIStandardItemLighting();
             drawTexturedModalRect(guiLeft + 14, guiTop + 139, 14, ySize, 18, 18);
             drawTexturedModalRect(guiLeft + 216, guiTop + 139, 32, ySize, 18, 18);
@@ -123,96 +124,85 @@ public class GUIReactor extends GUIBase {
 
         GL11.glColor4f(1f, 1f, 1f, 1f);
         // Draw Indicators
-        double value = Math.min(reactor.reactionTemperature, reactor.maxReactTemperature) / reactor.maxReactTemperature;
+        double value = Math.min(core.reactionTemperature, core.maxReactTemperature) / core.maxReactTemperature;
         int pixOffset = (int) (value * 108);
         drawTexturedModalRect(11, 112 - pixOffset, 0, 222, 14, 5);
 
-        value = reactor.fieldCharge / reactor.maxFieldCharge;
+        value = core.fieldCharge / core.maxFieldCharge;
         pixOffset = (int) (value * 108);
         drawTexturedModalRect(35, 112 - pixOffset, 0, 222, 14, 5);
 
-        value = (double) reactor.energySaturation / (double) reactor.maxEnergySaturation;
+        value = (double) core.energySaturation / (double) core.maxEnergySaturation;
         pixOffset = (int) (value * 108);
         drawTexturedModalRect(199, 112 - pixOffset, 0, 222, 14, 5);
 
-        value = ((double) reactor.convertedFuel) / ((double) reactor.reactorFuel + (double) reactor.convertedFuel);
+        value = ((double) core.convertedFuel) / ((double) core.reactorFuel + (double) core.convertedFuel);
         pixOffset = (int) (value * 108);
         drawTexturedModalRect(223, 112 - pixOffset, 0, 222, 14, 5);
 
         GL11.glColor4f(1F, 1F, 1F, 1F);
-        if (!showStats) {
-
+        if (showStatistics) {
+            ResourceHandler.bindResource("textures/gui/Reactor.png");
+            for (int i = 1; i <= 10; i++) {
+                drawTexturedModalRect(63, i * 12, 0, 240, 122, 16);
+            }
+            drawStatistics();
+        } else {
             GL11.glPushMatrix();
             GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
             GL11.glTranslated(124, 71, 100);
-            double scale = 100 / (reactor.getCoreDiameter());
+            double scale = 100 / (core.getCoreDiameter());
             GL11.glScaled(scale, scale, scale);
             GL11.glColor4f(1F, 1F, 1F, 1F);
             GL11.glDisable(GL11.GL_CULL_FACE);
 
-            TileEntityRendererDispatcher.instance.renderTileEntityAt(reactor, -0.5D, -0.5D, -0.5D, 0.0F);
+            TileEntityRendererDispatcher.instance.renderTileEntityAt(core, -0.5D, -0.5D, -0.5D, 0.0F);
 
             GL11.glPopAttrib();
             GL11.glPopMatrix();
-        } else {
-            ResourceHandler.bindResource("textures/gui/Reactor.png");
-            for (int i = 1; i <= 10; i++) drawTexturedModalRect(63, i * 12, 0, 240, 122, 16);
-            drawStats();
+            drawStatus();
         }
-
-        String status = StatCollector.translateToLocal("gui.de.status.txt") + ": "
-                + (reactor.reactorState == 0 ? EnumChatFormatting.DARK_GRAY
-                        : reactor.reactorState == 1 ? EnumChatFormatting.RED
-                                : reactor.reactorState == 2 ? EnumChatFormatting.DARK_GREEN : EnumChatFormatting.RED)
-                + StatCollector.translateToLocal("gui.de.status" + reactor.reactorState + ".txt");
-        if (reactor.reactorState == 1 && reactor.canStart())
-            status = StatCollector.translateToLocal("gui.de.status.txt") + ": "
-                    + EnumChatFormatting.DARK_GREEN
-                    + StatCollector.translateToLocal("gui.de.status1_5.txt");
-        if (!showStats) fontRendererObj.drawString(status, xSize - 5 - fontRendererObj.getStringWidth(status), 125, 0);
     }
 
     @Override
-    public void drawScreen(int mouseX, int mouseY, float par3) {
-        super.drawScreen(mouseX, mouseY, par3);
-        List<String> text = new ArrayList<String>();
+    public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+        super.drawScreen(mouseX, mouseY, partialTicks);
+        List<String> text = new ArrayList<>();
         if (GuiHelper.isInRect(9, 4, 18, 114, mouseX - guiLeft, mouseY - guiTop)) {
             text.add(StatCollector.translateToLocal("gui.de.reactionTemp.txt"));
-            text.add((int) reactor.reactionTemperature + "C");
+            text.add((int) core.reactionTemperature + "C");
             drawHoveringText(text, mouseX, mouseY, fontRendererObj);
         } else if (GuiHelper.isInRect(33, 4, 18, 114, mouseX - guiLeft, mouseY - guiTop)) {
             text.add(StatCollector.translateToLocal("gui.de.fieldStrength.txt"));
-            if (reactor.maxFieldCharge > 0)
-                text.add(Utills.round(reactor.fieldCharge / reactor.maxFieldCharge * 100D, 100D) + "%");
-            text.add(
-                    Utills.addCommas((int) reactor.fieldCharge) + " / "
-                            + Utills.addCommas((int) reactor.maxFieldCharge)); // todo refine or remove
+            if (core.maxFieldCharge > 0) {
+                text.add(Utills.round(core.fieldCharge / core.maxFieldCharge * 100D, 100D) + "%");
+            }
+            text.add(Utills.addCommas((int) core.fieldCharge) + " / " + Utills.addCommas((int) core.maxFieldCharge));
             drawHoveringText(text, mouseX, mouseY, fontRendererObj);
         } else if (GuiHelper.isInRect(197, 4, 18, 114, mouseX - guiLeft, mouseY - guiTop)) {
             text.add(StatCollector.translateToLocal("gui.de.energySaturation.txt"));
-            if (reactor.maxEnergySaturation > 0) text.add(
-                    Utills.round((double) reactor.energySaturation / (double) reactor.maxEnergySaturation * 100D, 100D)
-                            + "%");
-            text.add(
-                    Utills.addCommas(reactor.energySaturation) + " / " + Utills.addCommas(reactor.maxEnergySaturation)); // todo
-                                                                                                                         // refine
-                                                                                                                         // or
-                                                                                                                         // remove
+            if (core.maxEnergySaturation > 0) {
+                text.add(
+                        Utills.round((double) core.energySaturation / (double) core.maxEnergySaturation * 100D, 100D)
+                                + "%");
+            }
+            text.add(Utills.addCommas(core.energySaturation) + " / " + Utills.addCommas(core.maxEnergySaturation));
             drawHoveringText(text, mouseX, mouseY, fontRendererObj);
         } else if (GuiHelper.isInRect(221, 4, 18, 114, mouseX - guiLeft, mouseY - guiTop)) {
             text.add(StatCollector.translateToLocal("gui.de.fuelConversion.txt"));
-            if (reactor.reactorFuel + reactor.convertedFuel > 0) text.add(
-                    Utills.round(
-                            ((double) reactor.convertedFuel + reactor.conversionUnit)
-                                    / ((double) reactor.convertedFuel + (double) reactor.reactorFuel)
-                                    * 100D,
-                            100D) + "%");
-            text.add(reactor.convertedFuel + " / " + (reactor.convertedFuel + reactor.reactorFuel)); // todo refine or
-                                                                                                     // remove
+            if (core.reactorFuel + core.convertedFuel > 0) {
+                text.add(
+                        Utills.round(
+                                ((double) core.convertedFuel + core.conversionUnit)
+                                        / ((double) core.convertedFuel + (double) core.reactorFuel)
+                                        * 100D,
+                                100D) + "%");
+            }
+            text.add(core.convertedFuel + " / " + (core.convertedFuel + core.reactorFuel));
             drawHoveringText(text, mouseX, mouseY, fontRendererObj);
         }
 
-        if (showStats) {
+        if (showStatistics) {
             if (GuiHelper.isInRect(53, 15, 140, 18, mouseX - guiLeft, mouseY - guiTop)) {
                 text.addAll(
                         fontRendererObj.listFormattedStringToWidth(
@@ -247,19 +237,18 @@ public class GUIReactor extends GUIBase {
         }
     }
 
-    private void drawStats() {
-
-        double inputRate = reactor.fieldDrain / (1D - (reactor.fieldCharge / reactor.maxFieldCharge));
+    private void drawStatistics() {
+        double inputRate = core.fieldDrain / (1D - (core.fieldCharge / core.maxFieldCharge));
         fontRendererObj.drawString(StatCollector.translateToLocal("gui.de.tempLoad.name"), 55, 16, 0x0000FF);
-        fontRendererObj.drawString(Utills.round(reactor.tempDrainFactor * 100D, 1D) + "%", 60, 2 + 24, 0);
+        fontRendererObj.drawString(Utills.round(core.tempDrainFactor * 100D, 1D) + "%", 60, 2 + 24, 0);
         fontRendererObj.drawString(StatCollector.translateToLocal("gui.de.mass.name"), 55, 16 + 24, 0x0000FF);
         fontRendererObj.drawString(
-                Utills.round((reactor.reactorFuel + reactor.convertedFuel) / 1296D, 100) + "m^3",
+                Utills.round((core.reactorFuel + core.convertedFuel) / 1296D, 100) + "m^3",
                 60,
                 2 + 2 * 24,
                 0);
         fontRendererObj.drawString(StatCollector.translateToLocal("gui.de.genRate.name"), 55, 16 + 2 * 24, 0x0000FF);
-        fontRendererObj.drawString(Utills.addCommas((int) reactor.generationRate) + "RF/t", 60, 2 + 3 * 24, 0);
+        fontRendererObj.drawString(Utills.addCommas((int) core.generationRate) + "RF/t", 60, 2 + 3 * 24, 0);
         fontRendererObj
                 .drawString(StatCollector.translateToLocal("gui.de.fieldInputRate.name"), 55, 16 + 3 * 24, 0x0000FF);
         fontRendererObj
@@ -267,38 +256,56 @@ public class GUIReactor extends GUIBase {
         fontRendererObj
                 .drawString(StatCollector.translateToLocal("gui.de.fuelConversion.name"), 55, 16 + 4 * 24, 0x0000FF);
         fontRendererObj.drawString(
-                Utills.addCommas((int) Math.round(reactor.fuelUseRate * 1000000D)) + "nb/t",
+                Utills.addCommas((int) Math.round(core.fuelUseRate * 1000000D)) + "nb/t",
                 60,
                 2 + 5 * 24,
                 0);
     }
 
+    private void drawStatus() {
+        String status = StatCollector.translateToLocal("gui.de.status.txt") + ": ";
+        switch (core.reactorState) {
+            case TileReactorCore.STATE_OFFLINE:
+                status += EnumChatFormatting.DARK_GRAY;
+                break;
+            case TileReactorCore.STATE_START:
+            case TileReactorCore.STATE_STOP:
+                status += EnumChatFormatting.RED;
+                break;
+            case TileReactorCore.STATE_ONLINE:
+                status += EnumChatFormatting.DARK_GREEN;
+                break;
+            case TileReactorCore.STATE_INVALID:
+                status += EnumChatFormatting.DARK_RED;
+                break;
+        }
+        status += StatCollector.translateToLocal(
+                core.reactorState == TileReactorCore.STATE_START && core.canStart() ? "gui.de.status1_5.txt"
+                        : "gui.de.status" + core.reactorState + ".txt");
+        fontRendererObj.drawString(status, xSize - 5 - fontRendererObj.getStringWidth(status), 125, 0);
+    }
+
     @Override
     public void updateScreen() {
-
-        if (reactor.reactorState == TileReactorCore.STATE_INVALID
-                || reactor.reactorState == TileReactorCore.STATE_OFFLINE
-                || reactor.reactorState == TileReactorCore.STATE_STOP)
-            collection.getComponent("DEACTIVATE").setEnabled(false);
-        else collection.getComponent("DEACTIVATE").setEnabled(true);
-        if ((reactor.reactorState == TileReactorCore.STATE_OFFLINE
-                || (reactor.reactorState == TileReactorCore.STATE_STOP && !reactor.canStart())) && reactor.canCharge())
-            collection.getComponent("CHARGE").setEnabled(true);
-        else collection.getComponent("CHARGE").setEnabled(false);
-        if ((reactor.reactorState == TileReactorCore.STATE_START || reactor.reactorState == TileReactorCore.STATE_STOP)
-                && reactor.canStart())
-            collection.getComponent("ACTIVATE").setEnabled(true);
-        else collection.getComponent("ACTIVATE").setEnabled(false);
+        collection.getComponent("DEACTIVATE").setEnabled(
+                core.reactorState == TileReactorCore.STATE_START || core.reactorState == TileReactorCore.STATE_ONLINE);
+        collection.getComponent("CHARGE").setEnabled(
+                (core.reactorState == TileReactorCore.STATE_OFFLINE
+                        || (core.reactorState == TileReactorCore.STATE_STOP && !core.canStart())) && core.canCharge());
+        collection.getComponent("ACTIVATE").setEnabled(
+                (core.reactorState == TileReactorCore.STATE_START || core.reactorState == TileReactorCore.STATE_STOP)
+                        && core.canStart());
         super.updateScreen();
     }
 
     @Override
     public void buttonClicked(int id, int button) {
         super.buttonClicked(id, button);
-        if (id < 3) container.sendObjectToServer(null, 20, id);
-        else if (id == 3) {
-            showStats = !showStats;
-            ((ComponentButton) collection.getComponent("STATS")).hoverText = showStats
+        if (id < 3) {
+            container.sendObjectToServer(null, 20, id);
+        } else if (id == 3) {
+            showStatistics = !showStatistics;
+            ((ComponentButton) collection.getComponent("STATS")).hoverText = showStatistics
                     ? StatCollector.translateToLocal("button.de.statsHide.txt")
                     : StatCollector.translateToLocal("button.de.statsShow.txt");
         }

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/componentguis/GUIReactor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/componentguis/GUIReactor.java
@@ -11,7 +11,11 @@ import net.minecraft.util.StatCollector;
 
 import org.lwjgl.opengl.GL11;
 
-import com.brandon3055.brandonscore.client.gui.guicomponents.*;
+import com.brandon3055.brandonscore.client.gui.guicomponents.ComponentButton;
+import com.brandon3055.brandonscore.client.gui.guicomponents.ComponentCollection;
+import com.brandon3055.brandonscore.client.gui.guicomponents.ComponentTextureButton;
+import com.brandon3055.brandonscore.client.gui.guicomponents.ComponentTexturedRect;
+import com.brandon3055.brandonscore.client.gui.guicomponents.GUIBase;
 import com.brandon3055.brandonscore.client.utills.GuiHelper;
 import com.brandon3055.brandonscore.common.utills.Utills;
 import com.brandon3055.draconicevolution.client.handler.ResourceHandler;
@@ -166,6 +170,7 @@ public class GUIReactor extends GUIBase {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
         super.drawScreen(mouseX, mouseY, partialTicks);
         List<String> text = new ArrayList<>();
@@ -266,19 +271,10 @@ public class GUIReactor extends GUIBase {
     private void drawStatus() {
         String status = StatCollector.translateToLocal("gui.de.status.txt") + ": ";
         switch (core.reactorState) {
-            case OFFLINE:
-                status += EnumChatFormatting.DARK_GRAY;
-                break;
-            case STARTING:
-            case STOPPING:
-                status += EnumChatFormatting.RED;
-                break;
-            case ONLINE:
-                status += EnumChatFormatting.DARK_GREEN;
-                break;
-            case INVALID:
-                status += EnumChatFormatting.DARK_RED;
-                break;
+            case OFFLINE -> status += EnumChatFormatting.DARK_GRAY;
+            case STARTING, STOPPING -> status += EnumChatFormatting.RED;
+            case ONLINE -> status += EnumChatFormatting.DARK_GREEN;
+            case INVALID -> status += EnumChatFormatting.DARK_RED;
         }
         status += core.reactorState.toLocalizedString(core.canStart());
         fontRendererObj.drawString(status, xSize - 5 - fontRendererObj.getStringWidth(status), 125, 0);

--- a/src/main/java/com/brandon3055/draconicevolution/client/gui/componentguis/GUIReactor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/gui/componentguis/GUIReactor.java
@@ -17,6 +17,7 @@ import com.brandon3055.brandonscore.common.utills.Utills;
 import com.brandon3055.draconicevolution.client.handler.ResourceHandler;
 import com.brandon3055.draconicevolution.common.container.ContainerReactor;
 import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor.TileReactorCore;
+import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor.TileReactorCore.ReactorState;
 
 /**
  * Created by brandon3055 on 30/7/2015.
@@ -99,7 +100,7 @@ public class GUIReactor extends GUIBase {
     protected void drawGuiContainerBackgroundLayer(float partialTicks, int mouseX, int mouseY) {
         super.drawGuiContainerBackgroundLayer(partialTicks, mouseX, mouseY);
         // Draw I/O Slots
-        if (core.reactorState == TileReactorCore.STATE_OFFLINE) {
+        if (core.reactorState == ReactorState.OFFLINE) {
             RenderHelper.enableGUIStandardItemLighting();
             drawTexturedModalRect(guiLeft + 14, guiTop + 139, 14, ySize, 18, 18);
             drawTexturedModalRect(guiLeft + 216, guiTop + 139, 32, ySize, 18, 18);
@@ -265,35 +266,33 @@ public class GUIReactor extends GUIBase {
     private void drawStatus() {
         String status = StatCollector.translateToLocal("gui.de.status.txt") + ": ";
         switch (core.reactorState) {
-            case TileReactorCore.STATE_OFFLINE:
+            case OFFLINE:
                 status += EnumChatFormatting.DARK_GRAY;
                 break;
-            case TileReactorCore.STATE_START:
-            case TileReactorCore.STATE_STOP:
+            case STARTING:
+            case STOPPING:
                 status += EnumChatFormatting.RED;
                 break;
-            case TileReactorCore.STATE_ONLINE:
+            case ONLINE:
                 status += EnumChatFormatting.DARK_GREEN;
                 break;
-            case TileReactorCore.STATE_INVALID:
+            case INVALID:
                 status += EnumChatFormatting.DARK_RED;
                 break;
         }
-        status += StatCollector.translateToLocal(
-                core.reactorState == TileReactorCore.STATE_START && core.canStart() ? "gui.de.status1_5.txt"
-                        : "gui.de.status" + core.reactorState + ".txt");
+        status += core.reactorState.toLocalizedString(core.canStart());
         fontRendererObj.drawString(status, xSize - 5 - fontRendererObj.getStringWidth(status), 125, 0);
     }
 
     @Override
     public void updateScreen() {
-        collection.getComponent("DEACTIVATE").setEnabled(
-                core.reactorState == TileReactorCore.STATE_START || core.reactorState == TileReactorCore.STATE_ONLINE);
+        collection.getComponent("DEACTIVATE")
+                .setEnabled(core.reactorState == ReactorState.STARTING || core.reactorState == ReactorState.ONLINE);
         collection.getComponent("CHARGE").setEnabled(
-                (core.reactorState == TileReactorCore.STATE_OFFLINE
-                        || (core.reactorState == TileReactorCore.STATE_STOP && !core.canStart())) && core.canCharge());
+                (core.reactorState == ReactorState.OFFLINE
+                        || (core.reactorState == ReactorState.STOPPING && !core.canStart())) && core.canCharge());
         collection.getComponent("ACTIVATE").setEnabled(
-                (core.reactorState == TileReactorCore.STATE_START || core.reactorState == TileReactorCore.STATE_STOP)
+                (core.reactorState == ReactorState.STARTING || core.reactorState == ReactorState.STOPPING)
                         && core.canStart());
         super.updateScreen();
     }

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileEnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileEnergyPylon.java
@@ -20,7 +20,7 @@ public class RenderTileEnergyPylon extends TileEntitySpecialRenderer {
     private static final ResourceLocation model_texture = new ResourceLocation(
             References.MODID.toLowerCase(),
             "textures/models/pylon_sphere_texture.png");
-    private IModelCustom model;
+    private final IModelCustom model;
 
     public RenderTileEnergyPylon() {
         model = AdvancedModelLoader
@@ -30,10 +30,14 @@ public class RenderTileEnergyPylon extends TileEntitySpecialRenderer {
     @Override
     public void renderTileEntityAt(TileEntity tile, double x, double y, double z, float timeSinceLastTick) {
 
-        if (tile == null || !(tile instanceof TileEnergyPylon)) return;
+        if (!(tile instanceof TileEnergyPylon)) {
+            return;
+        }
         TileEnergyPylon pylon = (TileEnergyPylon) tile;
-        if (!pylon.active) return;
-        float scale = pylon.modelScale + (timeSinceLastTick *= !pylon.reciveEnergy ? -0.01F : 0.01F);
+        if (!pylon.active) {
+            return;
+        }
+        float scale = pylon.modelScale + (timeSinceLastTick *= !pylon.isReceivingEnergy ? -0.01F : 0.01F);
         float rotation = pylon.modelRotation + (timeSinceLastTick / 2F);
 
         GL11.glPushMatrix();
@@ -59,37 +63,10 @@ public class RenderTileEnergyPylon extends TileEntitySpecialRenderer {
         GL11.glDepthMask(false);
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 200F, 200F);
 
-        GL11.glPushMatrix();
-        float scale1 = scale % 1F;
-        GL11.glScalef(scale1, scale1, scale1);
-        GL11.glRotatef(rotation * 0.5F, 0F, -1F, -0.5F);
-        GL11.glColor4d(1D, 1D, 1D, 1F - (scale1));
-        model.renderAll();
-        GL11.glPopMatrix();
-
-        GL11.glPushMatrix();
-        float scale2 = (scale + 0.25F) % 1F;
-        GL11.glScalef(scale2, scale2, scale2);
-        GL11.glRotatef(rotation * 0.5F, 0F, -1F, -0.5F);
-        GL11.glColor4f(1F, 1F, 1F, 1F - (scale2));
-        model.renderAll();
-        GL11.glPopMatrix();
-
-        GL11.glPushMatrix();
-        float scale3 = (scale + 0.5F) % 1F;
-        GL11.glScalef(scale3, scale3, scale3);
-        GL11.glRotatef(rotation * 0.5F, 0F, -1F, -0.5F);
-        GL11.glColor4f(1F, 1F, 1F, 1F - (scale3));
-        model.renderAll();
-        GL11.glPopMatrix();
-
-        GL11.glPushMatrix();
-        float scale4 = (scale + 0.75F) % 1F;
-        GL11.glScalef(scale4, scale4, scale4);
-        GL11.glRotatef(rotation * 0.5F, 0F, -1F, -0.5F);
-        GL11.glColor4f(1F, 1F, 1F, 1F - (scale4));
-        model.renderAll();
-        GL11.glPopMatrix();
+        renderPass(scale % 1F, rotation);
+        renderPass((scale + 0.25F) % 1F, rotation);
+        renderPass((scale + 0.5F) % 1F, rotation);
+        renderPass((scale + 0.75F) % 1F, rotation);
 
         GL11.glEnable(GL11.GL_LIGHTING);
         GL11.glEnable(GL11.GL_TEXTURE_2D);
@@ -100,5 +77,12 @@ public class RenderTileEnergyPylon extends TileEntitySpecialRenderer {
         GL11.glPopMatrix();
     }
 
-    // private void renderSphere()
+    private void renderPass(float scale, float rotation) {
+        GL11.glPushMatrix();
+        GL11.glScalef(scale, scale, scale);
+        GL11.glRotatef(rotation * 0.5F, 0F, -1F, -0.5F);
+        GL11.glColor4f(1F, 1F, 1F, 1F - scale);
+        model.renderAll();
+        GL11.glPopMatrix();
+    }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileEnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileEnergyPylon.java
@@ -17,7 +17,7 @@ import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.Til
  */
 public class RenderTileEnergyPylon extends TileEntitySpecialRenderer {
 
-    private static final ResourceLocation model_texture = new ResourceLocation(
+    private static final ResourceLocation modelTexture = new ResourceLocation(
             References.MODID.toLowerCase(),
             "textures/models/pylon_sphere_texture.png");
     private final IModelCustom model;
@@ -30,10 +30,9 @@ public class RenderTileEnergyPylon extends TileEntitySpecialRenderer {
     @Override
     public void renderTileEntityAt(TileEntity tile, double x, double y, double z, float timeSinceLastTick) {
 
-        if (!(tile instanceof TileEnergyPylon)) {
+        if (!(tile instanceof TileEnergyPylon pylon)) {
             return;
         }
-        TileEnergyPylon pylon = (TileEnergyPylon) tile;
         if (!pylon.active) {
             return;
         }
@@ -52,7 +51,7 @@ public class RenderTileEnergyPylon extends TileEntitySpecialRenderer {
 
         GL11.glAlphaFunc(GL11.GL_GREATER, 0.0F);
 
-        bindTexture(model_texture);
+        bindTexture(modelTexture);
         GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, 10497.0F);
         GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, 10497.0F);
         GL11.glDisable(GL11.GL_LIGHTING);

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileEnergyStorageCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileEnergyStorageCore.java
@@ -35,10 +35,9 @@ public class RenderTileEnergyStorageCore extends TileEntitySpecialRenderer {
 
     @Override
     public void renderTileEntityAt(TileEntity tile, double x, double y, double z, float timeSinceLastTick) {
-        if (!(tile instanceof TileEnergyStorageCore)) {
+        if (!(tile instanceof TileEnergyStorageCore core)) {
             return;
         }
-        TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
         if (!core.isOnline()) {
             return;
         }
@@ -46,27 +45,13 @@ public class RenderTileEnergyStorageCore extends TileEntitySpecialRenderer {
         float rotation = core.modelRotation + (timeSinceLastTick / 2F);
 
         switch (core.getTier()) {
-            case 0:
-                scale = 0.7F;
-                break;
-            case 1:
-                scale = 1.2F;
-                break;
-            case 2:
-                scale = 1.7F;
-                break;
-            case 3:
-                scale = 2.5F;
-                break;
-            case 4:
-                scale = 3.5F;
-                break;
-            case 5:
-                scale = 4.5F;
-                break;
-            case 6:
-                scale = 5.5F;
-                break;
+            case 0 -> scale = 0.7F;
+            case 1 -> scale = 1.2F;
+            case 2 -> scale = 1.7F;
+            case 3 -> scale = 2.5F;
+            case 4 -> scale = 3.5F;
+            case 5 -> scale = 4.5F;
+            case 6 -> scale = 5.5F;
         }
 
         GL11.glPushMatrix();

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileEnergyStorageCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileEnergyStorageCore.java
@@ -20,24 +20,28 @@ import cpw.mods.fml.client.FMLClientHandler;
  */
 public class RenderTileEnergyStorageCore extends TileEntitySpecialRenderer {
 
-    private static final ResourceLocation iner_model_texture = new ResourceLocation(
+    private static final ResourceLocation InnerModelTexture = new ResourceLocation(
             References.MODID.toLowerCase(),
             "textures/models/power_sphere_layer_1.png");
-    private static final ResourceLocation outer_model_texture = new ResourceLocation(
+    private static final ResourceLocation OuterModelTexture = new ResourceLocation(
             References.MODID.toLowerCase(),
             "textures/models/power_sphere_layer_2.png");
-    private IModelCustom iner_model;
+    private final IModelCustom innerModel;
 
     public RenderTileEnergyStorageCore() {
-        iner_model = AdvancedModelLoader
+        innerModel = AdvancedModelLoader
                 .loadModel(new ResourceLocation(References.MODID.toLowerCase(), "models/power_sphere_layer_1.obj"));
     }
 
     @Override
     public void renderTileEntityAt(TileEntity tile, double x, double y, double z, float timeSinceLastTick) {
-        if (tile == null || !(tile instanceof TileEnergyStorageCore)) return;
+        if (!(tile instanceof TileEnergyStorageCore)) {
+            return;
+        }
         TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
-        if (!core.isOnline()) return;
+        if (!core.isOnline()) {
+            return;
+        }
         float scale = 0;
         float rotation = core.modelRotation + (timeSinceLastTick / 2F);
 
@@ -71,44 +75,29 @@ public class RenderTileEnergyStorageCore extends TileEntitySpecialRenderer {
         GL11.glDisable(GL11.GL_LIGHTING);
         GL11.glDisable(GL11.GL_CULL_FACE);
         GL11.glTranslated(x + 0.5, y + 0.5, z + 0.5);
-        FMLClientHandler.instance().getClient().getTextureManager().bindTexture(iner_model_texture);
+        FMLClientHandler.instance().getClient().getTextureManager().bindTexture(InnerModelTexture);
 
-        double colour = (double) ((TileEnergyStorageCore) tile).getEnergyStored()
-                / (double) ((TileEnergyStorageCore) tile).getMaxEnergyStored();
+        double color = (double) core.getEnergyStored() / core.getMaxEnergyStored();
         float brightness = (float) Math.abs(Math.sin((float) Minecraft.getSystemTime() / 3000f) * 100f);
 
-        colour = 1f - colour;
+        color = 1f - color;
         GL11.glScalef(scale, scale, scale);
         GL11.glPushMatrix();
         GL11.glRotatef(rotation, 0F, 1F, 0.5F);
-        GL11.glColor4d(1F, colour * 0.3f, colour * 0.7f, 1F);
+        GL11.glColor4d(1F, color * 0.3f, color * 0.7f, 1F);
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 80f + brightness, 80f + brightness);
-        iner_model.renderAll();
+        innerModel.renderAll();
         GL11.glPopMatrix();
-
-        // GL11.glPushMatrix();
-        // GL11.glScalef(0.8F, 0.8F, 0.8F);
-        // GL11.glColor4d(1F, 1f, 0.2f, 1F);
-        // GL11.glRotatef(rotation, 0F, 1F, 0.5F);
-        // //iner_model.renderAll();
-        // GL11.glPopMatrix();
-        //
-        // GL11.glPushMatrix();
-        // GL11.glScalef(0.9F, 0.9F, 0.9F);
-        // GL11.glColor4d(1F, 0f, 0.2f, 1F);
-        // GL11.glRotatef(rotation, 0F, 1F, 0.5F);
-        // //iner_model.renderAll();
-        // GL11.glPopMatrix();
 
         GL11.glScalef(1.1F, 1.1F, 1.1F);
         GL11.glDepthMask(false);
-        FMLClientHandler.instance().getClient().getTextureManager().bindTexture(outer_model_texture);
+        FMLClientHandler.instance().getClient().getTextureManager().bindTexture(OuterModelTexture);
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 200F, 200F);
         GL11.glEnable(GL11.GL_BLEND);
         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         GL11.glRotatef(rotation * 0.5F, 0F, -1F, -0.5F);
         GL11.glColor4f(0.5F, 2F, 2F, 0.7F);
-        iner_model.renderAll();
+        innerModel.renderAll();
         GL11.glDisable(GL11.GL_BLEND);
         GL11.glDepthMask(true);
         GL11.glEnable(GL11.GL_LIGHTING);

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileParticleGen.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileParticleGen.java
@@ -54,8 +54,8 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
     public void renderBlock(TileParticleGenerator tl, float f3) {
         Tessellator tessellator = Tessellator.instance;
 
-        boolean inverted = tl.inverted;
-        boolean stabilizerMode = tl.stabalizerMode;
+        boolean inverted = tl.isInverted;
+        boolean stabilizerMode = tl.isInStabilizerMode;
 
         GL11.glPushMatrix();
 
@@ -104,7 +104,7 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
             drawEnergyBeam(tessellator, tl, f3);
         }
 
-        if (tl.beam_enabled) preRenderBeam(tessellator, tl, f3);
+        if (tl.isBeamEnabled) preRenderBeam(tessellator, tl, f3);
     }
 
     private void drawEnergyBeam(Tessellator tess, TileParticleGenerator gen, float f) {
@@ -144,12 +144,12 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
         GL11.glColor4f(0.0F, 2.0F, 0.0F, 1F);
         GL11.glTranslated(0.5, 0, 0.5);
         GL11.glScalef(0.4F, 0.4F, 0.4F);
-        if (!tile.stabalizerMode) {
-            float red = (float) tile.beam_red / 255F;
-            float green = (float) tile.beam_green / 255F;
-            float blue = (float) tile.beam_blue / 255F;
+        if (!tile.isInStabilizerMode) {
+            float red = (float) tile.beamRed / 255F;
+            float green = (float) tile.beamGreen / 255F;
+            float blue = (float) tile.beamBlue / 255F;
             GL11.glColor4f(red, green, blue, 1F);
-            GL11.glScalef(tile.beam_scale, tile.beam_scale, tile.beam_scale);
+            GL11.glScalef(tile.beamScale, tile.beamScale, tile.beamScale);
         }
 
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 200, 200);
@@ -166,10 +166,10 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
         GL11.glDisable(GL11.GL_LIGHTING);
         GL11.glDepthMask(false);
         GL11.glColor4f(0.0F, 1.0F, 1.0F, 0.5F);
-        if (!tile.stabalizerMode) {
-            float red = (float) tile.beam_red / 255F;
-            float green = (float) tile.beam_green / 255F;
-            float blue = (float) tile.beam_blue / 255F;
+        if (!tile.isInStabilizerMode) {
+            float red = (float) tile.beamRed / 255F;
+            float green = (float) tile.beamGreen / 255F;
+            float blue = (float) tile.beamBlue / 255F;
             GL11.glColor4f(red, green, blue, 0.5F);
         }
         GL11.glEnable(GL11.GL_BLEND);
@@ -491,17 +491,17 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
         GL11.glPushMatrix();
 
         GL11.glTranslated(0, 0.5, 0.5);
-        GL11.glRotatef(90F + gen.beam_pitch, 1F, 0F, 0F);
+        GL11.glRotatef(90F + gen.beamPitch, 1F, 0F, 0F);
         GL11.glTranslated(0, 0, -0.5);
 
         GL11.glTranslated(0.5, 0, 0);
-        GL11.glRotatef(gen.beam_yaw, 0F, 0F, 1F);
+        GL11.glRotatef(gen.beamYaw, 0F, 0F, 1F);
         GL11.glTranslated(-0.5, 0, 0);
 
         renderBeam(tess, gen, f);
         GL11.glPopMatrix();
 
-        if (gen.render_core) {
+        if (gen.shouldRenderCore) {
             GL11.glPushMatrix();
             GL11.glTranslated(0, 0.5, 0);
             renderStabilizerSphere(gen);
@@ -513,10 +513,10 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
         int x = 0;
         int y = 0;
         int z = 0;
-        double length = tile.beam_length;
-        float red = (float) tile.beam_red / 255F;
-        float green = (float) tile.beam_green / 255F;
-        float blue = (float) tile.beam_blue / 255F;
+        double length = tile.beamLength;
+        float red = (float) tile.beamRed / 255F;
+        float green = (float) tile.beamGreen / 255F;
+        float blue = (float) tile.beamBlue / 255F;
 
         GL11.glPushMatrix();
         GL11.glAlphaFunc(GL11.GL_GREATER, 0.1F);
@@ -533,14 +533,14 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
         // float time = (float)tile.getWorldObj().getTotalWorldTime() + f;
         float time = tile.rotation + f;
         float upMot = -time * 0.2F - (float) MathHelper.floor_float(-time * 0.1F);
-        float rotValue = tile.beam_rotation * (tile.rotation + f * 0.5F);
+        float rotValue = tile.beamRotation * (tile.rotation + f * 0.5F);
         double rotation = rotValue;
 
         tess.startDrawingQuads();
         tess.setBrightness(200);
-        tess.setColorRGBA(tile.beam_red, tile.beam_green, tile.beam_blue, 32);
+        tess.setColorRGBA(tile.beamRed, tile.beamGreen, tile.beamBlue, 32);
 
-        double scale = (double) tile.beam_scale * 0.2D;
+        double scale = (double) tile.beamScale * 0.2D;
         double d7 = 0.5D + Math.cos(rotation + 2.356194490192345D) * scale; // x point 1
         double d9 = 0.5D + Math.sin(rotation + 2.356194490192345D) * scale; // z point 1
         double d11 = 0.5D + Math.cos(rotation + (Math.PI / 4D)) * scale; // x point 2
@@ -620,10 +620,10 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
         OpenGlHelper.glBlendFunc(770, 771, 1, 0);
         GL11.glDepthMask(false);
         GL11.glTranslated(0.5, 0, 0.5);
-        GL11.glScalef(tile.beam_scale, 1f, tile.beam_scale);
+        GL11.glScalef(tile.beamScale, 1f, tile.beamScale);
         GL11.glTranslated(-0.5, -0, -0.5);
         tess.startDrawingQuads();
-        tess.setColorRGBA(tile.beam_red, tile.beam_green, tile.beam_blue, 32);
+        tess.setColorRGBA(tile.beamRed, tile.beamGreen, tile.beamBlue, 32);
         double d30 = 0.2D;
         double d4 = 0.2D;
         double d6 = 0.8D;

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileParticleGen.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileParticleGen.java
@@ -31,9 +31,9 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
     private static final ResourceLocation modelTexture = new ResourceLocation(
             References.MODID.toLowerCase(),
             "textures/models/stabilizer_sphere.png");
-    private IModelCustom stabilizerSphereModel;
+    private final IModelCustom stabilizerSphereModel;
 
-    private float pxl = 1F / 64;
+    private final float pixel = 1F / 64F;
 
     public RenderTileParticleGen() {
         stabilizerSphereModel = AdvancedModelLoader
@@ -217,10 +217,10 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
         double d17 = 0.5D + Math.sin(rotation + 3.9269908169872414D) * scale;
         double d19 = 0.5D + Math.cos(rotation + 5.497787143782138D) * scale;
         double d21 = 0.5D + Math.sin(rotation + 5.497787143782138D) * scale;
-        double height = (double) (length);
+        double height = length;
         double texXMin = 0.0D;
         double texXMax = 1.0D;
-        double d28 = (double) (-1.0F + upMot);
+        double d28 = -1.0F + upMot;
         double texHeight = (double) (length) * (0.5D / scale) + d28;
 
         tess.addVertexWithUV(x + d7, y + height, z + d9, texXMax, texHeight);
@@ -297,10 +297,10 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
         double d12 = 0.8D;
         double d14 = 0.8D;
         double d16 = 0.8D;
-        double d18 = (double) (length);
+        double d18 = length;
         double d20 = 0.0D;
         double d22 = 1.0D;
-        double d24 = (double) (-1.0F + upMot);
+        double d24 = -1.0F + upMot;
         double d26 = (double) (length) + d24;
         tess.addVertexWithUV(x + d30, y + d18, z + d4, d22, d26);
         tess.addVertexWithUV(x + d30, y, z + d4, d22, d24);
@@ -333,16 +333,16 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
 
     private void drawCornerCube(Tessellator tess, float x, float y, float z, float FP, boolean inverted,
             boolean stabalizerMode) {
-        float srcXMin = inverted ? 38F * pxl : 32F * pxl;
+        float srcXMin = inverted ? 38F * pixel : 32F * pixel;
         float srcYMin = 0F;
-        float srcXMax = inverted ? 44F * pxl : 38F * pxl;
-        float srcYMax = 6 * pxl;
+        float srcXMax = inverted ? 44F * pixel : 38F * pixel;
+        float srcYMax = 6 * pixel;
         // float FP = 0.6F; //Scale
         float FN = 1F - FP;
 
         if (stabalizerMode) {
-            srcXMin = 44F * pxl;
-            srcXMax = 50F * pxl;
+            srcXMin = 44F * pixel;
+            srcXMax = 50F * pixel;
         }
 
         // X+
@@ -385,8 +385,8 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
     private void drawBeamX(Tessellator tess, float x, float y, float z, float FP) {
         float srcXMin = 0;
         float srcYMin = 0F;
-        float srcXMax = 32F * pxl;
-        float srcYMax = 4 * pxl;
+        float srcXMax = 32F * pixel;
+        float srcYMax = 4 * pixel;
         float FN = 1F - FP;
 
         float XX = 0.9F;
@@ -420,8 +420,8 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
     private void drawBeamY(Tessellator tess, float x, float y, float z, float FP) {
         float srcXMin = 0;
         float srcYMin = 0F;
-        float srcXMax = 32F * pxl;
-        float srcYMax = 4 * pxl;
+        float srcXMax = 32F * pixel;
+        float srcYMax = 4 * pixel;
         float FN = 1F - FP;
 
         float XX = 0.9F;
@@ -455,8 +455,8 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
     private void drawBeamZ(Tessellator tess, float x, float y, float z, float FP) {
         float srcXMin = 0;
         float srcYMin = 0F;
-        float srcXMax = 32F * pxl;
-        float srcYMax = 4 * pxl;
+        float srcXMax = 32F * pixel;
+        float srcYMax = 4 * pixel;
         float FN = 1F - FP;
 
         float XX = 0.9F;
@@ -533,8 +533,7 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
         // float time = (float)tile.getWorldObj().getTotalWorldTime() + f;
         float time = tile.rotation + f;
         float upMot = -time * 0.2F - (float) MathHelper.floor_float(-time * 0.1F);
-        float rotValue = tile.beamRotation * (tile.rotation + f * 0.5F);
-        double rotation = rotValue;
+        double rotation = tile.beamRotation * (tile.rotation + f * 0.5F);
 
         tess.startDrawingQuads();
         tess.setBrightness(200);
@@ -549,31 +548,30 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
         double d17 = 0.5D + Math.sin(rotation + 3.9269908169872414D) * scale;
         double d19 = 0.5D + Math.cos(rotation + 5.497787143782138D) * scale;
         double d21 = 0.5D + Math.sin(rotation + 5.497787143782138D) * scale;
-        double height = (double) (length);
         double texXMin = 0.0D;
         double texXMax = 1.0D;
-        double d28 = (double) (-1.0F + upMot);
-        double texHeight = (double) (length) * (0.5D / scale) + d28;
+        double d28 = -1.0F + upMot;
+        double texHeight = length * (0.5D / scale) + d28;
 
-        tess.addVertexWithUV(x + d7, y + height, z + d9, texXMax, texHeight);
+        tess.addVertexWithUV(x + d7, y + length, z + d9, texXMax, texHeight);
         tess.addVertexWithUV(x + d7, y, z + d9, texXMax, d28);
         tess.addVertexWithUV(x + d11, y, z + d13, texXMin, d28);
-        tess.addVertexWithUV(x + d11, y + height, z + d13, texXMin, texHeight);
+        tess.addVertexWithUV(x + d11, y + length, z + d13, texXMin, texHeight);
 
-        tess.addVertexWithUV(x + d19, y + height, z + d21, texXMax, texHeight);
+        tess.addVertexWithUV(x + d19, y + length, z + d21, texXMax, texHeight);
         tess.addVertexWithUV(x + d19, y, z + d21, texXMax, d28);
         tess.addVertexWithUV(x + d15, y, z + d17, texXMin, d28);
-        tess.addVertexWithUV(x + d15, y + height, z + d17, texXMin, texHeight);
+        tess.addVertexWithUV(x + d15, y + length, z + d17, texXMin, texHeight);
 
-        tess.addVertexWithUV(x + d11, y + height, z + d13, texXMax, texHeight);
+        tess.addVertexWithUV(x + d11, y + length, z + d13, texXMax, texHeight);
         tess.addVertexWithUV(x + d11, y, z + d13, texXMax, d28);
         tess.addVertexWithUV(x + d19, y, z + d21, texXMin, d28);
-        tess.addVertexWithUV(x + d19, y + height, z + d21, texXMin, texHeight);
+        tess.addVertexWithUV(x + d19, y + length, z + d21, texXMin, texHeight);
 
-        tess.addVertexWithUV(x + d15, y + height, z + d17, texXMax, texHeight);
+        tess.addVertexWithUV(x + d15, y + length, z + d17, texXMax, texHeight);
         tess.addVertexWithUV(x + d15, y, z + d17, texXMax, d28);
         tess.addVertexWithUV(x + d7, y, z + d9, texXMin, d28);
-        tess.addVertexWithUV(x + d7, y + height, z + d9, texXMin, texHeight);
+        tess.addVertexWithUV(x + d7, y + length, z + d9, texXMin, texHeight);
 
         rotation += 0.77f;
         d7 = 0.5D + Math.cos(rotation + 2.356194490192345D) * scale;
@@ -586,29 +584,29 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
         d21 = 0.5D + Math.sin(rotation + 5.497787143782138D) * scale;
 
         d28 = (-1F + (upMot * 1));
-        texHeight = (double) (length) * (0.5D / scale) + d28;
+        texHeight = length * (0.5D / scale) + d28;
 
         tess.setColorRGBA_F(red, green, blue, 1f);
 
-        tess.addVertexWithUV(x + d7, y + height, z + d9, texXMax, texHeight);
+        tess.addVertexWithUV(x + d7, y + length, z + d9, texXMax, texHeight);
         tess.addVertexWithUV(x + d7, y, z + d9, texXMax, d28);
         tess.addVertexWithUV(x + d11, y, z + d13, texXMin, d28);
-        tess.addVertexWithUV(x + d11, y + height, z + d13, texXMin, texHeight);
+        tess.addVertexWithUV(x + d11, y + length, z + d13, texXMin, texHeight);
 
-        tess.addVertexWithUV(x + d19, y + height, z + d21, texXMax, texHeight);
+        tess.addVertexWithUV(x + d19, y + length, z + d21, texXMax, texHeight);
         tess.addVertexWithUV(x + d19, y, z + d21, texXMax, d28);
         tess.addVertexWithUV(x + d15, y, z + d17, texXMin, d28);
-        tess.addVertexWithUV(x + d15, y + height, z + d17, texXMin, texHeight);
+        tess.addVertexWithUV(x + d15, y + length, z + d17, texXMin, texHeight);
 
-        tess.addVertexWithUV(x + d11, y + height, z + d13, texXMax, texHeight);
+        tess.addVertexWithUV(x + d11, y + length, z + d13, texXMax, texHeight);
         tess.addVertexWithUV(x + d11, y, z + d13, texXMax, d28);
         tess.addVertexWithUV(x + d19, y, z + d21, texXMin, d28);
-        tess.addVertexWithUV(x + d19, y + height, z + d21, texXMin, texHeight);
+        tess.addVertexWithUV(x + d19, y + length, z + d21, texXMin, texHeight);
 
-        tess.addVertexWithUV(x + d15, y + height, z + d17, texXMax, texHeight);
+        tess.addVertexWithUV(x + d15, y + length, z + d17, texXMax, texHeight);
         tess.addVertexWithUV(x + d15, y, z + d17, texXMax, d28);
         tess.addVertexWithUV(x + d7, y, z + d9, texXMin, d28);
-        tess.addVertexWithUV(x + d7, y + height, z + d9, texXMin, texHeight);
+        tess.addVertexWithUV(x + d7, y + length, z + d9, texXMin, texHeight);
 
         tess.draw();
         GL11.glPushMatrix();
@@ -632,27 +630,26 @@ public class RenderTileParticleGen extends TileEntitySpecialRenderer {
         double d12 = 0.8D;
         double d14 = 0.8D;
         double d16 = 0.8D;
-        double d18 = (double) (length);
         double d20 = 0.0D;
         double d22 = 1D;
-        double d24 = (double) (-1.0F + upMot);
-        double d26 = (double) (length) + d24;
-        tess.addVertexWithUV(x + d30, y + d18, z + d4, d22, d26);
+        double d24 = -1.0F + upMot;
+        double d26 = length + d24;
+        tess.addVertexWithUV(x + d30, y + length, z + d4, d22, d26);
         tess.addVertexWithUV(x + d30, y, z + d4, d22, d24);
         tess.addVertexWithUV(x + d6, y, z + d8, d20, d24);
-        tess.addVertexWithUV(x + d6, y + d18, z + d8, d20, d26);
-        tess.addVertexWithUV(x + d14, y + d18, z + d16, d22, d26);
+        tess.addVertexWithUV(x + d6, y + length, z + d8, d20, d26);
+        tess.addVertexWithUV(x + d14, y + length, z + d16, d22, d26);
         tess.addVertexWithUV(x + d14, y, z + d16, d22, d24);
         tess.addVertexWithUV(x + d10, y, z + d12, d20, d24);
-        tess.addVertexWithUV(x + d10, y + d18, z + d12, d20, d26);
-        tess.addVertexWithUV(x + d6, y + d18, z + d8, d22, d26);
+        tess.addVertexWithUV(x + d10, y + length, z + d12, d20, d26);
+        tess.addVertexWithUV(x + d6, y + length, z + d8, d22, d26);
         tess.addVertexWithUV(x + d6, y, z + d8, d22, d24);
         tess.addVertexWithUV(x + d14, y, z + d16, d20, d24);
-        tess.addVertexWithUV(x + d14, y + d18, z + d16, d20, d26);
-        tess.addVertexWithUV(x + d10, y + d18, z + d12, d22, d26);
+        tess.addVertexWithUV(x + d14, y + length, z + d16, d20, d26);
+        tess.addVertexWithUV(x + d10, y + length, z + d12, d22, d26);
         tess.addVertexWithUV(x + d10, y, z + d12, d22, d24);
         tess.addVertexWithUV(x + d30, y, z + d4, d20, d24);
-        tess.addVertexWithUV(x + d30, y + d18, z + d4, d20, d26);
+        tess.addVertexWithUV(x + d30, y + length, z + d4, d20, d26);
         tess.draw();
         GL11.glPopMatrix();
 

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileReactorCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileReactorCore.java
@@ -27,35 +27,23 @@ public class RenderTileReactorCore extends TileEntitySpecialRenderer {
 
     @Override
     public void renderTileEntityAt(TileEntity tileEntity, double x, double y, double z, float partialTick) {
-        TileReactorCore tile = (TileReactorCore) tileEntity;
-        // tile.renderList.clear();
+        TileReactorCore core = (TileReactorCore) tileEntity;
 
         GL11.glPushMatrix();
         GL11.glTranslated(x + 0.5, y + 0.5, z + 0.5);
 
-        renderReactorCore(tile, partialTick);
-        // for (MultiblockHelper.TileOffset offset : tile.stabilizerLocations){
-        // if (!(offset.getTileEntity(tileEntity) instanceof TileReactorStabilizer)) continue;
-        // GL11.glPushMatrix();
-        //
-        // TileReactorStabilizer stabilizer = (TileReactorStabilizer)offset.getTileEntity(tileEntity);
-        // GL11.glTranslated(-offset.offsetX, -offset.offsetY, -offset.offsetZ);
-        // //RenderTileReactorStabilizer.renderCore(stabilizer, partialTick);
-        // //RenderTileReactorStabilizer.renderEffects(stabilizer, partialTick);
-        //
-        // GL11.glPopMatrix();
-        // }
+        renderReactorCore(core, partialTick);
 
         GL11.glPopMatrix();
     }
 
-    public void renderReactorCore(TileReactorCore tile, float partialTick) {
-        float rotation = (tile.renderRotation * 0.2F) + (partialTick * (tile.renderSpeed * 0.2F));
-        double ff = tile.maxFieldCharge > 0 ? tile.fieldCharge / tile.maxFieldCharge : 0;
-        double r = ff < 0.5 ? 1 - (ff * 2) : 0;
-        double g = ff > 0.5 ? (ff - 0.5) * 2 : 0;
-        double b = ff * 2;
-        double a = ff < 0.1 ? (ff * 10) : 1;
+    public void renderReactorCore(TileReactorCore core, float partialTick) {
+        float rotation = core.renderRotation * 0.2F + partialTick * (core.renderSpeed * 0.2F);
+        double fieldChargePercentage = core.maxFieldCharge > 0 ? core.fieldCharge / core.maxFieldCharge : 0;
+        double r = fieldChargePercentage < 0.5 ? 1 - fieldChargePercentage * 2 : 0;
+        double g = fieldChargePercentage > 0.5 ? (fieldChargePercentage - 0.5) * 2 : 0;
+        double b = fieldChargePercentage * 2;
+        double a = fieldChargePercentage < 0.1 ? fieldChargePercentage * 10 : 1;
 
         // Pre Render
         GL11.glPushMatrix();
@@ -65,7 +53,7 @@ public class RenderTileReactorCore extends TileEntitySpecialRenderer {
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 200F, 200F);
 
         // Render inner
-        if (tile.reactorFuel + tile.convertedFuel < 144) {
+        if (core.reactorFuel + core.convertedFuel < 144) {
             ResourceHandler.bindResource("textures/blocks/draconic_block_blank.png");
             GL11.glPushMatrix();
             GL11.glScaled(0.1, 0.1, 0.1);
@@ -77,8 +65,8 @@ public class RenderTileReactorCore extends TileEntitySpecialRenderer {
         GL11.glColor4d(1, 1, 1, 1);
         GL11.glRotatef(rotation, 0.5F, 1F, 0.5F);
         GL11.glScaled(0.5, 0.5, 0.5);
-        double r3 = tile.getCoreDiameter();
-        GL11.glScaled(r3, r3, r3);
+        double diameter = core.getCoreDiameter();
+        GL11.glScaled(diameter, diameter, diameter);
         reactorModel.renderAll();
 
         // Mid Render
@@ -87,10 +75,11 @@ public class RenderTileReactorCore extends TileEntitySpecialRenderer {
         GL11.glEnable(GL11.GL_ALPHA_TEST);
         GL11.glAlphaFunc(GL11.GL_GREATER, 0F);
 
-        if (tile.reactionTemperature < 2000) {
+        if (core.reactionTemperature < 2000) {
             ResourceHandler.bindResource("textures/blocks/draconic_block_blank.png");
-            if (tile.reactionTemperature > 1000)
-                GL11.glColor4d(1F, 1F, 1F, 1D - ((tile.reactionTemperature - 1000) / 1000D));
+            if (core.reactionTemperature > 1000) {
+                GL11.glColor4d(1F, 1F, 1F, 1D - (core.reactionTemperature - 1000) / 1000D);
+            }
             reactorModel.renderAll();
         }
 

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileReactorEnergyInjector.java
@@ -18,11 +18,14 @@ public class RenderTileReactorEnergyInjector extends TileEntitySpecialRenderer {
     public static ModelReactorEnergyInjector modelReactorEnergyInjector = new ModelReactorEnergyInjector();
 
     @Override
-    public void renderTileEntityAt(TileEntity tileEntity, double x, double y, double z, float partialTick) {
+    public void renderTileEntityAt(TileEntity tile, double x, double y, double z, float partialTick) {
+        if (!(tile instanceof TileReactorEnergyInjector injector)) {
+            return;
+        }
         GL11.glPushMatrix();
         GL11.glTranslated(x + 0.5, y + 0.5, z + 0.5);
 
-        renderCore((TileReactorEnergyInjector) tileEntity);
+        renderCore(injector);
 
         GL11.glPopMatrix();
     }

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileReactorEnergyInjector.java
@@ -2,6 +2,7 @@ package com.brandon3055.draconicevolution.client.render.tile;
 
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
 
@@ -21,34 +22,40 @@ public class RenderTileReactorEnergyInjector extends TileEntitySpecialRenderer {
         GL11.glPushMatrix();
         GL11.glTranslated(x + 0.5, y + 0.5, z + 0.5);
 
-        renderCore((TileReactorEnergyInjector) tileEntity, partialTick);
+        renderCore((TileReactorEnergyInjector) tileEntity);
 
         GL11.glPopMatrix();
     }
 
-    public static void renderCore(TileReactorEnergyInjector tile, float partialTick) {
+    public static void renderCore(TileReactorEnergyInjector injector) {
         GL11.glPushMatrix();
         float scale = (1F / 16F);
 
-        switch (tile.facingDirection) {
-            case 1:
-                GL11.glRotated(180, -1, 0, 0);
+        int angle = 90;
+        ForgeDirection axis = injector.facing;
+        switch (injector.facing) {
+            case UP:
+                angle = 180;
+                // it's intended to fall through
+            case SOUTH:
+                axis = ForgeDirection.WEST;
                 break;
-            case 2:
-                GL11.glRotated(90, 1, 0, 0);
+            case NORTH:
+                axis = ForgeDirection.EAST;
                 break;
-            case 3:
-                GL11.glRotated(90, -1, 0, 0);
+            case WEST:
+                axis = ForgeDirection.NORTH;
                 break;
-            case 4:
-                GL11.glRotated(90, 0, 0, -1);
+            case EAST:
+                axis = ForgeDirection.SOUTH;
                 break;
-            case 5:
-                GL11.glRotated(90, 0, 0, 1);
+        }
+        if (injector.facing != ForgeDirection.DOWN) {
+            GL11.glRotated(angle, axis.offsetX, axis.offsetY, axis.offsetZ);
         }
 
         ResourceHandler.bindResource("textures/models/ModelReactorPowerInjector.png");
-        modelReactorEnergyInjector.render(null, tile.modelIllumination, 0F, 0F, 0F, 0F, scale);
+        modelReactorEnergyInjector.render(null, injector.modelIllumination, 0F, 0F, 0F, 0F, scale);
 
         GL11.glPopMatrix();
     }

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileReactorEnergyInjector.java
@@ -37,21 +37,14 @@ public class RenderTileReactorEnergyInjector extends TileEntitySpecialRenderer {
         int angle = 90;
         ForgeDirection axis = injector.facing;
         switch (injector.facing) {
-            case UP:
+            case UP -> {
                 angle = 180;
-                // it's intended to fall through
-            case SOUTH:
                 axis = ForgeDirection.WEST;
-                break;
-            case NORTH:
-                axis = ForgeDirection.EAST;
-                break;
-            case WEST:
-                axis = ForgeDirection.NORTH;
-                break;
-            case EAST:
-                axis = ForgeDirection.SOUTH;
-                break;
+            }
+            case SOUTH -> axis = ForgeDirection.WEST;
+            case NORTH -> axis = ForgeDirection.EAST;
+            case WEST -> axis = ForgeDirection.NORTH;
+            case EAST -> axis = ForgeDirection.SOUTH;
         }
         if (injector.facing != ForgeDirection.DOWN) {
             GL11.glRotated(angle, axis.offsetX, axis.offsetY, axis.offsetZ);

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileReactorStabilizer.java
@@ -20,12 +20,14 @@ public class RenderTileReactorStabilizer extends TileEntitySpecialRenderer {
     public static ModelReactorStabilizerCore modelStabilizerCore = new ModelReactorStabilizerCore();
 
     @Override
-    public void renderTileEntityAt(TileEntity tileEntity, double x, double y, double z, float partialTick) {
+    public void renderTileEntityAt(TileEntity tile, double x, double y, double z, float partialTick) {
+        if (!(tile instanceof TileReactorStabilizer stabilizer)) {
+            return;
+        }
         GL11.glPushMatrix();
         GL11.glTranslated(x + 0.5, y + 0.5, z + 0.5);
 
-        renderCore((TileReactorStabilizer) tileEntity, partialTick);
-        // renderEffects((TileReactorStabilizer) tileEntity, partialTick);
+        renderCore(stabilizer, partialTick);
 
         GL11.glPopMatrix();
     }

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileReactorStabilizer.java
@@ -2,6 +2,7 @@ package com.brandon3055.draconicevolution.client.render.tile;
 
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
 
@@ -29,110 +30,44 @@ public class RenderTileReactorStabilizer extends TileEntitySpecialRenderer {
         GL11.glPopMatrix();
     }
 
-    public static void renderCore(TileReactorStabilizer tile, float partialTick) {
+    public static void renderCore(TileReactorStabilizer stabilizer, float partialTick) {
         GL11.glPushMatrix();
         float scale = (1F / 16F);
-        float coreRotation = tile.coreRotation + (partialTick * tile.coreSpeed);
-        float ringRotation = tile.ringRotation + (partialTick * tile.ringSpeed);
+        float coreRotation = stabilizer.coreRotation + (partialTick * stabilizer.coreSpeed);
+        float ringRotation = stabilizer.ringRotation + (partialTick * stabilizer.ringSpeed);
 
-        switch (tile.facingDirection) {
-            case 0:
-                GL11.glRotated(90, -1, 0, 0);
+        int angle = 90;
+        ForgeDirection axis = stabilizer.facing;
+        switch (stabilizer.facing) {
+            case DOWN:
+                axis = ForgeDirection.WEST;
                 break;
-            case 1:
-                GL11.glRotated(90, 1, 0, 0);
+            case SOUTH:
+                angle = 180;
+                // it's intended to fall through
+            case UP:
+                axis = ForgeDirection.EAST;
                 break;
-            case 3:
-                GL11.glRotated(180, 1, 0, 0);
+            case WEST:
+                axis = ForgeDirection.UP;
                 break;
-            case 4:
-                GL11.glRotated(90, 0, 1, 0);
+            case EAST:
+                axis = ForgeDirection.DOWN;
                 break;
-            case 5:
-                GL11.glRotated(90, 0, -1, 0);
+        }
+        if (stabilizer.facing != ForgeDirection.NORTH) {
+            GL11.glRotated(angle, axis.offsetX, axis.offsetY, axis.offsetZ);
         }
 
         ResourceHandler.bindResource("textures/models/reactorStabilizerCore.png");
-        modelStabilizerCore.render(null, coreRotation, tile.modelIllumination, 0F, 0F, 0F, scale);
+        modelStabilizerCore.render(null, coreRotation, stabilizer.modelIllumination, 0F, 0F, 0F, scale);
 
         ResourceHandler.bindResource("textures/models/reactorStabilizerRing.png");
         GL11.glRotated(90, 1, 0, 0);
         GL11.glTranslated(0, -0.58, 0);
         GL11.glScaled(0.95, 0.95, 0.95);
         GL11.glRotatef(ringRotation, 0, 1, 0);
-        modelStabilizerRing.render(null, -70F, tile.modelIllumination, 0F, 0F, 0F, scale);
+        modelStabilizerRing.render(null, -70F, stabilizer.modelIllumination, 0F, 0F, 0F, scale);
         GL11.glPopMatrix();
     }
-
-    // public static void renderEffects(TileReactorStabilizer tile, float partialTick) {
-    // if (tile.isValid)
-    // {
-    // //Common Fields
-    // MultiblockHelper.TileLocation master = tile.masterLocation;
-    // float offsetX = (float)(master.posX - tile.xCoord);
-    // float offsetY = (float)((double)master.posY - tile.yCoord);
-    // float offsetZ = (float)(master.posZ - tile.zCoord);
-    // float length = MathHelper.sqrt_float(offsetX * offsetX + offsetY * offsetY + offsetZ * offsetZ);
-    //
-    // Tessellator tessellator = Tessellator.instance;
-    //
-    // //Pre Render
-    // GL11.glPushMatrix();
-    //// RenderHelper.disableStandardItemLighting();
-    // GL11.glDisable(GL11.GL_CULL_FACE);
-    // GL11.glShadeModel(GL11.GL_SMOOTH);
-    // GL11.glEnable(GL11.GL_BLEND);
-    // OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
-    // GL11.glAlphaFunc(GL11.GL_GREATER, 0.0F);
-    // GL11.glDisable(GL11.GL_LIGHTING);
-    // GL11.glDepthMask(false);
-    //
-    // //Rotate beam to face target
-    // float f7 = MathHelper.sqrt_float(offsetX * offsetX + offsetZ * offsetZ);
-    // GL11.glRotatef((float) (-Math.atan2((double) offsetZ, (double) offsetX)) * 180.0F / (float) Math.PI - 90.0F,
-    // 0.0F, 1.0F, 0.0F);
-    // GL11.glRotatef((float)(-Math.atan2((double)f7, (double)offsetY)) * 180.0F / (float)Math.PI - 90.0F, 1.0F, 0.0F,
-    // 0.0F);
-    //
-    //
-    // //Draw Beams
-    // GL11.glPushMatrix();
-    // GL11.glTranslated(0, 0, -0.35);
-    // ResourceHandler.bindTexture(new ResourceLocation("textures/entity/endercrystal/endercrystal_beam.png"));
-    //// drawBeam(tessellator, 1F, 0.355F, 0.8F, offsetX, offsetY, offsetZ, tile.tick, partialTick, true, false);
-    // GL11.glPopMatrix();
-    //
-    // GL11.glPushMatrix();
-    // GL11.glTranslated(0, 0, 0.4526);
-    // float coreSize = 1.1F;
-    // float s = 0.355F;
-    //// drawBeam(tessellator, s/coreSize, coreSize, length - 0.5F, offsetX, offsetY, offsetZ, tile.tick, partialTick,
-    // false, false);
-    // GL11.glPopMatrix();
-    //
-    //// GL11.glPushMatrix();
-    //// GL11.glTranslated(0, 0, -0.35);
-    //// ResourceHandler.bindTexture(new ResourceLocation("textures/entity/endercrystal/endercrystal_beam.png"));
-    //// drawBeam(tessellator, 1F, 0.26F, 0.8F, offsetX, offsetY, offsetZ, tile.tick, partialTick, true, true);
-    //// GL11.glPopMatrix();
-    ////
-    //// GL11.glPushMatrix();
-    //// GL11.glTranslated(0, 0, 0.4526);
-    //// coreSize = 1.1F;
-    //// s = 0.263F;
-    //// drawBeam(tessellator, s/coreSize, coreSize, length - 0.5F, offsetX, offsetY, offsetZ, tile.tick, partialTick,
-    // false, true);
-    //// GL11.glPopMatrix();
-    //
-    // //Post Render
-    // GL11.glDepthMask(true);
-    // GL11.glEnable(GL11.GL_LIGHTING);
-    // GL11.glEnable(GL11.GL_CULL_FACE);
-    // GL11.glShadeModel(GL11.GL_FLAT);
-    //// RenderHelper.enableStandardItemLighting();
-    // GL11.glDisable(GL11.GL_BLEND);
-    // GL11.glAlphaFunc(GL11.GL_GREATER, 0.1F);
-    // GL11.glPopMatrix();
-    // }
-    // }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileReactorStabilizer.java
@@ -41,21 +41,14 @@ public class RenderTileReactorStabilizer extends TileEntitySpecialRenderer {
         int angle = 90;
         ForgeDirection axis = stabilizer.facing;
         switch (stabilizer.facing) {
-            case DOWN:
-                axis = ForgeDirection.WEST;
-                break;
-            case SOUTH:
+            case DOWN -> axis = ForgeDirection.WEST;
+            case SOUTH -> {
                 angle = 180;
-                // it's intended to fall through
-            case UP:
                 axis = ForgeDirection.EAST;
-                break;
-            case WEST:
-                axis = ForgeDirection.UP;
-                break;
-            case EAST:
-                axis = ForgeDirection.DOWN;
-                break;
+            }
+            case UP -> axis = ForgeDirection.EAST;
+            case WEST -> axis = ForgeDirection.UP;
+            case EAST -> axis = ForgeDirection.DOWN;
         }
         if (stabilizer.facing != ForgeDirection.NORTH) {
             GL11.glRotated(angle, axis.offsetX, axis.offsetY, axis.offsetZ);

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/CKeyStone.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/CKeyStone.java
@@ -69,8 +69,8 @@ public class CKeyStone extends BlockDE implements ITileEntityProvider {
             return Blocks.furnace.getIcon(side, 0);
         }
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileCKeyStone) {
-            return ((TileCKeyStone) tile).isActivated ? blockIconActive : blockIcon;
+        if (tile instanceof TileCKeyStone keyStone) {
+            return keyStone.isActivated ? blockIconActive : blockIcon;
         }
         return blockIcon;
     }
@@ -79,7 +79,7 @@ public class CKeyStone extends BlockDE implements ITileEntityProvider {
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float subX,
             float subY, float subZ) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        return tile instanceof TileCKeyStone && ((TileCKeyStone) tile).onActivated(player.getHeldItem(), player);
+        return tile instanceof TileCKeyStone keyStone && keyStone.onActivated(player.getHeldItem(), player);
     }
 
     @Override
@@ -95,14 +95,13 @@ public class CKeyStone extends BlockDE implements ITileEntityProvider {
     @Override
     public int isProvidingWeakPower(IBlockAccess world, int x, int y, int z, int meta) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        return tile instanceof TileCKeyStone && ((TileCKeyStone) tile).isActivated ? 15 : 0;
+        return tile instanceof TileCKeyStone keyStone && keyStone.isActivated ? 15 : 0;
     }
 
     @Override
     public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z, EntityPlayer player) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileCKeyStone) {
-            TileCKeyStone keyStone = (TileCKeyStone) tile;
+        if (tile instanceof TileCKeyStone keyStone) {
             ItemStack key = new ItemStack(ModItems.key);
             ItemNBTHelper.setInteger(key, "KeyCode", keyStone.getKeyCode());
             ItemNBTHelper.setInteger(key, "X", x);

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/CKeyStone.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/CKeyStone.java
@@ -1,5 +1,6 @@
 package com.brandon3055.draconicevolution.common.blocks;
 
+import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
@@ -26,9 +27,10 @@ import cpw.mods.fml.relauncher.SideOnly;
 /**
  * Created by Brandon on 27/08/2014.
  */
-public class CKeyStone extends BlockDE {
+public class CKeyStone extends BlockDE implements ITileEntityProvider {
 
-    private IIcon blockIcon1;
+    @SideOnly(Side.CLIENT)
+    private IIcon blockIconActive;
 
     public CKeyStone() {
         this.setBlockUnbreakable();
@@ -43,43 +45,41 @@ public class CKeyStone extends BlockDE {
     }
 
     @Override
-    public TileEntity createTileEntity(World world, int metadata) {
+    public TileEntity createNewTileEntity(World world, int metadata) {
         return new TileCKeyStone();
     }
 
-    @SideOnly(Side.CLIENT)
     @Override
+    @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister iconRegister) {
         blockIcon = iconRegister.registerIcon(References.RESOURCESPREFIX + "key_stone_inactive");
-        blockIcon1 = iconRegister.registerIcon(References.RESOURCESPREFIX + "key_stone_active");
+        blockIconActive = iconRegister.registerIcon(References.RESOURCESPREFIX + "key_stone_active");
     }
 
+    @Override
     @SideOnly(Side.CLIENT)
-    @Override
-    public IIcon getIcon(int side, int meta) {
-        if (side == 0 || side == 1) return Blocks.furnace.getIcon(side, meta);
-        else return blockIcon1;
+    public IIcon getIcon(int side, int metadata) {
+        return side == 0 || side == 1 ? Blocks.furnace.getIcon(side, metadata) : blockIconActive;
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public IIcon getIcon(IBlockAccess world, int x, int y, int z, int side) {
-        if (side == 0 || side == 1) return Blocks.furnace.getIcon(side, 0);
-        TileCKeyStone tile = world.getTileEntity(x, y, z) != null
-                && world.getTileEntity(x, y, z) instanceof TileCKeyStone ? (TileCKeyStone) world.getTileEntity(x, y, z)
-                        : null;
-        if (tile != null) return tile.isActivated ? blockIcon1 : blockIcon;
-        else return blockIcon;
+        if (side == 0 || side == 1) {
+            return Blocks.furnace.getIcon(side, 0);
+        }
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileCKeyStone) {
+            return ((TileCKeyStone) tile).isActivated ? blockIconActive : blockIcon;
+        }
+        return blockIcon;
     }
 
     @Override
-    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int p_149727_6_,
-            float p_149727_7_, float p_149727_8_, float p_149727_9_) {
-        TileCKeyStone tile = world.getTileEntity(x, y, z) != null
-                && world.getTileEntity(x, y, z) instanceof TileCKeyStone ? (TileCKeyStone) world.getTileEntity(x, y, z)
-                        : null;
-
-        if (tile != null) return tile.onActivated(player.getHeldItem(), player);
-        return false;
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float subX,
+            float subY, float subZ) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        return tile instanceof TileCKeyStone && ((TileCKeyStone) tile).onActivated(player.getHeldItem(), player);
     }
 
     @Override
@@ -94,26 +94,17 @@ public class CKeyStone extends BlockDE {
 
     @Override
     public int isProvidingWeakPower(IBlockAccess world, int x, int y, int z, int meta) {
-        TileCKeyStone tile = world.getTileEntity(x, y, z) != null
-                && world.getTileEntity(x, y, z) instanceof TileCKeyStone ? (TileCKeyStone) world.getTileEntity(x, y, z)
-                        : null;
-        if (tile != null) return tile.isActivated ? 15 : 0;
-        return 0;
-    }
-
-    @Override
-    public int isProvidingStrongPower(IBlockAccess world, int x, int y, int z, int meta) {
-        return 0;
+        TileEntity tile = world.getTileEntity(x, y, z);
+        return tile instanceof TileCKeyStone && ((TileCKeyStone) tile).isActivated ? 15 : 0;
     }
 
     @Override
     public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z, EntityPlayer player) {
-        TileCKeyStone tile = world.getTileEntity(x, y, z) != null
-                && world.getTileEntity(x, y, z) instanceof TileCKeyStone ? (TileCKeyStone) world.getTileEntity(x, y, z)
-                        : null;
-        if (tile != null) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileCKeyStone) {
+            TileCKeyStone keyStone = (TileCKeyStone) tile;
             ItemStack key = new ItemStack(ModItems.key);
-            ItemNBTHelper.setInteger(key, "KeyCode", tile.getKeyCode());
+            ItemNBTHelper.setInteger(key, "KeyCode", keyStone.getKeyCode());
             ItemNBTHelper.setInteger(key, "X", x);
             ItemNBTHelper.setInteger(key, "Y", y);
             ItemNBTHelper.setInteger(key, "Z", z);
@@ -123,8 +114,7 @@ public class CKeyStone extends BlockDE {
     }
 
     @Override
-    public boolean isBlockSolid(IBlockAccess p_149747_1_, int p_149747_2_, int p_149747_3_, int p_149747_4_,
-            int p_149747_5_) {
+    public boolean isBlockSolid(IBlockAccess world, int x, int y, int z, int side) {
         return true;
     }
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/ParticleGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/ParticleGenerator.java
@@ -202,7 +202,7 @@ public class ParticleGenerator extends BlockDE {
                 TileParticleGenerator generator = (TileParticleGenerator) tile;
                 if (generator.getMaster() != null) {
                     world.setBlockMetadataWithNotify(x, y, z, 0, 2);
-                    generator.getMaster().isStructureStillValid(true);
+                    generator.getMaster().validateStructure(true);
                 }
             }
         }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/ParticleGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/ParticleGenerator.java
@@ -87,7 +87,7 @@ public class ParticleGenerator extends BlockDE {
     public void onNeighborBlockChange(final World world, final int x, final int y, final int z, final Block block) {
         TileEntity tile = world.getTileEntity(x, y, z);
         if (tile instanceof TileParticleGenerator) {
-            ((TileParticleGenerator) tile).signal = world.isBlockIndirectlyGettingPowered(x, y, z);
+            ((TileParticleGenerator) tile).hasRedstoneSignal = world.isBlockIndirectlyGettingPowered(x, y, z);
             world.markBlockForUpdate(x, y, z);
         }
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/ParticleGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/ParticleGenerator.java
@@ -11,6 +11,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import com.brandon3055.draconicevolution.DraconicEvolution;
 import com.brandon3055.draconicevolution.client.gui.GuiHandler;
@@ -45,33 +46,34 @@ public class ParticleGenerator extends BlockDE {
     }
 
     @Override
-    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float p_149727_7_,
-            float p_149727_8_, float p_149727_9_) {
-        if (world.getBlockMetadata(x, y, z) == 1) return false;
-
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float subX,
+            float subY, float subZ) {
+        if (world.getBlockMetadata(x, y, z) == 1) {
+            return false;
+        }
         if (player.getHeldItem() != null && player.getHeldItem().getItem() == Items.paper) {
             TileEntity tile = world.getTileEntity(x, y, z);
-            TileParticleGenerator gen = (tile != null && tile instanceof TileParticleGenerator)
-                    ? (TileParticleGenerator) tile
-                    : null;
-            ItemStack stack = player.getHeldItem();
-            if (gen != null && stack.hasTagCompound() && stack.getTagCompound().hasKey("particles_enabled")) {
-                gen.setBlockNBT(stack.getTagCompound());
-                return true;
+            if (tile instanceof TileParticleGenerator) {
+                TileParticleGenerator generator = (TileParticleGenerator) tile;
+                ItemStack stack = player.getHeldItem();
+                if (stack.hasTagCompound() && stack.getTagCompound().hasKey("particles_enabled")) {
+                    generator.setBlockNBT(stack.getTagCompound());
+                    return true;
+                }
             }
         }
 
         if (player.isSneaking()) {
-            if (activateEnergyStorageCore(world, x, y, z, player)) return true;
-            TileEntity tile = world.getTileEntity(x, y, z);
-            TileParticleGenerator gen = (tile != null && tile instanceof TileParticleGenerator)
-                    ? (TileParticleGenerator) tile
-                    : null;
-            if (gen != null) {
-                gen.toggleInverted();
+            if (activateEnergyStorageCore(world, x, y, z, player)) {
+                return true;
             }
-        } else
+            TileEntity tile = world.getTileEntity(x, y, z);
+            if (tile instanceof TileParticleGenerator) {
+                ((TileParticleGenerator) tile).toggleInverted();
+            }
+        } else {
             FMLNetworkHandler.openGui(player, DraconicEvolution.instance, GuiHandler.GUIID_PARTICLEGEN, world, x, y, z);
+        }
         return true;
     }
 
@@ -84,11 +86,8 @@ public class ParticleGenerator extends BlockDE {
     @Override
     public void onNeighborBlockChange(final World world, final int x, final int y, final int z, final Block block) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        TileParticleGenerator gen = (tile != null && tile instanceof TileParticleGenerator)
-                ? (TileParticleGenerator) tile
-                : null;
-        if (gen != null) {
-            gen.signal = world.isBlockIndirectlyGettingPowered(x, y, z);
+        if (tile instanceof TileParticleGenerator) {
+            ((TileParticleGenerator) tile).signal = world.isBlockIndirectlyGettingPowered(x, y, z);
             world.markBlockForUpdate(x, y, z);
         }
     }
@@ -100,42 +99,43 @@ public class ParticleGenerator extends BlockDE {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void onBlockDestroyedByPlayer(World world, int x, int y, int z, int meta) {
-        if (world.isRemote) {
-            Random rand = world.rand;
-            float modifier = 0.1F;
-            float SCALE = 1;
-            double spawnX = x + 0.5D;
-            double spawnY = y + 0.5D;
-            double spawnZ = z + 0.5D;
+    public void onBlockDestroyedByPlayer(World world, int x, int y, int z, int metadata) {
+        if (!world.isRemote) {
+            return;
+        }
+        Random rand = world.rand;
+        float modifier = 0.1F;
+        float scale = 1;
+        double spawnX = x + 0.5D;
+        double spawnY = y + 0.5D;
+        double spawnZ = z + 0.5D;
 
-            for (int i = 0; i < 100; i++) {
-                float MX = modifier - ((2f * modifier) * rand.nextFloat());
-                float MY = modifier - ((2f * modifier) * rand.nextFloat());
-                float MZ = modifier - ((2f * modifier) * rand.nextFloat());
+        for (int i = 0; i < 100; i++) {
+            float motionX = modifier - ((2f * modifier) * rand.nextFloat());
+            float motionY = modifier - ((2f * modifier) * rand.nextFloat());
+            float motionZ = modifier - ((2f * modifier) * rand.nextFloat());
 
-                {
-                    ParticleCustom particle = new ParticleCustom(
-                            world,
-                            spawnX,
-                            spawnY,
-                            spawnZ,
-                            MX,
-                            MY,
-                            MZ,
-                            SCALE,
-                            false,
-                            1);
-                    particle.red = rand.nextInt(255);
-                    particle.green = rand.nextInt(255);
-                    particle.blue = rand.nextInt(255);
-                    particle.maxAge = rand.nextInt(10);
-                    particle.fadeTime = 20;
-                    particle.fadeLength = 20;
-                    particle.gravity = 0F;
+            {
+                ParticleCustom particle = new ParticleCustom(
+                        world,
+                        spawnX,
+                        spawnY,
+                        spawnZ,
+                        motionX,
+                        motionY,
+                        motionZ,
+                        scale,
+                        false,
+                        1);
+                particle.red = rand.nextInt(255);
+                particle.green = rand.nextInt(255);
+                particle.blue = rand.nextInt(255);
+                particle.maxAge = rand.nextInt(10);
+                particle.fadeTime = 20;
+                particle.fadeLength = 20;
+                particle.gravity = 0F;
 
-                    ParticleHandler.spawnCustomParticle(particle);
-                }
+                ParticleHandler.spawnCustomParticle(particle);
             }
         }
     }
@@ -146,8 +146,7 @@ public class ParticleGenerator extends BlockDE {
     }
 
     @Override
-    public boolean shouldSideBeRendered(IBlockAccess p_149646_1_, int p_149646_2_, int p_149646_3_, int p_149646_4_,
-            int p_149646_5_) {
+    public boolean shouldSideBeRendered(IBlockAccess worldIn, int x, int y, int z, int side) {
         return false;
     }
 
@@ -157,7 +156,7 @@ public class ParticleGenerator extends BlockDE {
     }
 
     @Override
-    public boolean hasTileEntity(int meta) {
+    public boolean hasTileEntity(int metadata) {
         return true;
     }
 
@@ -167,71 +166,46 @@ public class ParticleGenerator extends BlockDE {
     }
 
     private boolean activateEnergyStorageCore(World world, int x, int y, int z, EntityPlayer player) {
-        for (int x1 = x - 11; x1 <= x + 11; x1++) {
-            if (world.getBlock(x1, y, z) == ModBlocks.energyStorageCore) {
-                TileEnergyStorageCore tile = (world.getTileEntity(x1, y, z) != null
-                        && world.getTileEntity(x1, y, z) instanceof TileEnergyStorageCore)
-                                ? (TileEnergyStorageCore) world.getTileEntity(x1, y, z)
-                                : null;
-                if (tile != null && !tile.isOnline()) {
-                    if (player.capabilities.isCreativeMode) {
-                        if (!tile.creativeActivate()) {
-                            if (world.isRemote) player.addChatComponentMessage(
-                                    new ChatComponentTranslation("msg.energyStorageCoreUTA.txt"));
-                            return false;
-                        }
-                    } else {
-                        if (!tile.tryActivate()) {
-                            if (world.isRemote) player.addChatComponentMessage(
-                                    new ChatComponentTranslation("msg.energyStorageCoreUTA.txt"));
-                            return false;
-                        }
-                    }
-                    return true;
-                }
-            }
-        }
-
-        for (int z1 = z - 11; z1 <= z + 11; z1++) {
-            if (world.getBlock(x, y, z1) == ModBlocks.energyStorageCore) {
-                TileEnergyStorageCore tile = (world.getTileEntity(x, y, z1) != null
-                        && world.getTileEntity(x, y, z1) instanceof TileEnergyStorageCore)
-                                ? (TileEnergyStorageCore) world.getTileEntity(x, y, z1)
-                                : null;
-                if (tile != null && !tile.isOnline()) {
-                    if (player.capabilities.isCreativeMode) {
-                        if (!tile.creativeActivate()) {
-                            if (world.isRemote) player.addChatComponentMessage(
-                                    new ChatComponentTranslation("msg.energyStorageCoreUTA.txt"));
-                            return false;
-                        }
-                    } else {
-                        if (!tile.tryActivate()) {
-                            if (world.isRemote) player.addChatComponentMessage(
-                                    new ChatComponentTranslation("msg.energyStorageCoreUTA.txt"));
-                            return false;
-                        }
-                    }
-                    return true;
+        final ForgeDirection[] horizontalDirections = new ForgeDirection[] { ForgeDirection.EAST, ForgeDirection.SOUTH,
+                ForgeDirection.WEST, ForgeDirection.NORTH };
+        for (ForgeDirection direction : horizontalDirections) {
+            for (int distance = 1; distance <= TileEnergyStorageCore.STABILIZER_SEARCH_DISTANCE; distance++) {
+                int coreX = x + direction.offsetX * distance;
+                int coreZ = z + direction.offsetZ * distance;
+                if (world.getBlock(coreX, y, coreZ) == ModBlocks.energyStorageCore) {
+                    return tryActivateEnergyStorageCore(world, coreX, y, coreZ, player);
                 }
             }
         }
         return false;
     }
 
-    @Override
-    public void breakBlock(World world, int x, int y, int z, Block p_149749_5_, int meta) {
-        if (meta == 1) {
-            TileEntity tile = world.getTileEntity(x, y, z);
-            TileParticleGenerator gen = (tile != null && tile instanceof TileParticleGenerator)
-                    ? (TileParticleGenerator) tile
-                    : null;
-            if (gen != null && gen.getMaster() != null) {
-                world.setBlockMetadataWithNotify(x, y, z, 0, 2);
-                // LogHelper.info("deActivate");
-                gen.getMaster().isStructureStillValid(true);
+    private boolean tryActivateEnergyStorageCore(World world, int coreX, int coreY, int coreZ, EntityPlayer player) {
+        TileEntity tile = world.getTileEntity(coreX, coreY, coreZ);
+        if (tile instanceof TileEnergyStorageCore) {
+            TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
+            if (core.tryActivate(player.capabilities.isCreativeMode)) {
+                return true;
+            }
+            if (world.isRemote) {
+                player.addChatComponentMessage(new ChatComponentTranslation("msg.energyStorageCoreUTA.txt"));
             }
         }
-        super.breakBlock(world, x, y, z, p_149749_5_, meta);
+        return false;
+    }
+
+    @Override
+    public void breakBlock(World world, int x, int y, int z, Block blockBroken, int metadata) {
+        if (metadata == 1) {
+            TileEntity tile = world.getTileEntity(x, y, z);
+            if (tile instanceof TileParticleGenerator) {
+                TileParticleGenerator generator = (TileParticleGenerator) tile;
+                if (generator.getMaster() != null) {
+                    world.setBlockMetadataWithNotify(x, y, z, 0, 2);
+                    generator.getMaster().isStructureStillValid(true);
+                }
+            }
+        }
+        super.breakBlock(world, x, y, z, blockBroken, metadata);
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/ParticleGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/ParticleGenerator.java
@@ -3,6 +3,7 @@ package com.brandon3055.draconicevolution.common.blocks;
 import java.util.Random;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
@@ -27,7 +28,7 @@ import cpw.mods.fml.common.network.internal.FMLNetworkHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-public class ParticleGenerator extends BlockDE {
+public class ParticleGenerator extends BlockDE implements ITileEntityProvider {
 
     public static Block instance;
 
@@ -39,8 +40,8 @@ public class ParticleGenerator extends BlockDE {
         ModBlocks.register(this);
     }
 
-    @SideOnly(Side.CLIENT)
     @Override
+    @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister iconRegister) {
         blockIcon = iconRegister.registerIcon(References.RESOURCESPREFIX + "machine_side");
     }
@@ -77,8 +78,8 @@ public class ParticleGenerator extends BlockDE {
         return true;
     }
 
-    @SideOnly(Side.CLIENT)
     @Override
+    @SideOnly(Side.CLIENT)
     public int getRenderType() {
         return -1;
     }
@@ -97,8 +98,8 @@ public class ParticleGenerator extends BlockDE {
         return true;
     }
 
-    @SideOnly(Side.CLIENT)
     @Override
+    @SideOnly(Side.CLIENT)
     public void onBlockDestroyedByPlayer(World world, int x, int y, int z, int metadata) {
         if (!world.isRemote) {
             return;
@@ -161,7 +162,7 @@ public class ParticleGenerator extends BlockDE {
     }
 
     @Override
-    public TileEntity createTileEntity(World world, int metadata) {
+    public TileEntity createNewTileEntity(World world, int metadata) {
         return new TileParticleGenerator();
     }
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/ParticleGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/ParticleGenerator.java
@@ -54,11 +54,10 @@ public class ParticleGenerator extends BlockDE implements ITileEntityProvider {
         }
         if (player.getHeldItem() != null && player.getHeldItem().getItem() == Items.paper) {
             TileEntity tile = world.getTileEntity(x, y, z);
-            if (tile instanceof TileParticleGenerator) {
-                TileParticleGenerator generator = (TileParticleGenerator) tile;
+            if (tile instanceof TileParticleGenerator particleGenerator) {
                 ItemStack stack = player.getHeldItem();
                 if (stack.hasTagCompound() && stack.getTagCompound().hasKey("particles_enabled")) {
-                    generator.setBlockNBT(stack.getTagCompound());
+                    particleGenerator.setBlockNBT(stack.getTagCompound());
                     return true;
                 }
             }
@@ -69,8 +68,8 @@ public class ParticleGenerator extends BlockDE implements ITileEntityProvider {
                 return true;
             }
             TileEntity tile = world.getTileEntity(x, y, z);
-            if (tile instanceof TileParticleGenerator) {
-                ((TileParticleGenerator) tile).toggleInverted();
+            if (tile instanceof TileParticleGenerator particleGenerator) {
+                particleGenerator.toggleInverted();
             }
         } else {
             FMLNetworkHandler.openGui(player, DraconicEvolution.instance, GuiHandler.GUIID_PARTICLEGEN, world, x, y, z);
@@ -87,8 +86,8 @@ public class ParticleGenerator extends BlockDE implements ITileEntityProvider {
     @Override
     public void onNeighborBlockChange(final World world, final int x, final int y, final int z, final Block block) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileParticleGenerator) {
-            ((TileParticleGenerator) tile).hasRedstoneSignal = world.isBlockIndirectlyGettingPowered(x, y, z);
+        if (tile instanceof TileParticleGenerator particleGenerator) {
+            particleGenerator.hasRedstoneSignal = world.isBlockIndirectlyGettingPowered(x, y, z);
             world.markBlockForUpdate(x, y, z);
         }
     }
@@ -183,8 +182,7 @@ public class ParticleGenerator extends BlockDE implements ITileEntityProvider {
 
     private boolean tryActivateEnergyStorageCore(World world, int coreX, int coreY, int coreZ, EntityPlayer player) {
         TileEntity tile = world.getTileEntity(coreX, coreY, coreZ);
-        if (tile instanceof TileEnergyStorageCore) {
-            TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
+        if (tile instanceof TileEnergyStorageCore core) {
             if (core.tryActivate(player.capabilities.isCreativeMode)) {
                 return true;
             }
@@ -199,11 +197,10 @@ public class ParticleGenerator extends BlockDE implements ITileEntityProvider {
     public void breakBlock(World world, int x, int y, int z, Block blockBroken, int metadata) {
         if (metadata == 1) {
             TileEntity tile = world.getTileEntity(x, y, z);
-            if (tile instanceof TileParticleGenerator) {
-                TileParticleGenerator generator = (TileParticleGenerator) tile;
-                if (generator.getMaster() != null) {
+            if (tile instanceof TileParticleGenerator particleGenerator) {
+                if (particleGenerator.getMaster() != null) {
                     world.setBlockMetadataWithNotify(x, y, z, 0, 2);
-                    generator.getMaster().validateStructure(true);
+                    particleGenerator.getMaster().validateStructure(true);
                 }
             }
         }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetector.java
@@ -1,6 +1,7 @@
 package com.brandon3055.draconicevolution.common.blocks.machine;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
@@ -18,11 +19,18 @@ import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.lib.Strings;
 import com.brandon3055.draconicevolution.common.tileentities.TilePlayerDetector;
 
-public class PlayerDetector extends BlockDE {
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
+public class PlayerDetector extends BlockDE implements ITileEntityProvider {
+
+    @SideOnly(Side.CLIENT)
     IIcon side_inactive;
+    @SideOnly(Side.CLIENT)
     IIcon side_active;
+    @SideOnly(Side.CLIENT)
     IIcon top;
+    @SideOnly(Side.CLIENT)
     IIcon bottom;
 
     public PlayerDetector() {
@@ -33,6 +41,7 @@ public class PlayerDetector extends BlockDE {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister iconRegister) {
         side_inactive = iconRegister.registerIcon(References.RESOURCESPREFIX + "player_detector_side_inactive");
         side_active = iconRegister.registerIcon(References.RESOURCESPREFIX + "player_detector_side_active");
@@ -40,28 +49,39 @@ public class PlayerDetector extends BlockDE {
         bottom = iconRegister.registerIcon(References.RESOURCESPREFIX + "machine_side");
     }
 
+    @Override
+    @SideOnly(Side.CLIENT)
     public IIcon getIcon(IBlockAccess world, int x, int y, int z, int side) {
+        if (side == 0) {
+            return bottom;
+        }
+        if (side == 1) {
+            return top;
+        }
         IIcon side_icon;
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile != null && tile instanceof TilePlayerDetector && ((TilePlayerDetector) tile).output)
+        if (tile instanceof TilePlayerDetector && ((TilePlayerDetector) tile).shouldOutput()) {
             side_icon = side_active;
-        else side_icon = side_inactive;
-
-        if (side == 0) return bottom;
-        else if (side == 1) return top;
-        else return side_icon;
+        } else {
+            side_icon = side_inactive;
+        }
+        return side_icon;
     }
 
     @Override
-    public IIcon getIcon(int side, int meta) {
-        if (side == 0) return bottom;
-        else if (side == 1) return top;
-        else return side_active;
+    @SideOnly(Side.CLIENT)
+    public IIcon getIcon(int side, int metadata) {
+        if (side == 0) {
+            return bottom;
+        }
+        if (side == 1) {
+            return top;
+        }
+        return side_active;
     }
 
     @Override
-    public boolean isBlockSolid(IBlockAccess p_149747_1_, int p_149747_2_, int p_149747_3_, int p_149747_4_,
-            int p_149747_5_) {
+    public boolean isBlockSolid(IBlockAccess world, int x, int y, int z, int side) {
         return true;
     }
 
@@ -71,19 +91,18 @@ public class PlayerDetector extends BlockDE {
     }
 
     @Override
-    public boolean hasTileEntity(int meta) {
+    public boolean hasTileEntity(int metadata) {
         return true;
     }
 
     @Override
-    public TileEntity createTileEntity(World world, int metadata) {
+    public TileEntity createNewTileEntity(World world, int metadata) {
         return new TilePlayerDetector();
     }
 
     @Override
     public boolean canConnectRedstone(IBlockAccess world, int x, int y, int z, int side) {
-        if (side == 0 || side == 1) return false;
-        else return true;
+        return side >= 0;
     }
 
     @Override
@@ -92,27 +111,22 @@ public class PlayerDetector extends BlockDE {
     }
 
     @Override
-    public int isProvidingWeakPower(IBlockAccess world, int x, int y, int z, int meta) {
-        TileEntity te = world.getTileEntity(x, y, z);
-        TilePlayerDetector detector = (te != null && te instanceof TilePlayerDetector) ? (TilePlayerDetector) te : null;
-        if (detector != null) return detector.output ? 15 : 0;
-        else return 0;
+    public int isProvidingWeakPower(IBlockAccess world, int x, int y, int z, int side) {
+        return isProvidingStrongPower(world, x, y, z, side);
     }
 
     @Override
-    public int isProvidingStrongPower(IBlockAccess world, int x, int y, int z, int meta) {
-        TileEntity te = world.getTileEntity(x, y, z);
-        TilePlayerDetector detector = (te != null && te instanceof TilePlayerDetector) ? (TilePlayerDetector) te : null;
-        if (detector != null) return detector.output ? 15 : 0;
-        else return 0;
+    public int isProvidingStrongPower(IBlockAccess world, int x, int y, int z, int side) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        return tile instanceof TilePlayerDetector && ((TilePlayerDetector) tile).shouldOutput() ? 15 : 0;
     }
 
     @Override
-    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float p_149727_7_,
-            float p_149727_8_, float p_149727_9_) {
-        TileEntity te = world.getTileEntity(x, y, z);
-        TilePlayerDetector detector = (te != null && te instanceof TilePlayerDetector) ? (TilePlayerDetector) te : null;
-        if (detector != null) {
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float subX,
+            float subY, float subZ) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TilePlayerDetector) {
+            TilePlayerDetector detector = (TilePlayerDetector) tile;
             int range = detector.getRange();
 
             if (player.isSneaking()) {
@@ -121,25 +135,27 @@ public class PlayerDetector extends BlockDE {
                 range++;
             }
 
-            if (range > 10) range = 1;
-            if (range < 1) range = 10;
             detector.setRange(range);
 
-            if (world.isRemote) player.addChatMessage(
-                    new ChatComponentTranslation("msg.range.txt").appendSibling(new ChatComponentText(" " + range)));
+            if (world.isRemote) {
+                player.addChatMessage(
+                        new ChatComponentTranslation("msg.range.txt")
+                                .appendSibling(new ChatComponentText(" " + detector.getRange())));
+            }
         }
         return true;
     }
 
     @Override
-    public void breakBlock(World world, int x, int y, int z, Block block, int meta) {
-        super.breakBlock(world, x, y, z, block, meta);
-
-        world.notifyBlocksOfNeighborChange(x - 1, y, z, world.getBlock(x, y, z));
-        world.notifyBlocksOfNeighborChange(x + 1, y, z, world.getBlock(x, y, z));
-        world.notifyBlocksOfNeighborChange(x, y - 1, z, world.getBlock(x, y, z));
-        world.notifyBlocksOfNeighborChange(x, y + 1, z, world.getBlock(x, y, z));
-        world.notifyBlocksOfNeighborChange(x, y, z - 1, world.getBlock(x, y, z));
-        world.notifyBlocksOfNeighborChange(x, y, z + 1, world.getBlock(x, y, z));
+    public void breakBlock(World world, int x, int y, int z, Block blockBroken, int metadata) {
+        super.breakBlock(world, x, y, z, blockBroken, metadata);
+        world.notifyBlocksOfNeighborChange(x, y, z, blockBroken);
+        for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
+            world.notifyBlocksOfNeighborChange(
+                    x + direction.offsetX,
+                    y + direction.offsetY,
+                    z + direction.offsetZ,
+                    blockBroken);
+        }
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetector.java
@@ -149,7 +149,6 @@ public class PlayerDetector extends BlockDE implements ITileEntityProvider {
     @Override
     public void breakBlock(World world, int x, int y, int z, Block blockBroken, int metadata) {
         super.breakBlock(world, x, y, z, blockBroken, metadata);
-        world.notifyBlocksOfNeighborChange(x, y, z, blockBroken);
         for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
             world.notifyBlocksOfNeighborChange(
                     x + direction.offsetX,

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetector.java
@@ -154,7 +154,8 @@ public class PlayerDetector extends BlockDE implements ITileEntityProvider {
                     x + direction.offsetX,
                     y + direction.offsetY,
                     z + direction.offsetZ,
-                    blockBroken);
+                    blockBroken,
+                    direction.getOpposite().ordinal());
         }
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetector.java
@@ -60,7 +60,7 @@ public class PlayerDetector extends BlockDE implements ITileEntityProvider {
         }
         IIcon side_icon;
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TilePlayerDetector && ((TilePlayerDetector) tile).shouldOutput()) {
+        if (tile instanceof TilePlayerDetector detector && detector.shouldOutput()) {
             side_icon = side_active;
         } else {
             side_icon = side_inactive;
@@ -118,15 +118,14 @@ public class PlayerDetector extends BlockDE implements ITileEntityProvider {
     @Override
     public int isProvidingStrongPower(IBlockAccess world, int x, int y, int z, int side) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        return tile instanceof TilePlayerDetector && ((TilePlayerDetector) tile).shouldOutput() ? 15 : 0;
+        return tile instanceof TilePlayerDetector detector && detector.shouldOutput() ? 15 : 0;
     }
 
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float subX,
             float subY, float subZ) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TilePlayerDetector) {
-            TilePlayerDetector detector = (TilePlayerDetector) tile;
+        if (tile instanceof TilePlayerDetector detector) {
             int range = detector.getRange();
 
             if (player.isSneaking()) {

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetectorAdvanced.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetectorAdvanced.java
@@ -167,7 +167,6 @@ public class PlayerDetectorAdvanced extends BlockCustomDrop {
     @Override
     public void breakBlock(World world, int x, int y, int z, Block blockBroken, int metadata) {
         super.breakBlock(world, x, y, z, blockBroken, metadata);
-        world.notifyBlocksOfNeighborChange(x, y, z, blockBroken);
         for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
             world.notifyBlocksOfNeighborChange(
                     x + direction.offsetX,

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetectorAdvanced.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetectorAdvanced.java
@@ -69,8 +69,7 @@ public class PlayerDetectorAdvanced extends BlockCustomDrop {
     @SideOnly(Side.CLIENT)
     public IIcon getIcon(IBlockAccess world, int x, int y, int z, int side) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TilePlayerDetectorAdvanced) {
-            TilePlayerDetectorAdvanced detector = (TilePlayerDetectorAdvanced) tile;
+        if (tile instanceof TilePlayerDetectorAdvanced detector) {
             if (detector.getStackInSlot(0) != null) {
                 ItemStack stack = detector.getStackInSlot(0);
                 Block block = Block.getBlockFromItem(stack.getItem());
@@ -135,8 +134,7 @@ public class PlayerDetectorAdvanced extends BlockCustomDrop {
     @Override
     public int isProvidingStrongPower(IBlockAccess world, int x, int y, int z, int side) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        return tile instanceof TilePlayerDetectorAdvanced && ((TilePlayerDetectorAdvanced) tile).shouldOutput() ? 15
-                : 0;
+        return tile instanceof TilePlayerDetectorAdvanced detector && detector.shouldOutput() ? 15 : 0;
     }
 
     @Override
@@ -155,8 +153,8 @@ public class PlayerDetectorAdvanced extends BlockCustomDrop {
     @Override
     public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z, EntityPlayer player) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TilePlayerDetectorAdvanced) {
-            ItemStack stackInSlot = ((TilePlayerDetectorAdvanced) tile).getStackInSlot(0);
+        if (tile instanceof TilePlayerDetectorAdvanced detector) {
+            ItemStack stackInSlot = detector.getStackInSlot(0);
             if (stackInSlot != null) {
                 return stackInSlot;
             }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetectorAdvanced.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetectorAdvanced.java
@@ -172,7 +172,8 @@ public class PlayerDetectorAdvanced extends BlockCustomDrop {
                     x + direction.offsetX,
                     y + direction.offsetY,
                     z + direction.offsetZ,
-                    blockBroken);
+                    blockBroken,
+                    direction.getOpposite().ordinal());
         }
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetectorAdvanced.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/machine/PlayerDetectorAdvanced.java
@@ -28,9 +28,13 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 public class PlayerDetectorAdvanced extends BlockCustomDrop {
 
+    @SideOnly(Side.CLIENT)
     IIcon side_inactive;
+    @SideOnly(Side.CLIENT)
     IIcon side_active;
+    @SideOnly(Side.CLIENT)
     IIcon top;
+    @SideOnly(Side.CLIENT)
     IIcon bottom;
 
     public PlayerDetectorAdvanced() {
@@ -41,8 +45,8 @@ public class PlayerDetectorAdvanced extends BlockCustomDrop {
         ModBlocks.register(this);
     }
 
-    @SideOnly(Side.CLIENT)
     @Override
+    @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister iconRegister) {
         side_inactive = iconRegister
                 .registerIcon(References.RESOURCESPREFIX + "advanced_player_detector_side_inactive");
@@ -52,8 +56,7 @@ public class PlayerDetectorAdvanced extends BlockCustomDrop {
     }
 
     @Override
-    public boolean isBlockSolid(IBlockAccess p_149747_1_, int p_149747_2_, int p_149747_3_, int p_149747_4_,
-            int p_149747_5_) {
+    public boolean isBlockSolid(IBlockAccess world, int x, int y, int z, int side) {
         return true;
     }
 
@@ -62,47 +65,51 @@ public class PlayerDetectorAdvanced extends BlockCustomDrop {
         return true;
     }
 
-    @SideOnly(Side.CLIENT)
     @Override
+    @SideOnly(Side.CLIENT)
     public IIcon getIcon(IBlockAccess world, int x, int y, int z, int side) {
-        IIcon side_icon;
-
         TileEntity tile = world.getTileEntity(x, y, z);
-        TilePlayerDetectorAdvanced detector = (tile != null && tile instanceof TilePlayerDetectorAdvanced)
-                ? (TilePlayerDetectorAdvanced) tile
-                : null;
-        if (detector != null && detector.getStackInSlot(0) != null) {
-            ItemStack stack = detector.getStackInSlot(0);
-            Block block = Block.getBlockFromItem(stack.getItem());
-            if (block != null && block.renderAsNormalBlock()) return block.getIcon(side, stack.getItemDamage());
-        } else {
-            if (detector != null && detector.output) side_icon = side_active;
-            else side_icon = side_inactive;
-
-            if (side == 0) return bottom;
-            else if (side == 1) return top;
-            else return side_icon;
+        if (tile instanceof TilePlayerDetectorAdvanced) {
+            TilePlayerDetectorAdvanced detector = (TilePlayerDetectorAdvanced) tile;
+            if (detector.getStackInSlot(0) != null) {
+                ItemStack stack = detector.getStackInSlot(0);
+                Block block = Block.getBlockFromItem(stack.getItem());
+                if (block != null && block.renderAsNormalBlock()) {
+                    return block.getIcon(side, stack.getItemDamage());
+                }
+            } else {
+                if (side == 0) {
+                    return bottom;
+                }
+                if (side == 1) {
+                    return top;
+                }
+                return detector.shouldOutput() ? side_active : side_inactive;
+            }
         }
-
-        return null;
+        return side_active;
     }
 
+    @Override
     @SideOnly(Side.CLIENT)
-    @Override
-    public IIcon getIcon(int side, int meta) {
-        if (side == 0) return bottom;
-        else if (side == 1) return top;
-        else return side_active;
+    public IIcon getIcon(int side, int metadata) {
+        if (side == 0) {
+            return bottom;
+        }
+        if (side == 1) {
+            return top;
+        }
+        return side_active;
     }
 
     @Override
-    public TileEntity createNewTileEntity(World var1, int var2) {
+    public TileEntity createNewTileEntity(World world, int metadata) {
         return new TilePlayerDetectorAdvanced();
     }
 
     @Override
-    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int p_149727_6_,
-            float p_149727_7_, float p_149727_8_, float p_149727_9_) {
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float subX,
+            float subY, float subZ) {
         if (!world.isRemote) {
             FMLNetworkHandler
                     .openGui(player, DraconicEvolution.instance, GuiHandler.GUIID_PLAYERDETECTOR, world, x, y, z);
@@ -112,8 +119,7 @@ public class PlayerDetectorAdvanced extends BlockCustomDrop {
 
     @Override
     public boolean canConnectRedstone(IBlockAccess world, int x, int y, int z, int side) {
-        if (side == 0 || side == 1) return false;
-        else return true;
+        return side >= 0;
     }
 
     @Override
@@ -122,25 +128,15 @@ public class PlayerDetectorAdvanced extends BlockCustomDrop {
     }
 
     @Override
-    public int isProvidingWeakPower(IBlockAccess world, int x, int y, int z, int meta) {
-        TileEntity te = world.getTileEntity(x, y, z);
-        TilePlayerDetectorAdvanced detector = (te != null && te instanceof TilePlayerDetectorAdvanced)
-                ? (TilePlayerDetectorAdvanced) te
-                : null;
-        if (detector != null) if (!detector.outputInverted) return detector.output ? 15 : 0;
-        else return detector.output ? 0 : 15;
-        else return 0;
+    public int isProvidingWeakPower(IBlockAccess world, int x, int y, int z, int side) {
+        return isProvidingStrongPower(world, x, y, z, side);
     }
 
     @Override
-    public int isProvidingStrongPower(IBlockAccess world, int x, int y, int z, int meta) {
-        TileEntity te = world.getTileEntity(x, y, z);
-        TilePlayerDetectorAdvanced detector = (te != null && te instanceof TilePlayerDetectorAdvanced)
-                ? (TilePlayerDetectorAdvanced) te
-                : null;
-        if (detector != null) if (!detector.outputInverted) return detector.output ? 15 : 0;
-        else return detector.output ? 0 : 15;
-        else return 0;
+    public int isProvidingStrongPower(IBlockAccess world, int x, int y, int z, int side) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        return tile instanceof TilePlayerDetectorAdvanced && ((TilePlayerDetectorAdvanced) tile).shouldOutput() ? 15
+                : 0;
     }
 
     @Override
@@ -154,17 +150,30 @@ public class PlayerDetectorAdvanced extends BlockCustomDrop {
     }
 
     @Override
-    protected void getCustomTileEntityDrops(TileEntity te, List<ItemStack> droppes) {}
+    protected void getCustomTileEntityDrops(TileEntity tile, List<ItemStack> drops) {}
 
     @Override
-    public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z) {
-        TileEntity te = world.getTileEntity(x, y, z);
-        TilePlayerDetectorAdvanced detector = (te != null && te instanceof TilePlayerDetectorAdvanced)
-                ? (TilePlayerDetectorAdvanced) te
-                : null;
-        if (detector != null && detector.getStackInSlot(0) != null) {
-            return detector.getStackInSlot(0);
+    public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z, EntityPlayer player) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TilePlayerDetectorAdvanced) {
+            ItemStack stackInSlot = ((TilePlayerDetectorAdvanced) tile).getStackInSlot(0);
+            if (stackInSlot != null) {
+                return stackInSlot;
+            }
         }
-        return super.getPickBlock(target, world, x, y, z);
+        return super.getPickBlock(target, world, x, y, z, player);
+    }
+
+    @Override
+    public void breakBlock(World world, int x, int y, int z, Block blockBroken, int metadata) {
+        super.breakBlock(world, x, y, z, blockBroken, metadata);
+        world.notifyBlocksOfNeighborChange(x, y, z, blockBroken);
+        for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
+            world.notifyBlocksOfNeighborChange(
+                    x + direction.offsetX,
+                    y + direction.offsetY,
+                    z + direction.offsetZ,
+                    blockBroken);
+        }
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/DislocatorReceptacle.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/DislocatorReceptacle.java
@@ -22,11 +22,15 @@ import com.brandon3055.draconicevolution.common.items.tools.TeleporterMKI;
 import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.TileDislocatorReceptacle;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 /**
  * Created by Brandon on 19/5/2015.
  */
 public class DislocatorReceptacle extends BlockCustomDrop implements ITileEntityProvider {
 
+    @SideOnly(Side.CLIENT)
     IIcon textureInactive;
 
     public DislocatorReceptacle() {
@@ -41,6 +45,7 @@ public class DislocatorReceptacle extends BlockCustomDrop implements ITileEntity
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister iconRegister) {
         textureInactive = iconRegister
                 .registerIcon(References.RESOURCESPREFIX + "animated/dislocatorReceptacle_inactive");
@@ -48,23 +53,21 @@ public class DislocatorReceptacle extends BlockCustomDrop implements ITileEntity
     }
 
     @Override
-    public IIcon getIcon(IBlockAccess access, int x, int y, int z, int side) {
-        TileDislocatorReceptacle tile = access.getTileEntity(x, y, z) instanceof TileDislocatorReceptacle
-                ? (TileDislocatorReceptacle) access.getTileEntity(x, y, z)
-                : null;
-        if (tile != null) return tile.isActive ? blockIcon : textureInactive;
+    @SideOnly(Side.CLIENT)
+    public IIcon getIcon(IBlockAccess world, int x, int y, int z, int side) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileDislocatorReceptacle) {
+            return ((TileDislocatorReceptacle) tile).isActive ? blockIcon : textureInactive;
+        }
         return blockIcon;
     }
 
     @Override
     public void updateTick(World world, int x, int y, int z, Random random) {
-        TileDislocatorReceptacle tile = (TileDislocatorReceptacle) world.getTileEntity(x, y, z);
-        if (tile != null) tile.updateState();
-    }
-
-    @Override
-    public IIcon getIcon(int p_149691_1_, int meta) {
-        return blockIcon;
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileDislocatorReceptacle) {
+            ((TileDislocatorReceptacle) tile).updateState();
+        }
     }
 
     @Override
@@ -73,43 +76,44 @@ public class DislocatorReceptacle extends BlockCustomDrop implements ITileEntity
     }
 
     @Override
+    public TileEntity createNewTileEntity(World world, int metadata) {
+        return new TileDislocatorReceptacle();
+    }
+
+    @Override
     public boolean canEntityDestroy(IBlockAccess world, int x, int y, int z, Entity entity) {
         return false;
     }
 
     @Override
-    public TileEntity createNewTileEntity(World world, int i) {
-        return new TileDislocatorReceptacle();
-    }
-
-    @Override
-    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float p_149727_7_,
-            float p_149727_8_, float p_149727_9_) {
-        if (world.isRemote) return true;
-        TileDislocatorReceptacle tile = (TileDislocatorReceptacle) world.getTileEntity(x, y, z);
-        if (tile == null) return false;
-
-        if (tile.getStackInSlot(0) != null) {
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float subX,
+            float subY, float subZ) {
+        if (world.isRemote) {
+            return true;
+        }
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (!(tile instanceof TileDislocatorReceptacle)) {
+            return false;
+        }
+        TileDislocatorReceptacle receptacle = (TileDislocatorReceptacle) tile;
+        ItemStack stackInSlot = receptacle.getStackInSlot(0);
+        if (stackInSlot != null) {
             if (player.getHeldItem() == null) {
-                player.inventory.setInventorySlotContents(player.inventory.currentItem, tile.getStackInSlot(0));
-                tile.setInventorySlotContents(0, null);
+                player.inventory.setInventorySlotContents(player.inventory.currentItem, stackInSlot);
             } else {
-                world.spawnEntityInWorld(
-                        new EntityItem(world, player.posX, player.posY, player.posZ, tile.getStackInSlot(0)));
-                tile.setInventorySlotContents(0, null);
+                world.spawnEntityInWorld(new EntityItem(world, player.posX, player.posY, player.posZ, stackInSlot));
             }
+            receptacle.setInventorySlotContents(0, null);
             world.markBlockForUpdate(x, y, z);
             world.notifyBlockChange(x, y, z, this);
-
         } else {
             ItemStack stack = player.getHeldItem();
             if (stack != null && stack.getItem() instanceof TeleporterMKI
                     && ((TeleporterMKI) stack.getItem()).getLocation(stack) != null) {
-                tile.setInventorySlotContents(0, player.getHeldItem());
+                receptacle.setInventorySlotContents(0, player.getHeldItem());
                 player.destroyCurrentEquippedItem();
             }
         }
-
         return true;
     }
 
@@ -120,8 +124,13 @@ public class DislocatorReceptacle extends BlockCustomDrop implements ITileEntity
 
     @Override
     public int getComparatorInputOverride(World world, int x, int y, int z, int p_149736_5_) {
-        TileDislocatorReceptacle tile = (TileDislocatorReceptacle) world.getTileEntity(x, y, z);
-        return tile == null ? 0 : tile.getStackInSlot(0) != null ? 15 : 0;
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileDislocatorReceptacle) {
+            if (((TileDislocatorReceptacle) tile).getStackInSlot(0) != null) {
+                return 15;
+            }
+        }
+        return 0;
     }
 
     @Override
@@ -135,5 +144,5 @@ public class DislocatorReceptacle extends BlockCustomDrop implements ITileEntity
     }
 
     @Override
-    protected void getCustomTileEntityDrops(TileEntity te, List<ItemStack> droppes) {}
+    protected void getCustomTileEntityDrops(TileEntity tile, List<ItemStack> drops) {}
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/DislocatorReceptacle.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/DislocatorReceptacle.java
@@ -56,8 +56,8 @@ public class DislocatorReceptacle extends BlockCustomDrop implements ITileEntity
     @SideOnly(Side.CLIENT)
     public IIcon getIcon(IBlockAccess world, int x, int y, int z, int side) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileDislocatorReceptacle) {
-            return ((TileDislocatorReceptacle) tile).isActive ? blockIcon : textureInactive;
+        if (tile instanceof TileDislocatorReceptacle receptacle) {
+            return receptacle.isActive ? blockIcon : textureInactive;
         }
         return blockIcon;
     }
@@ -65,8 +65,8 @@ public class DislocatorReceptacle extends BlockCustomDrop implements ITileEntity
     @Override
     public void updateTick(World world, int x, int y, int z, Random random) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileDislocatorReceptacle) {
-            ((TileDislocatorReceptacle) tile).updateState();
+        if (tile instanceof TileDislocatorReceptacle receptacle) {
+            receptacle.updateState();
         }
     }
 
@@ -92,10 +92,9 @@ public class DislocatorReceptacle extends BlockCustomDrop implements ITileEntity
             return true;
         }
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (!(tile instanceof TileDislocatorReceptacle)) {
+        if (!(tile instanceof TileDislocatorReceptacle receptacle)) {
             return false;
         }
-        TileDislocatorReceptacle receptacle = (TileDislocatorReceptacle) tile;
         ItemStack stackInSlot = receptacle.getStackInSlot(0);
         if (stackInSlot != null) {
             if (player.getHeldItem() == null) {
@@ -108,8 +107,8 @@ public class DislocatorReceptacle extends BlockCustomDrop implements ITileEntity
             world.notifyBlockChange(x, y, z, this);
         } else {
             ItemStack stack = player.getHeldItem();
-            if (stack != null && stack.getItem() instanceof TeleporterMKI
-                    && ((TeleporterMKI) stack.getItem()).getLocation(stack) != null) {
+            if (stack != null && stack.getItem() instanceof TeleporterMKI teleporter
+                    && teleporter.getLocation(stack) != null) {
                 receptacle.setInventorySlotContents(0, player.getHeldItem());
                 player.destroyCurrentEquippedItem();
             }
@@ -125,8 +124,8 @@ public class DislocatorReceptacle extends BlockCustomDrop implements ITileEntity
     @Override
     public int getComparatorInputOverride(World world, int x, int y, int z, int p_149736_5_) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileDislocatorReceptacle) {
-            if (((TileDislocatorReceptacle) tile).getStackInSlot(0) != null) {
+        if (tile instanceof TileDislocatorReceptacle receptacle) {
+            if (receptacle.getStackInSlot(0) != null) {
                 return 15;
             }
         }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyPylon.java
@@ -72,7 +72,7 @@ public class EnergyPylon extends BlockDE { // todo fix sphere renderer
         if (metadata == 1 && side == 1 || metadata == 2 && side == 0) return icon_active_face;
         TileEntity tile = world.getTileEntity(x, y, z);
         if (tile instanceof TileEnergyPylon) {
-            return ((TileEnergyPylon) tile).reciveEnergy ? icon_input : icon_output;
+            return ((TileEnergyPylon) tile).isReceivingEnergy ? icon_input : icon_output;
         }
         return icon_input;
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyPylon.java
@@ -1,6 +1,7 @@
 package com.brandon3055.draconicevolution.common.blocks.multiblock;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
@@ -23,7 +24,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 /**
  * Created by Brandon on 28/07/2014.
  */
-public class EnergyPylon extends BlockDE { // todo fix sphere renderer
+public class EnergyPylon extends BlockDE implements ITileEntityProvider {
 
     @SideOnly(Side.CLIENT)
     public IIcon icon_active_face;
@@ -47,7 +48,7 @@ public class EnergyPylon extends BlockDE { // todo fix sphere renderer
     }
 
     @Override
-    public TileEntity createTileEntity(World world, int metadata) {
+    public TileEntity createNewTileEntity(World world, int metadata) {
         return metadata == 1 || metadata == 2 ? new TileEnergyPylon() : null;
     }
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyPylon.java
@@ -83,7 +83,6 @@ public class EnergyPylon extends BlockDE { // todo fix sphere renderer
     }
 
     private void updateBlockState(World world, int x, int y, int z) {
-        TileEntity tile = world.getTileEntity(x, y, z);
         int metadata = world.getBlockMetadata(x, y, z);
         if (metadata == 0) {
             if (world.getBlock(x, y + 1, z) == Blocks.glass) {
@@ -96,12 +95,14 @@ public class EnergyPylon extends BlockDE { // todo fix sphere renderer
                 world.setBlock(x, y - 1, z, ModBlocks.invisibleMultiblock, 2, 2);
             }
         } else {
+            TileEntity tile = world.getTileEntity(x, y, z);
             if (!(tile instanceof TileEnergyPylon) || (metadata == 1 && isGlassMissing(world, x, y + 1, z))
                     || (metadata == 2 && isGlassMissing(world, x, y - 1, z))) {
                 metadata = 0;
                 world.setBlockMetadataWithNotify(x, y, z, metadata, 2);
             }
         }
+        TileEntity tile = world.getTileEntity(x, y, z);
         if (tile instanceof TileEnergyPylon) {
             ((TileEnergyPylon) tile).onActivated();
             if (metadata == 0) {

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyPylon.java
@@ -78,7 +78,7 @@ public class EnergyPylon extends BlockDE { // todo fix sphere renderer
     }
 
     @Override
-    public void onNeighborBlockChange(World world, int x, int y, int z, Block p_149695_5_) {
+    public void onNeighborBlockChange(World world, int x, int y, int z, Block neighbor) {
         updateBlockState(world, x, y, z);
     }
 
@@ -115,17 +115,17 @@ public class EnergyPylon extends BlockDE { // todo fix sphere renderer
     }
 
     @Override
-    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int p_149727_6_,
-            float p_149727_7_, float p_149727_8_, float p_149727_9_) {
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float subX,
+            float subY, float subZ) {
         int metadata = world.getBlockMetadata(x, y, z);
         if (metadata == 0) return false;
         TileEntity tile = world.getTileEntity(x, y, z);
         if (tile instanceof TileEnergyPylon) {
-            TileEnergyPylon energyPylon = (TileEnergyPylon) tile;
+            TileEnergyPylon pylon = (TileEnergyPylon) tile;
             if (player.isSneaking()) {
-                energyPylon.nextCore();
+                pylon.nextCore();
             } else {
-                energyPylon.onActivated();
+                pylon.onActivated();
             }
             return true;
         }
@@ -133,7 +133,7 @@ public class EnergyPylon extends BlockDE { // todo fix sphere renderer
     }
 
     @Override
-    public void onPostBlockPlaced(World world, int x, int y, int z, int p_149714_5_) {
+    public void onPostBlockPlaced(World world, int x, int y, int z, int metadata) {
         updateBlockState(world, x, y, z);
     }
 
@@ -143,11 +143,11 @@ public class EnergyPylon extends BlockDE { // todo fix sphere renderer
     }
 
     @Override
-    public int getComparatorInputOverride(World world, int x, int y, int z, int meta) {
+    public int getComparatorInputOverride(World world, int x, int y, int z, int side) {
         TileEntity tile = world.getTileEntity(x, y, z);
         if (tile instanceof TileEnergyPylon) {
-            TileEnergyPylon energyPylon = (TileEnergyPylon) tile;
-            return (int) (energyPylon.getEnergyStored() / energyPylon.getMaxEnergyStored() * 15D);
+            TileEnergyPylon pylon = (TileEnergyPylon) tile;
+            return (int) (pylon.getEnergyStored() / pylon.getMaxEnergyStored() * 15D);
         }
         return 0;
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyPylon.java
@@ -72,8 +72,8 @@ public class EnergyPylon extends BlockDE implements ITileEntityProvider {
         int metadata = world.getBlockMetadata(x, y, z);
         if (metadata == 1 && side == 1 || metadata == 2 && side == 0) return icon_active_face;
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileEnergyPylon) {
-            return ((TileEnergyPylon) tile).isReceivingEnergy ? icon_input : icon_output;
+        if (tile instanceof TileEnergyPylon pylon) {
+            return pylon.isReceivingEnergy ? icon_input : icon_output;
         }
         return icon_input;
     }
@@ -122,8 +122,7 @@ public class EnergyPylon extends BlockDE implements ITileEntityProvider {
         int metadata = world.getBlockMetadata(x, y, z);
         if (metadata == 0) return false;
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileEnergyPylon) {
-            TileEnergyPylon pylon = (TileEnergyPylon) tile;
+        if (tile instanceof TileEnergyPylon pylon) {
             if (player.isSneaking()) {
                 pylon.nextCore();
             } else {
@@ -147,8 +146,7 @@ public class EnergyPylon extends BlockDE implements ITileEntityProvider {
     @Override
     public int getComparatorInputOverride(World world, int x, int y, int z, int side) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileEnergyPylon) {
-            TileEnergyPylon pylon = (TileEnergyPylon) tile;
+        if (tile instanceof TileEnergyPylon pylon) {
             return (int) (pylon.getEnergyStored() / pylon.getMaxEnergyStored() * 15D);
         }
         return 0;

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyStorageCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyStorageCore.java
@@ -103,7 +103,7 @@ public class EnergyStorageCore extends BlockDE implements IHudDisplayBlock {
         if (tile instanceof TileEnergyStorageCore) {
             TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
             if (core.isOnline() && core.getTier() == 0) {
-                core.isStructureStillValid(false);
+                core.validateStructure(false);
             }
         }
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyStorageCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyStorageCore.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
@@ -29,7 +30,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 /**
  * Created by Brandon on 25/07/2014.
  */
-public class EnergyStorageCore extends BlockDE implements IHudDisplayBlock {
+public class EnergyStorageCore extends BlockDE implements IHudDisplayBlock, ITileEntityProvider {
 
     public EnergyStorageCore() {
         super(Material.iron);
@@ -62,7 +63,7 @@ public class EnergyStorageCore extends BlockDE implements IHudDisplayBlock {
     }
 
     @Override
-    public TileEntity createTileEntity(World world, int metadata) {
+    public TileEntity createNewTileEntity(World world, int metadata) {
         return new TileEnergyStorageCore();
     }
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyStorageCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyStorageCore.java
@@ -72,11 +72,10 @@ public class EnergyStorageCore extends BlockDE implements IHudDisplayBlock, ITil
             float subY, float subZ) {
         if (!world.isRemote) {
             TileEntity tile = world.getTileEntity(x, y, z);
-            if (!(tile instanceof TileEnergyStorageCore)) {
+            if (!(tile instanceof TileEnergyStorageCore core)) {
                 LogHelper.error("Missing Tile Entity (EnergyStorageCore)");
                 return false;
             }
-            TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
             List<String> information = core.getDisplayInformation(false);
             for (String message : information) {
                 player.addChatComponentMessage(new ChatComponentText(message));
@@ -90,19 +89,17 @@ public class EnergyStorageCore extends BlockDE implements IHudDisplayBlock, ITil
     public boolean shouldSideBeRendered(IBlockAccess world, int x, int y, int z, int side) {
         ForgeDirection direction = ForgeDirection.getOrientation(side);
         TileEntity tile = world.getTileEntity(x - direction.offsetX, y - direction.offsetY, z - direction.offsetZ);
-        if (!(tile instanceof TileEnergyStorageCore)) {
+        if (!(tile instanceof TileEnergyStorageCore core)) {
             LogHelper.error("Missing Tile Entity (EnergyStorageCore)(shouldSideBeRendered)");
             return true;
         }
-        TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
         return !core.isOnline() && super.shouldSideBeRendered(world, x, y, z, side);
     }
 
     @Override
     public void onNeighborBlockChange(World world, int x, int y, int z, Block neighbor) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileEnergyStorageCore) {
-            TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
+        if (tile instanceof TileEnergyStorageCore core) {
             if (core.isOnline() && core.getTier() == 0) {
                 core.validateStructure(false);
             }
@@ -112,8 +109,7 @@ public class EnergyStorageCore extends BlockDE implements IHudDisplayBlock, ITil
     @Override
     public void breakBlock(World world, int x, int y, int z, Block blockBroken, int metadata) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileEnergyStorageCore) {
-            TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
+        if (tile instanceof TileEnergyStorageCore core) {
             if (core.isOnline() && core.getTier() == 0) {
                 core.deactivateStabilizers();
             }
@@ -124,8 +120,7 @@ public class EnergyStorageCore extends BlockDE implements IHudDisplayBlock, ITil
     @Override
     public AxisAlignedBB getSelectedBoundingBoxFromPool(World world, int x, int y, int z) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileEnergyStorageCore) {
-            TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
+        if (tile instanceof TileEnergyStorageCore core) {
             if (core.isOnline()) {
                 return AxisAlignedBB.getBoundingBox(
                         core.xCoord + 0.5,
@@ -142,10 +137,10 @@ public class EnergyStorageCore extends BlockDE implements IHudDisplayBlock, ITil
     @Override
     public List<String> getDisplayData(World world, int x, int y, int z) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (!(tile instanceof TileEnergyStorageCore)) {
+        if (!(tile instanceof TileEnergyStorageCore core)) {
             LogHelper.error("Missing Tile Entity (EnergyStorageCore getDisplayData)");
             return Collections.emptyList();
         }
-        return ((TileEnergyStorageCore) tile).getDisplayInformation(true);
+        return core.getDisplayInformation(true);
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyStorageCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/EnergyStorageCore.java
@@ -1,6 +1,6 @@
 package com.brandon3055.draconicevolution.common.blocks.multiblock;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.block.Block;
@@ -10,13 +10,10 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.ChatComponentText;
-import net.minecraft.util.StatCollector;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import com.brandon3055.brandonscore.common.utills.InfoHelper;
-import com.brandon3055.brandonscore.common.utills.Utills;
 import com.brandon3055.draconicevolution.DraconicEvolution;
 import com.brandon3055.draconicevolution.common.ModBlocks;
 import com.brandon3055.draconicevolution.common.blocks.BlockDE;
@@ -70,29 +67,19 @@ public class EnergyStorageCore extends BlockDE implements IHudDisplayBlock {
     }
 
     @Override
-    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int p_149727_6_,
-            float p_149727_7_, float p_149727_8_, float p_149727_9_) {
-        TileEnergyStorageCore tile = (world.getTileEntity(x, y, z) != null
-                && world.getTileEntity(x, y, z) instanceof TileEnergyStorageCore)
-                        ? (TileEnergyStorageCore) world.getTileEntity(x, y, z)
-                        : null;
-        if (tile == null) {
-            LogHelper.error("Missing Tile Entity (EnergyStorageCore)");
-            return false;
-        }
-
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float subX,
+            float subY, float subZ) {
         if (!world.isRemote) {
-            player.addChatComponentMessage(new ChatComponentText("Tier:" + (tile.getTier() + 1)));
-            String BN = String.valueOf(tile.getEnergyStored());
-            player.addChatComponentMessage(
-                    new ChatComponentText(
-                            StatCollector.translateToLocal("info.de.charge.txt") + ": "
-                                    + Utills.formatNumber(tile.getEnergyStored())
-                                    + " / "
-                                    + Utills.formatNumber(tile.getMaxEnergyStored())
-                                    + " ["
-                                    + BN
-                                    + " RF]"));
+            TileEntity tile = world.getTileEntity(x, y, z);
+            if (!(tile instanceof TileEnergyStorageCore)) {
+                LogHelper.error("Missing Tile Entity (EnergyStorageCore)");
+                return false;
+            }
+            TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
+            List<String> information = core.getDisplayInformation(false);
+            for (String message : information) {
+                player.addChatComponentMessage(new ChatComponentText(message));
+            }
         }
         return true;
     }
@@ -100,96 +87,64 @@ public class EnergyStorageCore extends BlockDE implements IHudDisplayBlock {
     @Override
     @SideOnly(Side.CLIENT)
     public boolean shouldSideBeRendered(IBlockAccess world, int x, int y, int z, int side) {
-        TileEnergyStorageCore tile = (world.getTileEntity(
-                x - ForgeDirection.getOrientation(side).offsetX,
-                y - ForgeDirection.getOrientation(side).offsetY,
-                z - ForgeDirection.getOrientation(side).offsetZ) != null
-                && world.getTileEntity(
-                        x - ForgeDirection.getOrientation(side).offsetX,
-                        y - ForgeDirection.getOrientation(side).offsetY,
-                        z - ForgeDirection.getOrientation(side).offsetZ) instanceof TileEnergyStorageCore)
-                                ? (TileEnergyStorageCore) world.getTileEntity(
-                                        x - ForgeDirection.getOrientation(side).offsetX,
-                                        y - ForgeDirection.getOrientation(side).offsetY,
-                                        z - ForgeDirection.getOrientation(side).offsetZ)
-                                : null;
-        // LogHelper.error(world.getTileEntity(x - ForgeDirection.getOrientation(side).offsetX, y -
-        // ForgeDirection.getOrientation(side).offsetY, z - ForgeDirection.getOrientation(side).offsetZ));
-        if (tile == null) {
+        ForgeDirection direction = ForgeDirection.getOrientation(side);
+        TileEntity tile = world.getTileEntity(x - direction.offsetX, y - direction.offsetY, z - direction.offsetZ);
+        if (!(tile instanceof TileEnergyStorageCore)) {
             LogHelper.error("Missing Tile Entity (EnergyStorageCore)(shouldSideBeRendered)");
             return true;
         }
-        if (tile.isOnline()) return false;
-        else return super.shouldSideBeRendered(world, x, y, z, side);
+        TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
+        return !core.isOnline() && super.shouldSideBeRendered(world, x, y, z, side);
     }
 
     @Override
-    public void onNeighborBlockChange(World world, int x, int y, int z, Block p_149695_5_) {
-        TileEnergyStorageCore thisTile = (world.getTileEntity(x, y, z) != null
-                && world.getTileEntity(x, y, z) instanceof TileEnergyStorageCore)
-                        ? (TileEnergyStorageCore) world.getTileEntity(x, y, z)
-                        : null;
-        if (thisTile != null && thisTile.isOnline() && thisTile.getTier() == 0) {
-            thisTile.isStructureStillValid(false);
+    public void onNeighborBlockChange(World world, int x, int y, int z, Block neighbor) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileEnergyStorageCore) {
+            TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
+            if (core.isOnline() && core.getTier() == 0) {
+                core.isStructureStillValid(false);
+            }
         }
     }
 
     @Override
-    public void breakBlock(World world, int x, int y, int z, Block p_149749_5_, int p_149749_6_) {
-        TileEnergyStorageCore thisTile = (world.getTileEntity(x, y, z) != null
-                && world.getTileEntity(x, y, z) instanceof TileEnergyStorageCore)
-                        ? (TileEnergyStorageCore) world.getTileEntity(x, y, z)
-                        : null;
-        if (thisTile != null && thisTile.isOnline() && thisTile.getTier() == 0) {
-            thisTile.deactivateStabilizers();
+    public void breakBlock(World world, int x, int y, int z, Block blockBroken, int metadata) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileEnergyStorageCore) {
+            TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
+            if (core.isOnline() && core.getTier() == 0) {
+                core.deactivateStabilizers();
+            }
         }
-        super.breakBlock(world, x, y, z, p_149749_5_, p_149749_6_);
+        super.breakBlock(world, x, y, z, blockBroken, metadata);
     }
 
     @Override
     public AxisAlignedBB getSelectedBoundingBoxFromPool(World world, int x, int y, int z) {
-        TileEnergyStorageCore thisTile = (world.getTileEntity(x, y, z) != null
-                && world.getTileEntity(x, y, z) instanceof TileEnergyStorageCore)
-                        ? (TileEnergyStorageCore) world.getTileEntity(x, y, z)
-                        : null;
-        if (thisTile != null && thisTile.isOnline()) {
-            return AxisAlignedBB.getBoundingBox(
-                    thisTile.xCoord + 0.5,
-                    thisTile.yCoord + 0.5,
-                    thisTile.zCoord + 0.5,
-                    thisTile.xCoord + 0.5,
-                    thisTile.yCoord + 0.5,
-                    thisTile.zCoord + 0.5);
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileEnergyStorageCore) {
+            TileEnergyStorageCore core = (TileEnergyStorageCore) tile;
+            if (core.isOnline()) {
+                return AxisAlignedBB.getBoundingBox(
+                        core.xCoord + 0.5,
+                        core.yCoord + 0.5,
+                        core.zCoord + 0.5,
+                        core.xCoord + 0.5,
+                        core.yCoord + 0.5,
+                        core.zCoord + 0.5);
+            }
         }
         return super.getSelectedBoundingBoxFromPool(world, x, y, z);
     }
 
     @Override
     public List<String> getDisplayData(World world, int x, int y, int z) {
-        List<String> list = new ArrayList<String>();
-
-        TileEnergyStorageCore tile = (world.getTileEntity(x, y, z) != null
-                && world.getTileEntity(x, y, z) instanceof TileEnergyStorageCore)
-                        ? (TileEnergyStorageCore) world.getTileEntity(x, y, z)
-                        : null;
-        if (tile == null) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (!(tile instanceof TileEnergyStorageCore)) {
             LogHelper.error("Missing Tile Entity (EnergyStorageCore getDisplayData)");
-            return list;
+            return Collections.emptyList();
         }
-
-        list.add(InfoHelper.HITC() + getLocalizedName());
-        list.add("Tier: " + InfoHelper.ITC() + (tile.getTier() + 1));
-        String BN = String.valueOf(tile.getEnergyStored());
-        list.add(
-                StatCollector.translateToLocal("info.de.charge.txt") + ": "
-                        + InfoHelper.ITC()
-                        + Utills.formatNumber(tile.getEnergyStored())
-                        + " / "
-                        + Utills.formatNumber(tile.getMaxEnergyStored())
-                        + " ["
-                        + BN
-                        + " RF]");
-
-        return list;
+        return ((TileEnergyStorageCore) tile).getDisplayInformation(true);
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/IReactorPart.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/IReactorPart.java
@@ -24,14 +24,14 @@ public interface IReactorPart {
         CONVERTED_FUEL,
         CONVERTED_FUEL_INVERTED;
 
-        private static final ComparatorMode[] Values = values();
+        private static final ComparatorMode[] values = values();
 
         public static ComparatorMode getMode(int ordinal) {
-            return ordinal >= 0 && ordinal < Values.length ? Values[ordinal] : TEMPERATURE;
+            return ordinal >= 0 && ordinal < values.length ? values[ordinal] : TEMPERATURE;
         }
 
         public ComparatorMode next() {
-            return Values[(ordinal() + 1) % Values.length];
+            return values[(ordinal() + 1) % values.length];
         }
 
         public String toLocalizedString() {
@@ -41,8 +41,7 @@ public interface IReactorPart {
 
     static int getComparatorOutput(IBlockAccess world, int x, int y, int z) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof IReactorPart) {
-            IReactorPart part = (IReactorPart) tile;
+        if (tile instanceof IReactorPart part) {
             TileReactorCore core = part.getMaster();
             if (core != null) {
                 return core.getComparatorOutput(part.getComparatorMode());

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/IReactorPart.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/IReactorPart.java
@@ -1,6 +1,7 @@
 package com.brandon3055.draconicevolution.common.blocks.multiblock;
 
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.StatCollector;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.util.ForgeDirection;
 
@@ -12,14 +13,32 @@ import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.rea
  */
 public interface IReactorPart {
 
-    int RMODE_TEMP = 0;
-    int RMODE_TEMP_INV = 1;
-    int RMODE_FIELD = 2;
-    int RMODE_FIELD_INV = 3;
-    int RMODE_SAT = 4;
-    int RMODE_SAT_INV = 5;
-    int RMODE_FUEL = 6;
-    int RMODE_FUEL_INV = 7;
+    enum ComparatorMode {
+
+        TEMPERATURE,
+        TEMPERATURE_INVERTED,
+        FIELD_CHARGE,
+        FIELD_CHARGE_INVERTED,
+        ENERGY_SATURATION,
+        ENERGY_SATURATION_INVERTED,
+        CONVERTED_FUEL,
+        CONVERTED_FUEL_INVERTED;
+
+        private static final ComparatorMode[] Values = values();
+
+        public static ComparatorMode getMode(int ordinal) {
+            return ordinal >= 0 && ordinal < Values.length ? Values[ordinal] : TEMPERATURE;
+        }
+
+        public ComparatorMode next() {
+            return Values[(ordinal() + 1) % Values.length];
+        }
+
+        @Override
+        public String toString() {
+            return StatCollector.translateToLocal("msg.de.reactorRSMode." + ordinal() + ".txt");
+        }
+    }
 
     static int getComparatorOutput(IBlockAccess world, int x, int y, int z) {
         TileEntity tile = world.getTileEntity(x, y, z);
@@ -27,7 +46,7 @@ public interface IReactorPart {
             IReactorPart part = (IReactorPart) tile;
             TileReactorCore core = part.getMaster();
             if (core != null) {
-                return core.getComparatorOutput(part.getRedstoneMode());
+                return core.getComparatorOutput(part.getComparatorMode());
             }
         }
         return 0;
@@ -45,9 +64,7 @@ public interface IReactorPart {
 
     ForgeDirection getFacing();
 
-    int getRedstoneMode();
+    ComparatorMode getComparatorMode();
 
-    void changeRedstoneMode();
-
-    String getRedstoneModeAsString();
+    void changeComparatorMode();
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/IReactorPart.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/IReactorPart.java
@@ -34,8 +34,7 @@ public interface IReactorPart {
             return Values[(ordinal() + 1) % Values.length];
         }
 
-        @Override
-        public String toString() {
+        public String toLocalizedString() {
             return StatCollector.translateToLocal("msg.de.reactorRSMode." + ordinal() + ".txt");
         }
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/IReactorPart.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/IReactorPart.java
@@ -1,30 +1,53 @@
 package com.brandon3055.draconicevolution.common.blocks.multiblock;
 
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import com.brandon3055.draconicevolution.common.blocks.multiblock.MultiblockHelper.TileLocation;
+import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor.TileReactorCore;
+
 /**
  * Created by Brandon on 23/7/2015.
  */
 public interface IReactorPart {
 
-    public static int RMODE_TEMP = 0;
-    public static int RMODE_TEMP_INV = 1;
-    public static int RMODE_FIELD = 2;
-    public static int RMODE_FIELD_INV = 3;
-    public static int RMODE_SAT = 4;
-    public static int RMODE_SAT_INV = 5;
-    public static int RMODE_FUEL = 6;
-    public static int RMODE_FUEL_INV = 7;
+    int RMODE_TEMP = 0;
+    int RMODE_TEMP_INV = 1;
+    int RMODE_FIELD = 2;
+    int RMODE_FIELD_INV = 3;
+    int RMODE_SAT = 4;
+    int RMODE_SAT_INV = 5;
+    int RMODE_FUEL = 6;
+    int RMODE_FUEL_INV = 7;
 
-    public MultiblockHelper.TileLocation getMaster();
+    static int getComparatorOutput(IBlockAccess world, int x, int y, int z) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof IReactorPart) {
+            IReactorPart part = (IReactorPart) tile;
+            TileReactorCore core = part.getMaster();
+            if (core != null) {
+                return core.getComparatorOutput(part.getRedstoneMode());
+            }
+        }
+        return 0;
+    }
 
-    public void shutDown();
+    TileLocation getMasterLocation();
 
-    public boolean checkForMaster();
+    TileReactorCore getMaster();
 
-    public boolean isActive();
+    void setUp(TileLocation masterLocation);
 
-    public String getRedstoneModeString();
+    void shutDown();
 
-    public void changeRedstoneMode();
+    boolean isActive();
 
-    public int getRedstoneMode();
+    ForgeDirection getFacing();
+
+    int getRedstoneMode();
+
+    void changeRedstoneMode();
+
+    String getRedstoneModeAsString();
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/InvisibleMultiblock.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/InvisibleMultiblock.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Random;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
@@ -34,7 +35,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 /**
  * Created by Brandon on 25/07/2014.
  */
-public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
+public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock, ITileEntityProvider {
 
     public static void revertStructure(World world, int x, int y, int z) {
         int metadata = world.getBlockMetadata(x, y, z);
@@ -93,7 +94,7 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
     }
 
     @Override
-    public TileEntity createTileEntity(World world, int metadata) {
+    public TileEntity createNewTileEntity(World world, int metadata) {
         return metadata == 0 || metadata == 1 ? new TileInvisibleMultiblock() : null;
     }
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/InvisibleMultiblock.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/InvisibleMultiblock.java
@@ -126,11 +126,10 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock, IT
         int metadata = world.getBlockMetadata(x, y, z);
         if (metadata == 0 || metadata == 1) {
             TileEntity tile = world.getTileEntity(x, y, z);
-            if (!(tile instanceof TileInvisibleMultiblock)) {
+            if (!(tile instanceof TileInvisibleMultiblock multiblock)) {
                 LogHelper.error("Missing Tile Entity (TileInvisibleMultiblock)");
                 return false;
             }
-            TileInvisibleMultiblock multiblock = (TileInvisibleMultiblock) tile;
             TileEnergyStorageCore core = multiblock.getMaster();
             if (core == null) {
                 onNeighborBlockChange(world, x, y, z, this);
@@ -165,12 +164,11 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock, IT
         int metadata = world.getBlockMetadata(x, y, z);
         if (metadata == 0 || metadata == 1) {
             TileEntity tile = world.getTileEntity(x, y, z);
-            if (!(tile instanceof TileInvisibleMultiblock)) {
+            if (!(tile instanceof TileInvisibleMultiblock multiblock)) {
                 LogHelper.error("Missing Tile Entity (TileInvisibleMultiblock)");
                 revertStructure(world, x, y, z);
                 return;
             }
-            TileInvisibleMultiblock multiblock = (TileInvisibleMultiblock) tile;
             TileEnergyStorageCore core = multiblock.getMaster();
             if (core == null) {
                 LogHelper.error("Master = null reverting!");
@@ -192,8 +190,7 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock, IT
     @Override
     public void breakBlock(World world, int x, int y, int z, Block blockBroken, int metadata) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileInvisibleMultiblock) {
-            TileInvisibleMultiblock multiblock = (TileInvisibleMultiblock) tile;
+        if (tile instanceof TileInvisibleMultiblock multiblock) {
             TileEnergyStorageCore core = multiblock.getMaster();
             if (core != null && core.isOnline()) {
                 world.setBlockMetadataWithNotify(x, y, z, 0, 2);
@@ -208,8 +205,7 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock, IT
         int metadata = world.getBlockMetadata(x, y, z);
         if (metadata == 0 || metadata == 1) {
             TileEntity tile = world.getTileEntity(x, y, z);
-            if (tile instanceof TileInvisibleMultiblock) {
-                TileInvisibleMultiblock multiblock = (TileInvisibleMultiblock) tile;
+            if (tile instanceof TileInvisibleMultiblock multiblock) {
                 TileEnergyStorageCore core = multiblock.getMaster();
                 if (core != null) {
                     return AxisAlignedBB.getBoundingBox(
@@ -260,11 +256,10 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock, IT
         int metadata = world.getBlockMetadata(x, y, z);
         if (metadata == 0 || metadata == 1) {
             TileEntity tile = world.getTileEntity(x, y, z);
-            if (!(tile instanceof TileInvisibleMultiblock)) {
+            if (!(tile instanceof TileInvisibleMultiblock multiblock)) {
                 LogHelper.error("Missing Tile Entity (TileInvisibleMultiblock getDisplayData)");
                 return Collections.emptyList();
             }
-            TileInvisibleMultiblock multiblock = (TileInvisibleMultiblock) tile;
             TileEnergyStorageCore core = multiblock.getMaster();
             if (core != null) {
                 return core.getDisplayInformation(true);

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/InvisibleMultiblock.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/InvisibleMultiblock.java
@@ -1,6 +1,6 @@
 package com.brandon3055.draconicevolution.common.blocks.multiblock;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -15,11 +15,8 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.MovingObjectPosition;
-import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
-import com.brandon3055.brandonscore.common.utills.InfoHelper;
-import com.brandon3055.brandonscore.common.utills.Utills;
 import com.brandon3055.draconicevolution.common.ModBlocks;
 import com.brandon3055.draconicevolution.common.blocks.BlockDE;
 import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
@@ -39,11 +36,31 @@ import cpw.mods.fml.relauncher.SideOnly;
  */
 public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
 
+    public static void revertStructure(World world, int x, int y, int z) {
+        int metadata = world.getBlockMetadata(x, y, z);
+        if (metadata == 0) {
+            world.setBlock(
+                    x,
+                    y,
+                    z,
+                    BalanceConfigHandler.energyStorageStructureOuterBlock,
+                    BalanceConfigHandler.energyStorageStructureOuterBlockMetadata,
+                    3);
+        } else if (metadata == 1) {
+            world.setBlock(
+                    x,
+                    y,
+                    z,
+                    BalanceConfigHandler.energyStorageStructureBlock,
+                    BalanceConfigHandler.energyStorageStructureBlockMetadata,
+                    3);
+        }
+    }
+
     public InvisibleMultiblock() {
         super(Material.iron);
         this.setHardness(10F);
         this.setResistance(2000F);
-        // this.setCreativeTab(DraconicEvolution.getCreativeTab(2));
         this.setBlockName(Strings.invisibleMultiblockName);
         ModBlocks.register(this);
     }
@@ -77,16 +94,15 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
 
     @Override
     public TileEntity createTileEntity(World world, int metadata) {
-        if (metadata == 0 || metadata == 1) return new TileInvisibleMultiblock();
-        else return null;
+        return metadata == 0 || metadata == 1 ? new TileInvisibleMultiblock() : null;
     }
 
     @Override
-    public Item getItemDropped(int meta, Random p_149650_2_, int var2) {
-        if (meta == 0) {
+    public Item getItemDropped(int metadata, Random random, int fortune) {
+        if (metadata == 0) {
             return Item.getItemFromBlock(BalanceConfigHandler.energyStorageStructureOuterBlock);
         }
-        if (meta == 1) {
+        if (metadata == 1) {
             return Item.getItemFromBlock(BalanceConfigHandler.energyStorageStructureBlock);
         }
         return null;
@@ -104,47 +120,37 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
     }
 
     @Override
-    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int p_149727_6_,
-            float p_149727_7_, float p_149727_8_, float p_149727_9_) {
-        int meta = world.getBlockMetadata(x, y, z);
-        if (meta == 0 || meta == 1) {
-            TileInvisibleMultiblock thisTile = (world.getTileEntity(x, y, z) != null
-                    && world.getTileEntity(x, y, z) instanceof TileInvisibleMultiblock)
-                            ? (TileInvisibleMultiblock) world.getTileEntity(x, y, z)
-                            : null;
-            if (thisTile == null) {
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float subX,
+            float subY, float subZ) {
+        int metadata = world.getBlockMetadata(x, y, z);
+        if (metadata == 0 || metadata == 1) {
+            TileEntity tile = world.getTileEntity(x, y, z);
+            if (!(tile instanceof TileInvisibleMultiblock)) {
                 LogHelper.error("Missing Tile Entity (TileInvisibleMultiblock)");
                 return false;
             }
-            TileEnergyStorageCore master = thisTile.getMaster();
-            if (master == null) {
+            TileInvisibleMultiblock multiblock = (TileInvisibleMultiblock) tile;
+            TileEnergyStorageCore core = multiblock.getMaster();
+            if (core == null) {
                 onNeighborBlockChange(world, x, y, z, this);
                 return false;
             }
             if (!world.isRemote) {
-                world.markBlockForUpdate(master.xCoord, master.yCoord, master.zCoord);
-                player.addChatComponentMessage(new ChatComponentText("Tier:" + (master.getTier() + 1)));
-                String BN = String.valueOf(master.getEnergyStored());
-                player.addChatComponentMessage(
-                        new ChatComponentText(
-                                StatCollector.translateToLocal("info.de.charge.txt") + ": "
-                                        + Utills.formatNumber(master.getEnergyStored())
-                                        + " / "
-                                        + Utills.formatNumber(master.getMaxEnergyStored())
-                                        + " ["
-                                        + BN
-                                        + " RF]"));
+                world.markBlockForUpdate(core.xCoord, core.yCoord, core.zCoord);
+                List<String> information = core.getDisplayInformation(false);
+                for (String message : information) {
+                    player.addChatComponentMessage(new ChatComponentText(message));
+                }
             }
             return true;
-        } else if (meta == 2) {
-            TileEnergyPylon pylon = (world.getTileEntity(x, y + 1, z) != null
-                    && world.getTileEntity(x, y + 1, z) instanceof TileEnergyPylon)
-                            ? (TileEnergyPylon) world.getTileEntity(x, y + 1, z)
-                            : (world.getTileEntity(x, y - 1, z) != null
-                                    && world.getTileEntity(x, y - 1, z) instanceof TileEnergyPylon)
-                                            ? (TileEnergyPylon) world.getTileEntity(x, y - 1, z)
-                                            : null;
-            if (pylon == null) return false;
+        } else if (metadata == 2) {
+            TileEntity tileAbove = world.getTileEntity(x, y + 1, z);
+            TileEntity tileBelow = world.getTileEntity(x, y - 1, z);
+            TileEnergyPylon pylon = tileAbove instanceof TileEnergyPylon ? (TileEnergyPylon) tileAbove
+                    : tileBelow instanceof TileEnergyPylon ? (TileEnergyPylon) tileBelow : null;
+            if (pylon == null) {
+                return false;
+            }
             pylon.reciveEnergy = !pylon.reciveEnergy;
             world.markBlockForUpdate(pylon.xCoord, pylon.yCoord, pylon.zCoord);
             pylon.onActivated();
@@ -154,87 +160,68 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
     }
 
     @Override
-    public void onNeighborBlockChange(World world, int x, int y, int z, Block p_149695_5_) {
-        int meta = world.getBlockMetadata(x, y, z);
-        if (meta == 0 || meta == 1) {
-            TileInvisibleMultiblock thisTile = (world.getTileEntity(x, y, z) != null
-                    && world.getTileEntity(x, y, z) instanceof TileInvisibleMultiblock)
-                            ? (TileInvisibleMultiblock) world.getTileEntity(x, y, z)
-                            : null;
-            if (thisTile == null) {
+    public void onNeighborBlockChange(World world, int x, int y, int z, Block neighbor) {
+        int metadata = world.getBlockMetadata(x, y, z);
+        if (metadata == 0 || metadata == 1) {
+            TileEntity tile = world.getTileEntity(x, y, z);
+            if (!(tile instanceof TileInvisibleMultiblock)) {
                 LogHelper.error("Missing Tile Entity (TileInvisibleMultiblock)");
-                revert(world, x, y, z);
+                revertStructure(world, x, y, z);
                 return;
             }
-            TileEnergyStorageCore master = thisTile.getMaster();
-            if (master == null) {
+            TileInvisibleMultiblock multiblock = (TileInvisibleMultiblock) tile;
+            TileEnergyStorageCore core = multiblock.getMaster();
+            if (core == null) {
                 LogHelper.error("Master = null reverting!");
-                revert(world, x, y, z);
+                revertStructure(world, x, y, z);
                 return;
             }
-            if (master.isOnline()) master.isStructureStillValid(thisTile.getMaster().getTier() == 1);
-            if (!master.isOnline()) revert(world, x, y, z);
-        } else if (meta == 2) {
+            if (core.isOnline()) {
+                core.isStructureStillValid(core.getTier() == 1);
+            } else {
+                revertStructure(world, x, y, z);
+            }
+        } else if (metadata == 2) {
             if (world.getBlock(x, y + 1, z) != ModBlocks.energyPylon
                     && world.getBlock(x, y - 1, z) != ModBlocks.energyPylon)
                 world.setBlock(x, y, z, Blocks.glass);
         }
     }
 
-    private void revert(World world, int x, int y, int z) {
-        int meta = world.getBlockMetadata(x, y, z);
-        if (meta == 0) {
-            world.setBlock(
-                    x,
-                    y,
-                    z,
-                    BalanceConfigHandler.energyStorageStructureOuterBlock,
-                    BalanceConfigHandler.energyStorageStructureOuterBlockMetadata,
-                    3);
-        } else if (meta == 1) {
-            world.setBlock(
-                    x,
-                    y,
-                    z,
-                    BalanceConfigHandler.energyStorageStructureBlock,
-                    BalanceConfigHandler.energyStorageStructureBlockMetadata,
-                    3);
-        }
-    }
-
     @Override
-    public void breakBlock(World world, int x, int y, int z, Block p_149749_5_, int meta) {
+    public void breakBlock(World world, int x, int y, int z, Block blockBroken, int metadata) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        TileInvisibleMultiblock thisTile = (tile != null && tile instanceof TileInvisibleMultiblock)
-                ? (TileInvisibleMultiblock) tile
-                : null;
-        if (thisTile != null && thisTile.getMaster() != null && thisTile.getMaster().isOnline()) {
-            world.setBlockMetadataWithNotify(x, y, z, 0, 2);
-
-            thisTile.getMaster().isStructureStillValid(thisTile.getMaster().getTier() == 1);
+        if (tile instanceof TileInvisibleMultiblock) {
+            TileInvisibleMultiblock multiblock = (TileInvisibleMultiblock) tile;
+            TileEnergyStorageCore core = multiblock.getMaster();
+            if (core != null && core.isOnline()) {
+                world.setBlockMetadataWithNotify(x, y, z, 0, 2);
+                core.isStructureStillValid(core.getTier() == 1);
+            }
         }
-        super.breakBlock(world, x, y, z, p_149749_5_, meta);
+        super.breakBlock(world, x, y, z, blockBroken, metadata);
     }
 
     @Override
     public AxisAlignedBB getSelectedBoundingBoxFromPool(World world, int x, int y, int z) {
-        int meta = world.getBlockMetadata(x, y, z);
-        if (meta == 0 || meta == 1) {
-            TileInvisibleMultiblock thisTile = (world.getTileEntity(x, y, z) != null
-                    && world.getTileEntity(x, y, z) instanceof TileInvisibleMultiblock)
-                            ? (TileInvisibleMultiblock) world.getTileEntity(x, y, z)
-                            : null;
-            if (thisTile != null && thisTile.getMaster() != null) {
-                return AxisAlignedBB.getBoundingBox(
-                        thisTile.getMaster().xCoord,
-                        thisTile.getMaster().yCoord,
-                        thisTile.getMaster().zCoord,
-                        thisTile.getMaster().xCoord + 0.5,
-                        thisTile.getMaster().yCoord + 0.5,
-                        thisTile.getMaster().zCoord + 0.5);
+        int metadata = world.getBlockMetadata(x, y, z);
+        if (metadata == 0 || metadata == 1) {
+            TileEntity tile = world.getTileEntity(x, y, z);
+            if (tile instanceof TileInvisibleMultiblock) {
+                TileInvisibleMultiblock multiblock = (TileInvisibleMultiblock) tile;
+                TileEnergyStorageCore core = multiblock.getMaster();
+                if (core != null) {
+                    return AxisAlignedBB.getBoundingBox(
+                            core.xCoord,
+                            core.yCoord,
+                            core.zCoord,
+                            core.xCoord + 0.5,
+                            core.yCoord + 0.5,
+                            core.zCoord + 0.5);
+                }
             }
             return super.getSelectedBoundingBoxFromPool(world, x, y, z);
-        } else if (meta == 2) {
+        } else if (metadata == 2) {
             return AxisAlignedBB.getBoundingBox(x + 0.49, y + 0.49, z + 0.49, x + 0.51, y + 0.51, z + 0.51);
         }
         return super.getSelectedBoundingBoxFromPool(world, x, y, z);
@@ -242,9 +229,8 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
 
     @Override
     public AxisAlignedBB getCollisionBoundingBoxFromPool(World world, int x, int y, int z) {
-
-        int meta = world.getBlockMetadata(x, y, z);
-        if (meta == 2) {
+        int metadata = world.getBlockMetadata(x, y, z);
+        if (metadata == 2) {
             return AxisAlignedBB.getBoundingBox(x, y, z, x, y, z);
         }
         return super.getCollisionBoundingBoxFromPool(world, x, y, z);
@@ -270,46 +256,19 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
 
     @Override
     public List<String> getDisplayData(World world, int x, int y, int z) {
-        List<String> list = new ArrayList<String>();
-
-        int meta = world.getBlockMetadata(x, y, z);
-        if (meta == 0 || meta == 1) {
-            TileInvisibleMultiblock thisTile = (world.getTileEntity(x, y, z) != null
-                    && world.getTileEntity(x, y, z) instanceof TileInvisibleMultiblock)
-                            ? (TileInvisibleMultiblock) world.getTileEntity(x, y, z)
-                            : null;
-            if (thisTile == null) {
+        int metadata = world.getBlockMetadata(x, y, z);
+        if (metadata == 0 || metadata == 1) {
+            TileEntity tile = world.getTileEntity(x, y, z);
+            if (!(tile instanceof TileInvisibleMultiblock)) {
                 LogHelper.error("Missing Tile Entity (TileInvisibleMultiblock getDisplayData)");
-                return list;
+                return Collections.emptyList();
             }
-
-            TileEnergyStorageCore master = thisTile.getMaster();
-
-            if (master == null) {
-                return list;
+            TileInvisibleMultiblock multiblock = (TileInvisibleMultiblock) tile;
+            TileEnergyStorageCore core = multiblock.getMaster();
+            if (core != null) {
+                return core.getDisplayInformation(true);
             }
-
-            list.add(InfoHelper.HITC() + ModBlocks.energyStorageCore.getLocalizedName());
-            list.add("Tier: " + InfoHelper.ITC() + (master.getTier() + 1));
-            String BN = String.valueOf(master.getEnergyStored());
-            list.add(
-                    StatCollector.translateToLocal("info.de.charge.txt") + ": "
-                            + InfoHelper.ITC()
-                            + Utills.formatNumber(master.getEnergyStored())
-                            + " / "
-                            + Utills.formatNumber(master.getMaxEnergyStored())
-                            + " ["
-                            + Utills.addCommas(master.getEnergyStored())
-                            + " RF]");
-
-            return list;
         }
-
-        return list;
-    }
-
-    @Override
-    public String getUnlocalizedName() {
-        return super.getUnlocalizedName();
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/InvisibleMultiblock.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/InvisibleMultiblock.java
@@ -151,7 +151,7 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
             if (pylon == null) {
                 return false;
             }
-            pylon.reciveEnergy = !pylon.reciveEnergy;
+            pylon.isReceivingEnergy = !pylon.isReceivingEnergy;
             world.markBlockForUpdate(pylon.xCoord, pylon.yCoord, pylon.zCoord);
             pylon.onActivated();
             return true;
@@ -177,7 +177,7 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
                 return;
             }
             if (core.isOnline()) {
-                core.isStructureStillValid(core.getTier() == 1);
+                core.validateStructure(core.getTier() == 1);
             } else {
                 revertStructure(world, x, y, z);
             }
@@ -196,7 +196,7 @@ public class InvisibleMultiblock extends BlockDE implements IHudDisplayBlock {
             TileEnergyStorageCore core = multiblock.getMaster();
             if (core != null && core.isOnline()) {
                 world.setBlockMetadataWithNotify(x, y, z, 0, 2);
-                core.isStructureStillValid(core.getTier() == 1);
+                core.validateStructure(core.getTier() == 1);
             }
         }
         super.breakBlock(world, x, y, z, blockBroken, metadata);

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/MultiblockHelper.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/MultiblockHelper.java
@@ -1,5 +1,6 @@
 package com.brandon3055.draconicevolution.common.blocks.multiblock;
 
+import net.minecraft.block.Block;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
@@ -58,6 +59,14 @@ public class MultiblockHelper {
         public void setZCoord(int z) {
             posZ = z;
             initialized = true;
+        }
+
+        public Block getBlock(World world) {
+            return world.getBlock(posX, posY, posZ);
+        }
+
+        public int getBlockMetadata(World world) {
+            return world.getBlockMetadata(posX, posY, posZ);
         }
 
         public TileEntity getTileEntity(World world) {

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/Portal.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/Portal.java
@@ -120,7 +120,7 @@ public class Portal extends BlockDE implements ITileEntityProvider {
 
     private TileDislocatorReceptacle getMaster(World world, int x, int y, int z) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        return tile instanceof TilePortalBlock ? ((TilePortalBlock) tile).getMaster() : null;
+        return tile instanceof TilePortalBlock portal ? portal.getMaster() : null;
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/Portal.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/Portal.java
@@ -35,8 +35,8 @@ public class Portal extends BlockDE implements ITileEntityProvider {
         ModBlocks.register(this);
     }
 
-    @SideOnly(Side.CLIENT)
     @Override
+    @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister iconRegister) {
         blockIcon = iconRegister.registerIcon(References.RESOURCESPREFIX + "transparency");
     }
@@ -47,8 +47,7 @@ public class Portal extends BlockDE implements ITileEntityProvider {
     }
 
     @Override
-    public AxisAlignedBB getSelectedBoundingBoxFromPool(World p_149633_1_, int p_149633_2_, int p_149633_3_,
-            int p_149633_4_) {
+    public AxisAlignedBB getSelectedBoundingBoxFromPool(World worldIn, int x, int y, int z) {
         return AxisAlignedBB.getBoundingBox(0, 0, 0, 0, 0, 0);
     }
 
@@ -63,26 +62,35 @@ public class Portal extends BlockDE implements ITileEntityProvider {
     }
 
     @Override
-    public TileEntity createNewTileEntity(World world, int i) {
+    public boolean hasTileEntity(int metadata) {
+        return true;
+    }
+
+    @Override
+    public TileEntity createNewTileEntity(World world, int metadata) {
         return new TilePortalBlock();
     }
 
     @Override
-    public AxisAlignedBB getCollisionBoundingBoxFromPool(World p_149668_1_, int p_149668_2_, int p_149668_3_,
-            int p_149668_4_) {
+    public AxisAlignedBB getCollisionBoundingBoxFromPool(World worldIn, int x, int y, int z) {
         return null;
     }
 
     @Override
     public void onNeighborBlockChange(World world, int x, int y, int z, Block block) {
-        if (world.isRemote) return;
-        if (getMaster(world, x, y, z) == null) {
+        if (world.isRemote) {
+            return;
+        }
+        TileDislocatorReceptacle receptacle = getMaster(world, x, y, z);
+        if (receptacle == null) {
             world.setBlockToAir(x, y, z);
             return;
         }
 
-        if (getMaster(world, x, y, z).isActive) getMaster(world, x, y, z).validateActivePortal();
-        if (!getMaster(world, x, y, z).isActive && !getMaster(world, x, y, z).updating) {
+        if (receptacle.isActive) {
+            receptacle.validateActivePortal();
+        }
+        if (!receptacle.isActive && !receptacle.updating) {
             world.setBlockToAir(x, y, z);
             return;
         }
@@ -91,29 +99,37 @@ public class Portal extends BlockDE implements ITileEntityProvider {
 
     @Override
     public void onEntityCollidedWithBlock(World world, int x, int y, int z, Entity entity) {
-        if (world.isRemote) return;
-        TileDislocatorReceptacle tile = getMaster(world, x, y, z);
-        if (tile != null && tile.isActive && tile.getLocation() != null) {
-            if (tile.coolDown > 0) return;
-            tile.coolDown = 1;
-            tile.getLocation().sendEntityToCoords(entity);
-        } else if (tile != null) tile.validateActivePortal();
-        else world.setBlockToAir(x, y, z);
+        if (world.isRemote) {
+            return;
+        }
+        TileDislocatorReceptacle receptacle = getMaster(world, x, y, z);
+        if (receptacle == null) {
+            world.setBlockToAir(x, y, z);
+            return;
+        }
+        if (receptacle.isActive && receptacle.getLocation() != null) {
+            if (receptacle.coolDown > 0) {
+                return;
+            }
+            receptacle.coolDown = 1;
+            receptacle.getLocation().sendEntityToCoords(entity);
+        } else {
+            receptacle.validateActivePortal();
+        }
     }
 
     private TileDislocatorReceptacle getMaster(World world, int x, int y, int z) {
-        return world.getTileEntity(x, y, z) instanceof TilePortalBlock
-                ? ((TilePortalBlock) world.getTileEntity(x, y, z)).getMaster()
-                : null;
+        TileEntity tile = world.getTileEntity(x, y, z);
+        return tile instanceof TilePortalBlock ? ((TilePortalBlock) tile).getMaster() : null;
     }
 
     @Override
-    public Item getItemDropped(int p_149650_1_, Random p_149650_2_, int p_149650_3_) {
+    public Item getItemDropped(int metadata, Random random, int fortune) {
         return null;
     }
 
-    private boolean isPortalOrFrame(IBlockAccess access, int x, int y, int z) {
-        Block block = access.getBlock(x, y, z);
+    private boolean isPortalOrFrame(IBlockAccess world, int x, int y, int z) {
+        Block block = world.getBlock(x, y, z);
         return block == ModBlocks.portal || block == ModBlocks.infusedObsidian
                 || block == ModBlocks.dislocatorReceptacle;
     }
@@ -124,22 +140,21 @@ public class Portal extends BlockDE implements ITileEntityProvider {
     }
 
     private void updateMetadata(World world, int x, int y, int z) {
-        if (world.isRemote || world.getBlockMetadata(x, y, z) != 0) return;
-        int meta = 0;
+        if (world.isRemote || world.getBlockMetadata(x, y, z) != 0) {
+            return;
+        }
+        int metadata = 0;
+        boolean hasPortalsAlongXAxis = isPortalOrFrame(world, x + 1, y, z) && isPortalOrFrame(world, x - 1, y, z);
+        boolean hasPortalsAlongYAxis = isPortalOrFrame(world, x, y + 1, z) && isPortalOrFrame(world, x, y - 1, z);
+        boolean hasPortalsAlongZAxis = isPortalOrFrame(world, x, y, z + 1) && isPortalOrFrame(world, x, y, z - 1);
 
-        if (isPortalOrFrame(world, x, y + 1, z) && isPortalOrFrame(world, x, y - 1, z)
-                && isPortalOrFrame(world, x + 1, y, z)
-                && isPortalOrFrame(world, x - 1, y, z))
-            meta = 1;
-        else if (isPortalOrFrame(world, x, y + 1, z) && isPortalOrFrame(world, x, y - 1, z)
-                && isPortalOrFrame(world, x, y, z + 1)
-                && isPortalOrFrame(world, x, y, z - 1))
-            meta = 2;
-        else if (isPortalOrFrame(world, x + 1, y, z) && isPortalOrFrame(world, x - 1, y, z)
-                && isPortalOrFrame(world, x, y, z + 1)
-                && isPortalOrFrame(world, x, y, z - 1))
-            meta = 3;
-
-        world.setBlockMetadataWithNotify(x, y, z, meta, 2);
+        if (hasPortalsAlongXAxis && hasPortalsAlongYAxis) {
+            metadata = 1;
+        } else if (hasPortalsAlongYAxis && hasPortalsAlongZAxis) {
+            metadata = 2;
+        } else if (hasPortalsAlongXAxis && hasPortalsAlongZAxis) {
+            metadata = 3;
+        }
+        world.setBlockMetadataWithNotify(x, y, z, metadata, 2);
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorCore.java
@@ -63,8 +63,8 @@ public class ReactorCore extends BlockDE implements ITileEntityProvider {
     @Override
     public void onBlockAdded(World world, int x, int y, int z) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileReactorCore) {
-            ((TileReactorCore) tile).onPlaced();
+        if (tile instanceof TileReactorCore core) {
+            core.onPlaced();
         }
     }
 
@@ -76,8 +76,8 @@ public class ReactorCore extends BlockDE implements ITileEntityProvider {
     @Override
     public void breakBlock(World world, int x, int y, int z, Block blockBroken, int metadata) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileReactorCore) {
-            ((TileReactorCore) tile).onBroken();
+        if (tile instanceof TileReactorCore core) {
+            core.onBroken();
         }
         super.breakBlock(world, x, y, z, blockBroken, metadata);
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorCore.java
@@ -1,8 +1,8 @@
 package com.brandon3055.draconicevolution.common.blocks.multiblock;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.client.renderer.texture.IIconRegister;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
@@ -19,7 +19,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 /**
  * Created by Brandon on 16/6/2015.
  */
-public class ReactorCore extends BlockDE {
+public class ReactorCore extends BlockDE implements ITileEntityProvider {
 
     public ReactorCore() {
         this.setCreativeTab(DraconicEvolution.tabBlocksItems);
@@ -29,8 +29,8 @@ public class ReactorCore extends BlockDE {
         ModBlocks.register(this);
     }
 
-    @SideOnly(Side.CLIENT)
     @Override
+    @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister iconRegister) {
         blockIcon = iconRegister.registerIcon(References.RESOURCESPREFIX + "transparency");
     }
@@ -56,40 +56,29 @@ public class ReactorCore extends BlockDE {
     }
 
     @Override
-    public TileEntity createTileEntity(World world, int metadata) {
+    public TileEntity createNewTileEntity(World world, int metadata) {
         return new TileReactorCore();
     }
 
     @Override
     public void onBlockAdded(World world, int x, int y, int z) {
-        TileReactorCore tile = world.getTileEntity(x, y, z) instanceof TileReactorCore
-                ? (TileReactorCore) world.getTileEntity(x, y, z)
-                : null;
-        if (tile != null) tile.onPlaced();
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileReactorCore) {
+            ((TileReactorCore) tile).onPlaced();
+        }
     }
 
     @Override
-    public AxisAlignedBB getSelectedBoundingBoxFromPool(World p_149633_1_, int x, int y, int z) {
-
-        return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 1, 1); // super.getSelectedBoundingBoxFromPool(p_149633_1_, x,
-                                                               // y, z);
+    public AxisAlignedBB getSelectedBoundingBoxFromPool(World world, int x, int y, int z) {
+        return AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 1, 1);
     }
 
     @Override
-    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int p_149727_6_,
-            float p_149727_7_, float p_149727_8_, float p_149727_9_) {
-        // TileReactorCore tile = world.getTileEntity(x, y, z) instanceof TileReactorCore ? (TileReactorCore)
-        // world.getTileEntity(x, y, z) : null;
-        // if (tile != null) return tile.onStructureRightClicked(player);
-        return false;
-    }
-
-    @Override
-    public void breakBlock(World world, int x, int y, int z, Block p_149749_5_, int p_149749_6_) {
-        TileReactorCore tile = world.getTileEntity(x, y, z) instanceof TileReactorCore
-                ? (TileReactorCore) world.getTileEntity(x, y, z)
-                : null;
-        if (tile != null) tile.onBroken();
-        super.breakBlock(world, x, y, z, p_149749_5_, p_149749_6_);
+    public void breakBlock(World world, int x, int y, int z, Block blockBroken, int metadata) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileReactorCore) {
+            ((TileReactorCore) tile).onBroken();
+        }
+        super.breakBlock(world, x, y, z, blockBroken, metadata);
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorEnergyInjector.java
@@ -111,9 +111,9 @@ public class ReactorEnergyInjector extends BlockDE implements ITileEntityProvide
         TileEntity tile = world.getTileEntity(x, y, z);
         if (tile instanceof IReactorPart && player.isSneaking()) {
             IReactorPart part = (IReactorPart) tile;
-            part.changeRedstoneMode();
+            part.changeComparatorMode();
             if (!world.isRemote) {
-                player.addChatComponentMessage(new ChatComponentText(part.getRedstoneModeAsString()));
+                player.addChatComponentMessage(new ChatComponentText(part.getComparatorMode().toString()));
             }
             return true;
         }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorEnergyInjector.java
@@ -56,23 +56,23 @@ public class ReactorEnergyInjector extends BlockDE implements ITileEntityProvide
         TileEntity tile = world.getTileEntity(x, y, z);
         if (tile instanceof TileReactorEnergyInjector) {
             TileReactorEnergyInjector injector = (TileReactorEnergyInjector) tile;
-            switch (injector.facingDirection) {
-                case 0:
-                    this.setBlockBounds(0F, 0.885F, 0F, 1F, 1F, 1F);
+            switch (injector.facing) {
+                case DOWN:
+                    this.setBlockBounds(0F, 0.875F, 0F, 1F, 1F, 1F);
                     break;
-                case 1:
+                case UP:
                     this.setBlockBounds(0F, 0F, 0F, 1F, 0.125F, 1F);
                     break;
-                case 2:
-                    this.setBlockBounds(0F, 0F, 0.885F, 1F, 1F, 1F);
+                case NORTH:
+                    this.setBlockBounds(0F, 0F, 0.875F, 1F, 1F, 1F);
                     break;
-                case 3:
+                case SOUTH:
                     this.setBlockBounds(0F, 0F, 0F, 1F, 1F, 0.125F);
                     break;
-                case 4:
-                    this.setBlockBounds(0.885F, 0F, 0F, 1F, 1F, 1F);
+                case WEST:
+                    this.setBlockBounds(0.875F, 0F, 0F, 1F, 1F, 1F);
                     break;
-                case 5:
+                case EAST:
                     this.setBlockBounds(0F, 0F, 0F, 0.125F, 1F, 1F);
                     break;
             }
@@ -96,13 +96,11 @@ public class ReactorEnergyInjector extends BlockDE implements ITileEntityProvide
 
     @Override
     public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack) {
-        int facing = Utills.determineOrientation(x, y, z, entity);
+        ForgeDirection facing = ForgeDirection.getOrientation(Utills.determineOrientation(x, y, z, entity));
         TileEntity tile = world.getTileEntity(x, y, z);
         if (tile instanceof TileReactorEnergyInjector) {
             TileReactorEnergyInjector injector = (TileReactorEnergyInjector) tile;
-            injector.facingDirection = entity.isSneaking()
-                    ? ForgeDirection.getOrientation(facing).getOpposite().ordinal()
-                    : ForgeDirection.getOrientation(facing).ordinal();
+            injector.facing = entity.isSneaking() ? facing.getOpposite() : facing;
             injector.onPlaced();
         }
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorEnergyInjector.java
@@ -113,7 +113,7 @@ public class ReactorEnergyInjector extends BlockDE implements ITileEntityProvide
             IReactorPart part = (IReactorPart) tile;
             part.changeComparatorMode();
             if (!world.isRemote) {
-                player.addChatComponentMessage(new ChatComponentText(part.getComparatorMode().toString()));
+                player.addChatComponentMessage(new ChatComponentText(part.getComparatorMode().toLocalizedString()));
             }
             return true;
         }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorEnergyInjector.java
@@ -1,5 +1,6 @@
 package com.brandon3055.draconicevolution.common.blocks.multiblock;
 
+import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -16,7 +17,6 @@ import com.brandon3055.draconicevolution.DraconicEvolution;
 import com.brandon3055.draconicevolution.common.ModBlocks;
 import com.brandon3055.draconicevolution.common.blocks.BlockDE;
 import com.brandon3055.draconicevolution.common.lib.References;
-import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor.TileReactorCore;
 import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor.TileReactorEnergyInjector;
 
 import cpw.mods.fml.relauncher.Side;
@@ -25,7 +25,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 /**
  * Created by Brandon on 23/7/2015.
  */
-public class ReactorEnergyInjector extends BlockDE {
+public class ReactorEnergyInjector extends BlockDE implements ITileEntityProvider {
 
     public ReactorEnergyInjector() {
         this.setCreativeTab(DraconicEvolution.tabBlocksItems);
@@ -34,49 +34,29 @@ public class ReactorEnergyInjector extends BlockDE {
         ModBlocks.register(this);
     }
 
-    @SideOnly(Side.CLIENT)
     @Override
+    @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister iconRegister) {
         blockIcon = iconRegister.registerIcon(References.RESOURCESPREFIX + "transparency");
     }
 
     @Override
-    public void setBlockBoundsBasedOnState(IBlockAccess access, int x, int y, int z) {
-        TileReactorEnergyInjector tile = access.getTileEntity(x, y, z) instanceof TileReactorEnergyInjector
-                ? (TileReactorEnergyInjector) access.getTileEntity(x, y, z)
-                : null;
-        if (tile != null) {
-            switch (tile.facingDirection) {
-                case 0:
-                    this.setBlockBounds(0F, 0.885F, 0F, 1F, 1F, 1F);
-                    break;
-                case 1:
-                    this.setBlockBounds(0F, 0F, 0F, 1F, 0.125F, 1F);
-                    break;
-                case 2:
-                    this.setBlockBounds(0F, 0F, 0.885F, 1F, 1F, 1F);
-                    break;
-                case 3:
-                    this.setBlockBounds(0F, 0F, 0F, 1F, 1F, 0.125F);
-                    break;
-                case 4:
-                    this.setBlockBounds(0.885F, 0F, 0F, 1F, 1F, 1F);
-                    break;
-                case 5:
-                    this.setBlockBounds(0F, 0F, 0F, 0.125F, 1F, 1F);
-                    break;
-            }
-        }
-        super.setBlockBoundsBasedOnState(access, x, y, z);
+    public void setBlockBoundsBasedOnState(IBlockAccess world, int x, int y, int z) {
+        initializeBoundingBox(world, x, y, z);
+        super.setBlockBoundsBasedOnState(world, x, y, z);
     }
 
     @Override
     public AxisAlignedBB getCollisionBoundingBoxFromPool(World world, int x, int y, int z) {
-        TileReactorEnergyInjector tile = world.getTileEntity(x, y, z) instanceof TileReactorEnergyInjector
-                ? (TileReactorEnergyInjector) world.getTileEntity(x, y, z)
-                : null;
-        if (tile != null) {
-            switch (tile.facingDirection) {
+        initializeBoundingBox(world, x, y, z);
+        return super.getCollisionBoundingBoxFromPool(world, x, y, z);
+    }
+
+    private void initializeBoundingBox(IBlockAccess world, int x, int y, int z) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileReactorEnergyInjector) {
+            TileReactorEnergyInjector injector = (TileReactorEnergyInjector) tile;
+            switch (injector.facingDirection) {
                 case 0:
                     this.setBlockBounds(0F, 0.885F, 0F, 1F, 1F, 1F);
                     break;
@@ -97,7 +77,6 @@ public class ReactorEnergyInjector extends BlockDE {
                     break;
             }
         }
-        return super.getCollisionBoundingBoxFromPool(world, x, y, z);
     }
 
     @Override
@@ -117,41 +96,40 @@ public class ReactorEnergyInjector extends BlockDE {
 
     @Override
     public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack) {
-        int d = Utills.determineOrientation(x, y, z, entity);
-        TileReactorEnergyInjector tile = (TileReactorEnergyInjector) world.getTileEntity(x, y, z);
-        tile.facingDirection = ForgeDirection.getOrientation(d).getOpposite().ordinal();
-        tile.onPlaced();
+        int facing = Utills.determineOrientation(x, y, z, entity);
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileReactorEnergyInjector) {
+            TileReactorEnergyInjector injector = (TileReactorEnergyInjector) tile;
+            injector.facingDirection = entity.isSneaking()
+                    ? ForgeDirection.getOrientation(facing).getOpposite().ordinal()
+                    : ForgeDirection.getOrientation(facing).ordinal();
+            injector.onPlaced();
+        }
     }
 
     @Override
-    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int p_149727_6_,
-            float p_149727_7_, float p_149727_8_, float p_149727_9_) {
-        IReactorPart tile = world.getTileEntity(x, y, z) instanceof IReactorPart
-                ? (IReactorPart) world.getTileEntity(x, y, z)
-                : null;
-        if (tile != null && player.isSneaking()) {
-            tile.changeRedstoneMode();
-            if (!world.isRemote) player.addChatComponentMessage(new ChatComponentText(tile.getRedstoneModeString()));
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float subX,
+            float subY, float subZ) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof IReactorPart && player.isSneaking()) {
+            IReactorPart part = (IReactorPart) tile;
+            part.changeRedstoneMode();
+            if (!world.isRemote) {
+                player.addChatComponentMessage(new ChatComponentText(part.getRedstoneModeAsString()));
+            }
             return true;
         }
         return false;
     }
 
+    @Override
     public boolean hasComparatorInputOverride() {
         return true;
     }
 
     @Override
-    public int getComparatorInputOverride(World world, int x, int y, int z, int p_149736_5_) {
-        IReactorPart tile = world.getTileEntity(x, y, z) instanceof IReactorPart
-                ? (IReactorPart) world.getTileEntity(x, y, z)
-                : null;
-        if (tile == null) return 0;
-        TileReactorCore core = tile.getMaster().getTileEntity(world) instanceof TileReactorCore
-                ? (TileReactorCore) tile.getMaster().getTileEntity(world)
-                : null;
-        if (core != null) return core.getComparatorOutput(tile.getRedstoneMode());
-        return 0;
+    public int getComparatorInputOverride(World world, int x, int y, int z, int side) {
+        return IReactorPart.getComparatorOutput(world, x, y, z);
     }
 
     @Override
@@ -160,7 +138,7 @@ public class ReactorEnergyInjector extends BlockDE {
     }
 
     @Override
-    public TileEntity createTileEntity(World world, int metadata) {
+    public TileEntity createNewTileEntity(World world, int metadata) {
         return new TileReactorEnergyInjector();
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorEnergyInjector.java
@@ -54,27 +54,14 @@ public class ReactorEnergyInjector extends BlockDE implements ITileEntityProvide
 
     private void initializeBoundingBox(IBlockAccess world, int x, int y, int z) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileReactorEnergyInjector) {
-            TileReactorEnergyInjector injector = (TileReactorEnergyInjector) tile;
+        if (tile instanceof TileReactorEnergyInjector injector) {
             switch (injector.facing) {
-                case DOWN:
-                    this.setBlockBounds(0F, 0.875F, 0F, 1F, 1F, 1F);
-                    break;
-                case UP:
-                    this.setBlockBounds(0F, 0F, 0F, 1F, 0.125F, 1F);
-                    break;
-                case NORTH:
-                    this.setBlockBounds(0F, 0F, 0.875F, 1F, 1F, 1F);
-                    break;
-                case SOUTH:
-                    this.setBlockBounds(0F, 0F, 0F, 1F, 1F, 0.125F);
-                    break;
-                case WEST:
-                    this.setBlockBounds(0.875F, 0F, 0F, 1F, 1F, 1F);
-                    break;
-                case EAST:
-                    this.setBlockBounds(0F, 0F, 0F, 0.125F, 1F, 1F);
-                    break;
+                case DOWN -> this.setBlockBounds(0F, 0.875F, 0F, 1F, 1F, 1F);
+                case UP -> this.setBlockBounds(0F, 0F, 0F, 1F, 0.125F, 1F);
+                case NORTH -> this.setBlockBounds(0F, 0F, 0.875F, 1F, 1F, 1F);
+                case SOUTH -> this.setBlockBounds(0F, 0F, 0F, 1F, 1F, 0.125F);
+                case WEST -> this.setBlockBounds(0.875F, 0F, 0F, 1F, 1F, 1F);
+                case EAST -> this.setBlockBounds(0F, 0F, 0F, 0.125F, 1F, 1F);
             }
         }
     }
@@ -98,8 +85,7 @@ public class ReactorEnergyInjector extends BlockDE implements ITileEntityProvide
     public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack) {
         ForgeDirection facing = ForgeDirection.getOrientation(Utills.determineOrientation(x, y, z, entity));
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileReactorEnergyInjector) {
-            TileReactorEnergyInjector injector = (TileReactorEnergyInjector) tile;
+        if (tile instanceof TileReactorEnergyInjector injector) {
             injector.facing = entity.isSneaking() ? facing.getOpposite() : facing;
             injector.onPlaced();
         }
@@ -109,8 +95,7 @@ public class ReactorEnergyInjector extends BlockDE implements ITileEntityProvide
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float subX,
             float subY, float subZ) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof IReactorPart && player.isSneaking()) {
-            IReactorPart part = (IReactorPart) tile;
+        if (tile instanceof IReactorPart part && player.isSneaking()) {
             part.changeComparatorMode();
             if (!world.isRemote) {
                 player.addChatComponentMessage(new ChatComponentText(part.getComparatorMode().toLocalizedString()));

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorStabilizer.java
@@ -53,7 +53,7 @@ public class ReactorStabilizer extends BlockDE implements ITileEntityProvider {
             if (player.isSneaking()) {
                 part.changeComparatorMode();
                 if (!world.isRemote) {
-                    player.addChatComponentMessage(new ChatComponentText(part.getComparatorMode().toString()));
+                    player.addChatComponentMessage(new ChatComponentText(part.getComparatorMode().toLocalizedString()));
                 }
                 return true;
             }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorStabilizer.java
@@ -87,13 +87,11 @@ public class ReactorStabilizer extends BlockDE implements ITileEntityProvider {
 
     @Override
     public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack) {
-        int facing = Utills.determineOrientation(x, y, z, entity);
+        ForgeDirection facing = ForgeDirection.getOrientation(Utills.determineOrientation(x, y, z, entity));
         TileEntity tile = world.getTileEntity(x, y, z);
         if (tile instanceof TileReactorStabilizer) {
             TileReactorStabilizer stabilizer = (TileReactorStabilizer) tile;
-            stabilizer.facingDirection = entity.isSneaking()
-                    ? ForgeDirection.getOrientation(facing).getOpposite().ordinal()
-                    : ForgeDirection.getOrientation(facing).ordinal();
+            stabilizer.facing = entity.isSneaking() ? facing.getOpposite() : facing;
             stabilizer.onPlaced();
         }
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorStabilizer.java
@@ -1,6 +1,7 @@
 package com.brandon3055.draconicevolution.common.blocks.multiblock;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -24,7 +25,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 /**
  * Created by Brandon on 5/7/2015.
  */
-public class ReactorStabilizer extends BlockDE {
+public class ReactorStabilizer extends BlockDE implements ITileEntityProvider {
 
     public ReactorStabilizer() {
         this.setCreativeTab(DraconicEvolution.tabBlocksItems);
@@ -32,8 +33,8 @@ public class ReactorStabilizer extends BlockDE {
         ModBlocks.register(this);
     }
 
-    @SideOnly(Side.CLIENT)
     @Override
+    @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister iconRegister) {
         blockIcon = iconRegister.registerIcon(References.RESOURCESPREFIX + "transparency");
     }
@@ -44,27 +45,21 @@ public class ReactorStabilizer extends BlockDE {
     }
 
     @Override
-    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int p_149727_6_,
-            float p_149727_7_, float p_149727_8_, float p_149727_9_) {
-        if (!player.isSneaking()) {
-            TileReactorStabilizer tile = world.getTileEntity(x, y, z) instanceof TileReactorStabilizer
-                    ? (TileReactorStabilizer) world.getTileEntity(x, y, z)
-                    : null;
-            TileEntity core = null;
-            if (tile != null) core = tile.getMaster().getTileEntity(world);
-            if (core instanceof TileReactorCore) {
-                ((TileReactorCore) core).onStructureRightClicked(player);
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float subX,
+            float subY, float subZ) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof IReactorPart) {
+            IReactorPart part = (IReactorPart) tile;
+            if (player.isSneaking()) {
+                part.changeRedstoneMode();
+                if (!world.isRemote) {
+                    player.addChatComponentMessage(new ChatComponentText(part.getRedstoneModeAsString()));
+                }
                 return true;
             }
-        } else if (!world.isRemote) {
-            IReactorPart tile = world.getTileEntity(x, y, z) instanceof IReactorPart
-                    ? (IReactorPart) world.getTileEntity(x, y, z)
-                    : null;
-            if (tile != null) {
-                tile.changeRedstoneMode();
-                if (!world.isRemote)
-                    player.addChatComponentMessage(new ChatComponentText(tile.getRedstoneModeString()));
-                return true;
+            TileReactorCore core = part.getMaster();
+            if (core != null) {
+                return core.onStructureRightClicked(player);
             }
         }
         return false;
@@ -86,48 +81,41 @@ public class ReactorStabilizer extends BlockDE {
     }
 
     @Override
-    public TileEntity createTileEntity(World world, int metadata) {
+    public TileEntity createNewTileEntity(World world, int metadata) {
         return new TileReactorStabilizer();
     }
 
     @Override
     public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack) {
-        int d = Utills.determineOrientation(x, y, z, entity);
-        TileReactorStabilizer tile = world.getTileEntity(x, y, z) instanceof TileReactorStabilizer
-                ? (TileReactorStabilizer) world.getTileEntity(x, y, z)
-                : null;
-        if (tile != null) {
-            if (entity.isSneaking()) tile.facingDirection = ForgeDirection.getOrientation(d).getOpposite().ordinal();
-            else tile.facingDirection = ForgeDirection.getOrientation(d).ordinal();
-            tile.onPlaced();
+        int facing = Utills.determineOrientation(x, y, z, entity);
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileReactorStabilizer) {
+            TileReactorStabilizer stabilizer = (TileReactorStabilizer) tile;
+            stabilizer.facingDirection = entity.isSneaking()
+                    ? ForgeDirection.getOrientation(facing).getOpposite().ordinal()
+                    : ForgeDirection.getOrientation(facing).ordinal();
+            stabilizer.onPlaced();
         }
     }
 
     @Override
-    public void breakBlock(World world, int x, int y, int z, Block p_149749_5_, int p_149749_6_) {
-        TileReactorStabilizer tile = world.getTileEntity(x, y, z) instanceof TileReactorStabilizer
-                ? (TileReactorStabilizer) world.getTileEntity(x, y, z)
-                : null;
-        TileEntity core = null;
-        if (tile != null) core = tile.getMaster().getTileEntity(world);
-        super.breakBlock(world, x, y, z, p_149749_5_, p_149749_6_);
-        if (core instanceof TileReactorCore) ((TileReactorCore) core).validateStructure();
+    public void breakBlock(World world, int x, int y, int z, Block blockBroken, int metadata) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        TileReactorCore core = tile instanceof IReactorPart ? ((IReactorPart) tile).getMaster() : null;
+        super.breakBlock(world, x, y, z, blockBroken, metadata);
+        if (core != null) {
+            core.updateReactorParts(false);
+            core.validateStructure();
+        }
     }
 
+    @Override
     public boolean hasComparatorInputOverride() {
         return true;
     }
 
     @Override
-    public int getComparatorInputOverride(World world, int x, int y, int z, int p_149736_5_) {
-        IReactorPart tile = world.getTileEntity(x, y, z) instanceof IReactorPart
-                ? (IReactorPart) world.getTileEntity(x, y, z)
-                : null;
-        if (tile == null) return 0;
-        TileReactorCore core = tile.getMaster().getTileEntity(world) instanceof TileReactorCore
-                ? (TileReactorCore) tile.getMaster().getTileEntity(world)
-                : null;
-        if (core != null) return core.getComparatorOutput(tile.getRedstoneMode());
-        return 0;
+    public int getComparatorInputOverride(World world, int x, int y, int z, int side) {
+        return IReactorPart.getComparatorOutput(world, x, y, z);
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorStabilizer.java
@@ -51,9 +51,9 @@ public class ReactorStabilizer extends BlockDE implements ITileEntityProvider {
         if (tile instanceof IReactorPart) {
             IReactorPart part = (IReactorPart) tile;
             if (player.isSneaking()) {
-                part.changeRedstoneMode();
+                part.changeComparatorMode();
                 if (!world.isRemote) {
-                    player.addChatComponentMessage(new ChatComponentText(part.getRedstoneModeAsString()));
+                    player.addChatComponentMessage(new ChatComponentText(part.getComparatorMode().toString()));
                 }
                 return true;
             }

--- a/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/blocks/multiblock/ReactorStabilizer.java
@@ -48,8 +48,7 @@ public class ReactorStabilizer extends BlockDE implements ITileEntityProvider {
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float subX,
             float subY, float subZ) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof IReactorPart) {
-            IReactorPart part = (IReactorPart) tile;
+        if (tile instanceof IReactorPart part) {
             if (player.isSneaking()) {
                 part.changeComparatorMode();
                 if (!world.isRemote) {
@@ -89,8 +88,7 @@ public class ReactorStabilizer extends BlockDE implements ITileEntityProvider {
     public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack) {
         ForgeDirection facing = ForgeDirection.getOrientation(Utills.determineOrientation(x, y, z, entity));
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof TileReactorStabilizer) {
-            TileReactorStabilizer stabilizer = (TileReactorStabilizer) tile;
+        if (tile instanceof TileReactorStabilizer stabilizer) {
             stabilizer.facing = entity.isSneaking() ? facing.getOpposite() : facing;
             stabilizer.onPlaced();
         }
@@ -99,7 +97,7 @@ public class ReactorStabilizer extends BlockDE implements ITileEntityProvider {
     @Override
     public void breakBlock(World world, int x, int y, int z, Block blockBroken, int metadata) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        TileReactorCore core = tile instanceof IReactorPart ? ((IReactorPart) tile).getMaster() : null;
+        TileReactorCore core = tile instanceof IReactorPart part ? part.getMaster() : null;
         super.breakBlock(world, x, y, z, blockBroken, metadata);
         if (core != null) {
             core.updateReactorParts(false);

--- a/src/main/java/com/brandon3055/draconicevolution/common/container/ContainerPlayerDetector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/container/ContainerPlayerDetector.java
@@ -1,37 +1,24 @@
 package com.brandon3055.draconicevolution.common.container;
 
-import java.util.Iterator;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
-import com.brandon3055.draconicevolution.client.gui.GUIPlayerDetector;
 import com.brandon3055.draconicevolution.common.inventory.SlotOpaqueBlock;
 import com.brandon3055.draconicevolution.common.tileentities.TilePlayerDetectorAdvanced;
 
 public class ContainerPlayerDetector extends Container {
 
-    private TilePlayerDetectorAdvanced tileDetector;
-    private GUIPlayerDetector gui = null;
+    private boolean shouldShowInventory = true;
+    private final TilePlayerDetectorAdvanced detector;
 
-    public ContainerPlayerDetector(InventoryPlayer invPlayer, TilePlayerDetectorAdvanced tileDetector) {
-        this.tileDetector = tileDetector;
+    public ContainerPlayerDetector(InventoryPlayer playerInventory, TilePlayerDetectorAdvanced detector) {
+        this.detector = detector;
 
-        bindPlayerInventory(invPlayer);
-        addContainerSlots(tileDetector);
-        updateContainerSlots();
-    }
-
-    public ContainerPlayerDetector(InventoryPlayer invPlayer, TilePlayerDetectorAdvanced tileDetector,
-            GUIPlayerDetector gui) {
-        this.tileDetector = tileDetector;
-        this.gui = gui;
-
-        bindPlayerInventory(invPlayer);
-        addContainerSlots(tileDetector);
+        bindPlayerInventory(playerInventory);
+        addContainerSlots(detector);
         updateContainerSlots();
     }
 
@@ -52,40 +39,27 @@ public class ContainerPlayerDetector extends Container {
     }
 
     public void updateContainerSlots() {
-        if (gui == null) {
-            return;
-        }
-
-        Iterator<Slot> i1 = inventorySlots.iterator();
-        while (i1.hasNext()) {
-            Slot sl = i1.next();
-            if (sl instanceof SlotOpaqueBlock) {
-                if (gui.showInvSlots) {
-                    sl.xDisplayPosition = 143;
-                    sl.yDisplayPosition = 20;
+        for (Slot slot : (Iterable<Slot>) inventorySlots) {
+            if (slot instanceof SlotOpaqueBlock) {
+                if (shouldShowInventory) {
+                    slot.xDisplayPosition = 143;
+                    slot.yDisplayPosition = 20;
                 } else {
-                    sl.xDisplayPosition = -1000;
-                    sl.yDisplayPosition = -1000;
+                    slot.xDisplayPosition = -1000;
+                    slot.yDisplayPosition = -1000;
                 }
             } else {
-                if (gui.showInvSlots) {
-                    if (sl.slotNumber < 9) {
-                        sl.xDisplayPosition = 8 + 18 * sl.slotNumber;
-                        sl.yDisplayPosition = 174;
-                    } else if (sl.slotNumber < 18) {
-                        sl.xDisplayPosition = 8 + 18 * (sl.slotNumber - 9);
-                        sl.yDisplayPosition = 116 + 0 * 18;
-                    } else if (sl.slotNumber < 27) {
-                        sl.xDisplayPosition = 8 + 18 * (sl.slotNumber - 18);
-                        sl.yDisplayPosition = 116 + 1 * 18;
-                    } else if (sl.slotNumber < 36) {
-                        sl.xDisplayPosition = 8 + 18 * (sl.slotNumber - 27);
-                        sl.yDisplayPosition = 116 + 2 * 18;
+                if (shouldShowInventory) {
+                    if (slot.slotNumber < 9) {
+                        slot.xDisplayPosition = 8 + 18 * slot.slotNumber;
+                        slot.yDisplayPosition = 174;
+                    } else if (slot.slotNumber < 36) {
+                        slot.xDisplayPosition = 8 + 18 * (slot.slotNumber % 9);
+                        slot.yDisplayPosition = 116 + (slot.slotNumber / 9 - 1) * 18;
                     }
-
                 } else {
-                    sl.xDisplayPosition = -1000;
-                    sl.yDisplayPosition = -1000;
+                    slot.xDisplayPosition = -1000;
+                    slot.yDisplayPosition = -1000;
                 }
             }
         }
@@ -93,53 +67,24 @@ public class ContainerPlayerDetector extends Container {
 
     @Override
     public boolean canInteractWith(EntityPlayer player) {
-        return tileDetector.isUseableByPlayer(player);
+        return detector.isUseableByPlayer(player);
     }
 
     @Override
-    public ItemStack transferStackInSlot(EntityPlayer player, int i) {
-        // Slot slot = getSlot(i);
-        //
-        //
-        // if (slot != null && slot.getHasStack())
-        // {
-        // ItemStack stack = slot.getStack();
-        // ItemStack result = stack.copy();
-        // Block block = Block.getBlockFromItem(stack.getItem());
-        //
-        // if (i >= 36){
-        // if (!mergeItemStack(stack, 0, 36, false)){
-        // return null;
-        // }
-        // }else if (!(block.isOpaqueCube() && block.renderAsNormalBlock()) || !mergeItemStack(stack, 36, 36 +
-        // tileDetector.getSizeInventory(), false)){
-        // return null;
-        // }
-        //
-        // if (stack.stackSize == 0) {
-        // slot.putStack(null);
-        // }else{
-        // slot.onSlotChanged();
-        // }
-        //
-        // slot.onPickupFromSlot(player, stack);
-        //
-        // return result;
-        // }
-
+    public ItemStack transferStackInSlot(EntityPlayer player, int slot) {
         return null;
     }
 
-    public TilePlayerDetectorAdvanced getTileDetector() {
-        return tileDetector;
+    public boolean shouldShowInventory() {
+        return shouldShowInventory;
     }
 
-    @Override
-    public ItemStack slotClick(int slot, int button, int par3, EntityPlayer par4EntityPlayer) {
-        return super.slotClick(slot, button, par3, par4EntityPlayer);
-        // if (par3 == 4)
-        // return super.slotClick(slot, button, 0, par4EntityPlayer);
-        // else
-        // return super.slotClick(slot, button, par3, par4EntityPlayer);
+    public void setShouldShowInventory(boolean shouldShow) {
+        shouldShowInventory = shouldShow;
+        updateContainerSlots();
+    }
+
+    public TilePlayerDetectorAdvanced getDetector() {
+        return detector;
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/container/ContainerReactor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/container/ContainerReactor.java
@@ -1,29 +1,33 @@
 package com.brandon3055.draconicevolution.common.container;
 
-import java.util.Iterator;
+import java.util.Set;
 
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 import com.brandon3055.draconicevolution.common.ModBlocks;
 import com.brandon3055.draconicevolution.common.ModItems;
 import com.brandon3055.draconicevolution.common.inventory.GenericInventory;
 import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor.TileReactorCore;
+import com.brandon3055.draconicevolution.common.utills.OreDictionaryHelper;
 
 /**
  * Created by brandon3055 on 30/7/2015.
  */
 public class ContainerReactor extends ContainerDataSync {
 
-    private TileReactorCore reactor;
-    private EntityPlayer player;
-    private GenericInventory ioSlots = new GenericInventory() {
+    private static final int MaximumFuelStorage = 10368;
+    private static final int NuggetFuelAmount = 16;
+    private static final int IngotFuelAmount = NuggetFuelAmount * 9;
+    private static final int BlockFuelAmount = IngotFuelAmount * 9;
+    private final TileReactorCore core;
+    private final EntityPlayer player;
+    private final GenericInventory ioSlots = new GenericInventory() {
 
-        private ItemStack[] items = new ItemStack[2];
+        private final ItemStack[] items = new ItemStack[2];
 
         @Override
         public ItemStack[] getStorage() {
@@ -31,53 +35,44 @@ public class ContainerReactor extends ContainerDataSync {
         }
 
         @Override
-        public boolean isItemValidForSlot(int i, ItemStack itemstack) {
-            return true;
-            // return itemstack != null && (itemstack.getItem() == ModItems.draconicIngot || itemstack.getItem() ==
-            // Item.getItemFromBlock(ModBlocks.draconicBlock));
-        }
-
-        @Override
         public int getInventoryStackLimit() {
-            return 1; // super.getInventoryStackLimit();
+            return 1;
         }
 
         @Override
-        public void setInventorySlotContents(int i, ItemStack stack) {
-            if (i == 0 && stack != null
-                    && (stack.getItem() == ModItems.draconicIngot
-                            || stack.getItem() == Item.getItemFromBlock(ModBlocks.draconicBlock)
-                            || (stack.getItem() == ModItems.nugget && stack.getItemDamage() == 1))) {
-                if (stack.getItem() == ModItems.nugget) reactor.reactorFuel += stack.stackSize * 16;
-                if (stack.getItem() == ModItems.draconicIngot) reactor.reactorFuel += stack.stackSize * 144;
-                if (stack.getItem() == Item.getItemFromBlock(ModBlocks.draconicBlock))
-                    reactor.reactorFuel += stack.stackSize * 1296;
-                reactor.validateStructure();
-            } else getStorage()[i] = stack;
+        public void setInventorySlotContents(int slot, ItemStack stack) {
+            if (slot == 0) {
+                Set<String> oreNames = OreDictionaryHelper.getOreNames(stack);
+                if (oreNames.contains("blockDraconiumAwakened")) {
+                    core.reactorFuel += stack.stackSize * BlockFuelAmount;
+                } else if (oreNames.contains("ingotDraconiumAwakened")) {
+                    core.reactorFuel += stack.stackSize * IngotFuelAmount;
+                } else if (oreNames.contains("nuggetDraconiumAwakened")) {
+                    core.reactorFuel += stack.stackSize * NuggetFuelAmount;
+                }
+            } else {
+                items[slot] = stack;
+            }
+        }
+
+        @Override
+        public void markDirty() {
+            super.markDirty();
+            core.markDirty();
         }
     };
 
-    // Syncing //todo sort out syncing
-    public int LTConversionUnit = -1;
-    public int LTReactionIntensity = -1;
-    // public int LTMaxReactIntensity = -1;
-    // public int LTFieldStrength = -1;
-    // public int LTMaxFieldStrength = -1;
-    // public int LTEnergySaturation = -1;
-    // public int LTMaxEnergySaturation = -1;
-    // public int LTFuelConversion = -1;
+    private int conversionUnitCache = -1;
+    private int tempDrainFactorCache = -1;
+    private int generationRateCache = -1;
+    private int fieldDrainCache = -1;
+    private int fuelUseRateCache = -1;
+    private boolean isOfflineCache;
 
-    public double LTTempDrainFactor = -1;
-    public double LTGenerationRate = -1;
-    public int LTFieldDrain = -1;
-    public double LTFuelUseRate = -1;
-    public boolean LTOffline;
-    // #######
-
-    public ContainerReactor(EntityPlayer player, TileReactorCore reactor) {
-        this.reactor = reactor;
+    public ContainerReactor(EntityPlayer player, TileReactorCore core) {
+        this.core = core;
         this.player = player;
-        this.LTOffline = reactor.reactorState == TileReactorCore.STATE_OFFLINE;
+        this.isOfflineCache = core.reactorState == TileReactorCore.STATE_OFFLINE;
 
         for (int x = 0; x < 9; x++) {
             addSlotToContainer(new Slot(player.inventory, x, 44 + 18 * x, 198));
@@ -89,10 +84,19 @@ public class ContainerReactor extends ContainerDataSync {
             }
         }
 
-        if (reactor.reactorState == TileReactorCore.STATE_OFFLINE) {
-            addSlotToContainer(new SlotInsert(ioSlots, 0, 15, 140, reactor));
-            addSlotToContainer(new SlotExtract(ioSlots, 1, 217, 140));
+        if (core.reactorState == TileReactorCore.STATE_OFFLINE) {
+            addFuelSlots();
         }
+    }
+
+    private void addFuelSlots() {
+        addSlotToContainer(new SlotInsert(ioSlots, 0, 15, 140, core));
+        addSlotToContainer(new SlotExtract(ioSlots, 1, 217, 140));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void removeFuelSlots() {
+        inventorySlots.removeIf(o -> o instanceof SlotExtract || o instanceof SlotInsert);
     }
 
     @Override
@@ -116,158 +120,141 @@ public class ContainerReactor extends ContainerDataSync {
     }
 
     @Override
-    public void detectAndSendChanges() { // todo check what values are being synced by the tile and remove them from
-                                         // here
-
-        if (LTOffline && reactor.reactorState != TileReactorCore.STATE_OFFLINE) {
-            Iterator i = inventorySlots.iterator();
-            while (i.hasNext()) {
-                Object o = i.next();
-                if (o instanceof SlotExtract || o instanceof SlotInsert) i.remove();
-            }
+    public void detectAndSendChanges() {
+        if (isOfflineCache && core.reactorState != TileReactorCore.STATE_OFFLINE) {
+            removeFuelSlots();
             sendObjectToClient(null, 99, 1);
-        } else if (!LTOffline && reactor.reactorState == TileReactorCore.STATE_OFFLINE) {
-            addSlotToContainer(new SlotInsert(ioSlots, 0, 15, 140, reactor));
-            addSlotToContainer(new SlotExtract(ioSlots, 1, 217, 140));
+        } else if (!isOfflineCache && core.reactorState == TileReactorCore.STATE_OFFLINE) {
+            addFuelSlots();
             sendObjectToClient(null, 98, 1);
         }
-        LTOffline = reactor.reactorState == TileReactorCore.STATE_OFFLINE;
+        isOfflineCache = core.reactorState == TileReactorCore.STATE_OFFLINE;
 
-        if (reactor.conversionUnit != LTConversionUnit)
-            LTConversionUnit = (Integer) sendObjectToClient(null, 0, (int) (reactor.conversionUnit * 100));
-        // if ((int)reactor.reactionTemperature != LTReactionIntensity)LTReactionIntensity = (Integer)
-        // sendObjectToClient(null, 1, (int) reactor.reactionTemperature);
-        // if ((int)reactor.maxReactTemperature != LTMaxReactIntensity)LTMaxReactIntensity = (Integer)
-        // sendObjectToClient(null, 2, (int) reactor.maxReactTemperature);
-        // if ((int)reactor.fieldCharge != LTFieldStrength) LTFieldStrength = (Integer) sendObjectToClient(null,
-        // 3, (int) reactor.fieldCharge);
-        // if ((int)reactor.maxFieldCharge != LTMaxFieldStrength) LTMaxFieldStrength = (Integer)
-        // sendObjectToClient(null, 7, (int) reactor.maxFieldCharge);
-        // if (reactor.energySaturation != LTEnergySaturation) LTEnergySaturation = (Integer)
-        // sendObjectToClient(null, 4, reactor.energySaturation);
-        // if (reactor.maxEnergySaturation != LTMaxEnergySaturation) LTMaxEnergySaturation = (Integer)
-        // sendObjectToClient(null, 5, reactor.maxEnergySaturation);
-        // if (reactor.convertedFuel != LTFuelConversion) LTFuelConversion = (Integer) sendObjectToClient(null,
-        // 6, reactor.convertedFuel);
-        /* if (reactor.tempDrainFactor != LTTempDrainFactor) LTTempDrainFactor = (Integer) */
-        sendObjectToClient(null, 8, (int) (reactor.tempDrainFactor * 1000D));
-        if (reactor.generationRate != LTGenerationRate)
-            LTGenerationRate = (Integer) sendObjectToClient(null, 9, (int) (reactor.generationRate));
-        if (reactor.fieldDrain != LTFieldDrain)
-            LTFieldDrain = (Integer) sendObjectToClient(null, 10, reactor.fieldDrain);
-        /* if (reactor.fuelUseRate != LTFuelUseRate) LTFuelUseRate = (Integer) */
-        sendObjectToClient(null, 11, (int) (reactor.fuelUseRate * 1000000D));
+        int conversionUnit = (int) (core.conversionUnit * 100);
+        if (conversionUnit != conversionUnitCache) {
+            conversionUnitCache = (int) sendObjectToClient(null, 0, conversionUnit);
+        }
+        int tempDrainFactor = (int) (core.tempDrainFactor * 1000);
+        if (tempDrainFactor != tempDrainFactorCache) {
+            tempDrainFactorCache = (int) sendObjectToClient(null, 8, tempDrainFactor);
+        }
+        int generationRate = (int) core.generationRate;
+        if (generationRate != generationRateCache) {
+            generationRateCache = (int) sendObjectToClient(null, 9, generationRate);
+        }
+        if (core.fieldDrain != fieldDrainCache) {
+            fieldDrainCache = (int) sendObjectToClient(null, 10, core.fieldDrain);
+        }
+        int fuelUseRate = (int) (core.fuelUseRate * 1000000);
+        if (fuelUseRate != fuelUseRateCache) {
+            fuelUseRateCache = (int) sendObjectToClient(null, 11, fuelUseRate);
+        }
 
         super.detectAndSendChanges();
     }
 
     @Override
     public void receiveSyncData(int index, int value) {
-        if (index == 0) reactor.conversionUnit = (double) value / 100D;
-        // else if (index == 1) reactor.reactionTemperature = value;
-        // else if (index == 2) reactor.maxReactTemperature = value;
-        // else if (index == 3) reactor.fieldCharge = value;
-        // else if (index == 4) reactor.energySaturation = value;
-        // else if (index == 5) reactor.maxEnergySaturation = value;
-        // else if (index == 6) reactor.convertedFuel = value;
-        // else if (index == 7) reactor.maxFieldCharge = value;
-        else if (index == 8) reactor.tempDrainFactor = value / 1000D;
-        else if (index == 9) reactor.generationRate = value;
-        else if (index == 10) reactor.fieldDrain = value;
-        else if (index == 11) reactor.fuelUseRate = value / 1000000D;
-        if (index == 20) reactor.processButtonPress(value);
+        if (index == 0) {
+            core.conversionUnit = (double) value / 100D;
+        } else if (index == 8) {
+            core.tempDrainFactor = value / 1000D;
+        } else if (index == 9) {
+            core.generationRate = value;
+        } else if (index == 10) {
+            core.fieldDrain = value;
+        } else if (index == 11) {
+            core.fuelUseRate = value / 1000000D;
+        }
+        if (index == 20) {
+            core.processButtonPress(value);
+        }
         if (index == 99) {
-            Iterator i = inventorySlots.iterator();
-            while (i.hasNext()) {
-                Object o = i.next();
-                if (o instanceof SlotExtract || o instanceof SlotInsert) i.remove();
-            }
+            removeFuelSlots();
         } else if (index == 98) {
-            addSlotToContainer(new SlotInsert(ioSlots, 0, 15, 140, reactor));
-            addSlotToContainer(new SlotExtract(ioSlots, 1, 217, 140));
+            addFuelSlots();
         }
     }
 
     @Override
-    public ItemStack slotClick(int slot, int button, int p_75144_3_, EntityPlayer player1) {
-        if (slot == 37 && player1.inventory.getItemStack() == null) {
-            if (reactor.reactorFuel / 144 >= 64) {
-                int i = reactor.reactorFuel / 1296;
-                int i2 = Math.min(64, i);
-                ioSlots.getStorage()[1] = new ItemStack(ModBlocks.draconicBlock, i2);
-                reactor.reactorFuel -= i2 * 1296;
-            } else if (reactor.reactorFuel >= 144) {
-                int i = reactor.reactorFuel / 144;
-                int i2 = Math.min(64, i);
-                ioSlots.getStorage()[1] = new ItemStack(ModItems.draconicIngot, i2);
-                reactor.reactorFuel -= i2 * 144;
-            } else if (reactor.reactorFuel >= 16) {
-                int i = reactor.reactorFuel / 16;
-                int i2 = Math.min(64, i);
-                ioSlots.getStorage()[1] = new ItemStack(ModItems.nugget, i2, 1);
-                reactor.reactorFuel -= i2 * 16;
-            } else if (reactor.convertedFuel / 144 >= 64) {
-                int i = reactor.convertedFuel / 1296;
-                int i2 = Math.min(64, i);
-                ioSlots.getStorage()[1] = new ItemStack(ModItems.chaosFragment, i2, 2);
-                reactor.convertedFuel -= i2 * 1296;
-            } else if (reactor.convertedFuel >= 144) {
-                int i = reactor.convertedFuel / 144;
-                int i2 = Math.min(64, i);
-                ioSlots.getStorage()[1] = new ItemStack(ModItems.chaosFragment, i2, 1);
-                reactor.convertedFuel -= i2 * 144;
-            } else if (reactor.convertedFuel >= 16) {
-                int i = reactor.convertedFuel / 16;
-                int i2 = Math.min(64, i);
-                ioSlots.getStorage()[1] = new ItemStack(ModItems.chaosFragment, i2, 0);
-                reactor.convertedFuel -= i2 * 16;
+    public ItemStack slotClick(int slot, int button, int mode, EntityPlayer player) {
+        if (slot == 37 && player.inventory.getItemStack() == null) {
+            if (core.reactorFuel / IngotFuelAmount >= 64) {
+                int stackSize = core.reactorFuel / BlockFuelAmount;
+                stackSize = Math.min(64, stackSize);
+                ioSlots.setInventorySlotContents(1, new ItemStack(ModBlocks.draconicBlock, stackSize));
+                core.reactorFuel -= stackSize * BlockFuelAmount;
+            } else if (core.reactorFuel >= IngotFuelAmount) {
+                int stackSize = core.reactorFuel / IngotFuelAmount;
+                stackSize = Math.min(64, stackSize);
+                ioSlots.setInventorySlotContents(1, new ItemStack(ModItems.draconicIngot, stackSize));
+                core.reactorFuel -= stackSize * IngotFuelAmount;
+            } else if (core.reactorFuel >= NuggetFuelAmount) {
+                int stackSize = core.reactorFuel / NuggetFuelAmount;
+                ioSlots.setInventorySlotContents(1, new ItemStack(ModItems.nugget, stackSize, 1));
+                core.reactorFuel -= stackSize * NuggetFuelAmount;
+            } else if (core.convertedFuel / IngotFuelAmount >= 64) {
+                int stackSize = core.convertedFuel / BlockFuelAmount;
+                stackSize = Math.min(64, stackSize);
+                ioSlots.setInventorySlotContents(1, new ItemStack(ModItems.chaosFragment, stackSize, 2));
+                core.convertedFuel -= stackSize * BlockFuelAmount;
+            } else if (core.convertedFuel >= IngotFuelAmount) {
+                int stackSize = core.convertedFuel / IngotFuelAmount;
+                stackSize = Math.min(64, stackSize);
+                ioSlots.setInventorySlotContents(1, new ItemStack(ModItems.chaosFragment, stackSize, 1));
+                core.convertedFuel -= stackSize * IngotFuelAmount;
+            } else if (core.convertedFuel >= NuggetFuelAmount) {
+                int stackSize = core.convertedFuel / NuggetFuelAmount;
+                ioSlots.setInventorySlotContents(1, new ItemStack(ModItems.chaosFragment, stackSize, 0));
+                core.convertedFuel -= stackSize * NuggetFuelAmount;
             }
         }
-        return super.slotClick(slot, button, p_75144_3_, player1);
+        return super.slotClick(slot, button, mode, player);
     }
 
     @Override
-    public ItemStack transferStackInSlot(EntityPlayer p_82846_1_, int p_82846_2_) {
+    public ItemStack transferStackInSlot(EntityPlayer player, int index) {
         return null;
     }
 
     public static class SlotInsert extends Slot {
 
-        private int numberAllowed = -1;
-        private TileReactorCore reactor;
+        private int stackSizeLimit = 0;
+        private final TileReactorCore core;
 
-        public SlotInsert(IInventory iInventory, int iSlot, int x, int y, TileReactorCore reactor) {
-            super(iInventory, iSlot, x, y);
-            this.reactor = reactor;
+        public SlotInsert(IInventory inventory, int slot, int x, int y, TileReactorCore core) {
+            super(inventory, slot, x, y);
+            this.core = core;
         }
 
         @Override
         public boolean isItemValid(ItemStack stack) {
-            if (stack == null) return false;
-            else if (stack.getItem() == ModItems.nugget && stack.getItemDamage() == 1)
-                numberAllowed = (10368 - (reactor.reactorFuel + reactor.convertedFuel)) / 16;
-            else if (stack.getItem() == ModItems.draconicIngot)
-                numberAllowed = (10368 - (reactor.reactorFuel + reactor.convertedFuel)) / 144;
-            else if (stack.getItem() == Item.getItemFromBlock(ModBlocks.draconicBlock))
-                numberAllowed = (10368 - (reactor.reactorFuel + reactor.convertedFuel)) / 1296;
-            else return false;
-
-            return numberAllowed > 0;
+            if (stack == null) {
+                return false;
+            }
+            Set<String> oreNames = OreDictionaryHelper.getOreNames(stack);
+            if (oreNames.contains("nuggetDraconiumAwakened")) {
+                stackSizeLimit = (MaximumFuelStorage - (core.reactorFuel + core.convertedFuel)) / NuggetFuelAmount;
+            } else if (oreNames.contains("ingotDraconiumAwakened")) {
+                stackSizeLimit = (MaximumFuelStorage - (core.reactorFuel + core.convertedFuel)) / IngotFuelAmount;
+            } else if (oreNames.contains("blockDraconiumAwakened")) {
+                stackSizeLimit = (MaximumFuelStorage - (core.reactorFuel + core.convertedFuel)) / BlockFuelAmount;
+            } else {
+                return false;
+            }
+            return stackSizeLimit > 0;
         }
 
         @Override
         public int getSlotStackLimit() {
-            return numberAllowed;
+            return stackSizeLimit;
         }
     }
 
     public static class SlotExtract extends Slot {
 
-        private GenericInventory inventory;
-
-        public SlotExtract(GenericInventory iInventory, int iSlot, int x, int y) {
-            super(iInventory, iSlot, x, y);
-            inventory = iInventory;
+        public SlotExtract(GenericInventory inventory, int slot, int x, int y) {
+            super(inventory, slot, x, y);
         }
 
         @Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/container/ContainerReactor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/container/ContainerReactor.java
@@ -20,10 +20,10 @@ import com.brandon3055.draconicevolution.common.utills.OreDictionaryHelper;
  */
 public class ContainerReactor extends ContainerDataSync {
 
-    private static final int MaximumFuelStorage = 10368;
-    private static final int NuggetFuelAmount = 16;
-    private static final int IngotFuelAmount = NuggetFuelAmount * 9;
-    private static final int BlockFuelAmount = IngotFuelAmount * 9;
+    private static final int maximumFuelStorage = 10368;
+    private static final int nuggetFuelAmount = 16;
+    private static final int ingotFuelAmount = nuggetFuelAmount * 9;
+    private static final int blockFuelAmount = ingotFuelAmount * 9;
     private final TileReactorCore core;
     private final EntityPlayer player;
     private final GenericInventory ioSlots = new GenericInventory() {
@@ -45,11 +45,11 @@ public class ContainerReactor extends ContainerDataSync {
             if (slot == 0) {
                 Set<String> oreNames = OreDictionaryHelper.getOreNames(stack);
                 if (oreNames.contains("blockDraconiumAwakened")) {
-                    core.reactorFuel += stack.stackSize * BlockFuelAmount;
+                    core.reactorFuel += stack.stackSize * blockFuelAmount;
                 } else if (oreNames.contains("ingotDraconiumAwakened")) {
-                    core.reactorFuel += stack.stackSize * IngotFuelAmount;
+                    core.reactorFuel += stack.stackSize * ingotFuelAmount;
                 } else if (oreNames.contains("nuggetDraconiumAwakened")) {
-                    core.reactorFuel += stack.stackSize * NuggetFuelAmount;
+                    core.reactorFuel += stack.stackSize * nuggetFuelAmount;
                 }
             } else {
                 items[slot] = stack;
@@ -180,34 +180,34 @@ public class ContainerReactor extends ContainerDataSync {
     @Override
     public ItemStack slotClick(int slot, int button, int mode, EntityPlayer player) {
         if (slot == 37 && player.inventory.getItemStack() == null) {
-            if (core.reactorFuel / IngotFuelAmount >= 64) {
-                int stackSize = core.reactorFuel / BlockFuelAmount;
+            if (core.reactorFuel / ingotFuelAmount >= 64) {
+                int stackSize = core.reactorFuel / blockFuelAmount;
                 stackSize = Math.min(64, stackSize);
                 ioSlots.setInventorySlotContents(1, new ItemStack(ModBlocks.draconicBlock, stackSize));
-                core.reactorFuel -= stackSize * BlockFuelAmount;
-            } else if (core.reactorFuel >= IngotFuelAmount) {
-                int stackSize = core.reactorFuel / IngotFuelAmount;
+                core.reactorFuel -= stackSize * blockFuelAmount;
+            } else if (core.reactorFuel >= ingotFuelAmount) {
+                int stackSize = core.reactorFuel / ingotFuelAmount;
                 stackSize = Math.min(64, stackSize);
                 ioSlots.setInventorySlotContents(1, new ItemStack(ModItems.draconicIngot, stackSize));
-                core.reactorFuel -= stackSize * IngotFuelAmount;
-            } else if (core.reactorFuel >= NuggetFuelAmount) {
-                int stackSize = core.reactorFuel / NuggetFuelAmount;
+                core.reactorFuel -= stackSize * ingotFuelAmount;
+            } else if (core.reactorFuel >= nuggetFuelAmount) {
+                int stackSize = core.reactorFuel / nuggetFuelAmount;
                 ioSlots.setInventorySlotContents(1, new ItemStack(ModItems.nugget, stackSize, 1));
-                core.reactorFuel -= stackSize * NuggetFuelAmount;
-            } else if (core.convertedFuel / IngotFuelAmount >= 64) {
-                int stackSize = core.convertedFuel / BlockFuelAmount;
+                core.reactorFuel -= stackSize * nuggetFuelAmount;
+            } else if (core.convertedFuel / ingotFuelAmount >= 64) {
+                int stackSize = core.convertedFuel / blockFuelAmount;
                 stackSize = Math.min(64, stackSize);
                 ioSlots.setInventorySlotContents(1, new ItemStack(ModItems.chaosFragment, stackSize, 2));
-                core.convertedFuel -= stackSize * BlockFuelAmount;
-            } else if (core.convertedFuel >= IngotFuelAmount) {
-                int stackSize = core.convertedFuel / IngotFuelAmount;
+                core.convertedFuel -= stackSize * blockFuelAmount;
+            } else if (core.convertedFuel >= ingotFuelAmount) {
+                int stackSize = core.convertedFuel / ingotFuelAmount;
                 stackSize = Math.min(64, stackSize);
                 ioSlots.setInventorySlotContents(1, new ItemStack(ModItems.chaosFragment, stackSize, 1));
-                core.convertedFuel -= stackSize * IngotFuelAmount;
-            } else if (core.convertedFuel >= NuggetFuelAmount) {
-                int stackSize = core.convertedFuel / NuggetFuelAmount;
+                core.convertedFuel -= stackSize * ingotFuelAmount;
+            } else if (core.convertedFuel >= nuggetFuelAmount) {
+                int stackSize = core.convertedFuel / nuggetFuelAmount;
                 ioSlots.setInventorySlotContents(1, new ItemStack(ModItems.chaosFragment, stackSize, 0));
-                core.convertedFuel -= stackSize * NuggetFuelAmount;
+                core.convertedFuel -= stackSize * nuggetFuelAmount;
             }
         }
         return super.slotClick(slot, button, mode, player);
@@ -235,11 +235,11 @@ public class ContainerReactor extends ContainerDataSync {
             }
             Set<String> oreNames = OreDictionaryHelper.getOreNames(stack);
             if (oreNames.contains("nuggetDraconiumAwakened")) {
-                stackSizeLimit = (MaximumFuelStorage - (core.reactorFuel + core.convertedFuel)) / NuggetFuelAmount;
+                stackSizeLimit = (maximumFuelStorage - (core.reactorFuel + core.convertedFuel)) / nuggetFuelAmount;
             } else if (oreNames.contains("ingotDraconiumAwakened")) {
-                stackSizeLimit = (MaximumFuelStorage - (core.reactorFuel + core.convertedFuel)) / IngotFuelAmount;
+                stackSizeLimit = (maximumFuelStorage - (core.reactorFuel + core.convertedFuel)) / ingotFuelAmount;
             } else if (oreNames.contains("blockDraconiumAwakened")) {
-                stackSizeLimit = (MaximumFuelStorage - (core.reactorFuel + core.convertedFuel)) / BlockFuelAmount;
+                stackSizeLimit = (maximumFuelStorage - (core.reactorFuel + core.convertedFuel)) / blockFuelAmount;
             } else {
                 return false;
             }

--- a/src/main/java/com/brandon3055/draconicevolution/common/container/ContainerReactor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/container/ContainerReactor.java
@@ -12,6 +12,7 @@ import com.brandon3055.draconicevolution.common.ModBlocks;
 import com.brandon3055.draconicevolution.common.ModItems;
 import com.brandon3055.draconicevolution.common.inventory.GenericInventory;
 import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor.TileReactorCore;
+import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor.TileReactorCore.ReactorState;
 import com.brandon3055.draconicevolution.common.utills.OreDictionaryHelper;
 
 /**
@@ -72,7 +73,7 @@ public class ContainerReactor extends ContainerDataSync {
     public ContainerReactor(EntityPlayer player, TileReactorCore core) {
         this.core = core;
         this.player = player;
-        this.isOfflineCache = core.reactorState == TileReactorCore.STATE_OFFLINE;
+        this.isOfflineCache = core.reactorState == ReactorState.OFFLINE;
 
         for (int x = 0; x < 9; x++) {
             addSlotToContainer(new Slot(player.inventory, x, 44 + 18 * x, 198));
@@ -84,7 +85,7 @@ public class ContainerReactor extends ContainerDataSync {
             }
         }
 
-        if (core.reactorState == TileReactorCore.STATE_OFFLINE) {
+        if (core.reactorState == ReactorState.OFFLINE) {
             addFuelSlots();
         }
     }
@@ -121,14 +122,14 @@ public class ContainerReactor extends ContainerDataSync {
 
     @Override
     public void detectAndSendChanges() {
-        if (isOfflineCache && core.reactorState != TileReactorCore.STATE_OFFLINE) {
+        if (isOfflineCache && core.reactorState != ReactorState.OFFLINE) {
             removeFuelSlots();
             sendObjectToClient(null, 99, 1);
-        } else if (!isOfflineCache && core.reactorState == TileReactorCore.STATE_OFFLINE) {
+        } else if (!isOfflineCache && core.reactorState == ReactorState.OFFLINE) {
             addFuelSlots();
             sendObjectToClient(null, 98, 1);
         }
-        isOfflineCache = core.reactorState == TileReactorCore.STATE_OFFLINE;
+        isOfflineCache = core.reactorState == ReactorState.OFFLINE;
 
         int conversionUnit = (int) (core.conversionUnit * 100);
         if (conversionUnit != conversionUnitCache) {

--- a/src/main/java/com/brandon3055/draconicevolution/common/entity/ChaosImplosionTrace.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/entity/ChaosImplosionTrace.java
@@ -54,7 +54,7 @@ public class ChaosImplosionTrace implements IProcess {
             List<Entity> entities = worldObj.getEntitiesWithinAABB(
                     Entity.class,
                     AxisAlignedBB.getBoundingBox(xCoord, y, zCoord, xCoord + 1, y + 1, zCoord + 1));
-            for (Entity entity : entities) entity.attackEntityFrom(ReactorExplosion.fusionExplosion, power * 100);
+            for (Entity entity : entities) entity.attackEntityFrom(ReactorExplosion.FUSION_EXPLOSION, power * 100);
 
             // energy -= block instanceof BlockLiquid ? 10 : block.getExplosionResistance(null);
             if (energy >= 0) worldObj.setBlockToAir(xCoord, y, zCoord);

--- a/src/main/java/com/brandon3055/draconicevolution/common/network/ParticleGenPacket.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/network/ParticleGenPacket.java
@@ -57,130 +57,49 @@ public class ParticleGenPacket implements IMessage {
         public IMessage onMessage(ParticleGenPacket message, MessageContext ctx) {
             TileEntity tile = ctx.getServerHandler().playerEntity.worldObj
                     .getTileEntity(message.tileX, message.tileY, message.tileZ);
-            if (!(tile instanceof TileParticleGenerator)) {
+            if (!(tile instanceof TileParticleGenerator particleGenerator)) {
                 return null;
             }
-            TileParticleGenerator particleGenerator = (TileParticleGenerator) tile;
             switch (message.id) {
-                case 0:
-                    particleGenerator.red = message.value;
-                    break;
-                case 1:
-                    particleGenerator.green = message.value;
-                    break;
-                case 2:
-                    particleGenerator.blue = message.value;
-                    break;
-                case 3:
-                    particleGenerator.motionX = (float) message.value / 1000F;
-                    break;
-                case 4:
-                    particleGenerator.motionY = (float) message.value / 1000F;
-                    break;
-                case 5:
-                    particleGenerator.motionZ = (float) message.value / 1000F;
-                    break;
-                case 6:
-                    particleGenerator.scale = (float) message.value / 100F;
-                    break;
-                case 7:
-                    particleGenerator.life = message.value;
-                    break;
-                case 10:
-                    particleGenerator.randomRed = message.value;
-                    break;
-                case 11:
-                    particleGenerator.randomGreen = message.value;
-                    break;
-                case 12:
-                    particleGenerator.randomBlue = message.value;
-                    break;
-                case 13:
-                    particleGenerator.randomMotionX = (float) message.value / 1000F;
-                    break;
-                case 14:
-                    particleGenerator.randomMotionY = (float) message.value / 1000F;
-                    break;
-                case 15:
-                    particleGenerator.randomMotionZ = (float) message.value / 1000F;
-                    break;
-                case 16:
-                    particleGenerator.randomScale = (float) message.value / 100F;
-                    break;
-                case 17:
-                    particleGenerator.randomLife = message.value;
-                    break;
-                case 20:
-                    particleGenerator.spawnX = (float) message.value / 10F;
-                    break;
-                case 21:
-                    particleGenerator.spawnY = (float) message.value / 10F;
-                    break;
-                case 22:
-                    particleGenerator.spawnZ = (float) message.value / 10F;
-                    break;
-                case 23:
-                    particleGenerator.spawnRate = message.value;
-                    break;
-                case 24:
-                    particleGenerator.fade = message.value;
-                    break;
-                case 25:
-                    particleGenerator.gravity = (float) message.value / 1000F;
-                case 30:
-                    particleGenerator.randomSpawnX = (float) message.value / 10F;
-                    break;
-                case 31:
-                    particleGenerator.randomSpawnY = (float) message.value / 10F;
-                    break;
-                case 32:
-                    particleGenerator.randomSpawnZ = (float) message.value / 10F;
-                    break;
-                case 40:
-                    particleGenerator.beamRed = message.value;
-                    break;
-                case 41:
-                    particleGenerator.beamGreen = message.value;
-                    break;
-                case 42:
-                    particleGenerator.beamBlue = message.value;
-                    break;
-                case 43:
-                    particleGenerator.beamPitch = (float) message.value / 10F;
-                    break;
-                case 44:
-                    particleGenerator.beamYaw = (float) message.value / 10F;
-                    break;
-                case 45:
-                    particleGenerator.beamRotation = (float) message.value / 100F;
-                    break;
-                case 46:
-                    particleGenerator.beamScale = (float) message.value / 100F;
-                    break;
-                case 47:
-                    particleGenerator.beamLength = (float) message.value / 100F;
-                    break;
-                case 100:
-                case 101:
-                case 102:
-                case 103:
-                    particleGenerator.page = message.value;
-                    break;
-                case 110:
-                    particleGenerator.canParticleCollide = message.value == 1;
-                    break;
-                case 111:
-                    particleGenerator.selectedParticle = message.value;
-                    break;
-                case 112:
-                    particleGenerator.isParticlesEnabled = message.value == 1;
-                    break;
-                case 120:
-                    particleGenerator.isBeamEnabled = message.value == 1;
-                    break;
-                case 121:
-                    particleGenerator.shouldRenderCore = message.value == 1;
-                    break;
+                case 0 -> particleGenerator.red = message.value;
+                case 1 -> particleGenerator.green = message.value;
+                case 2 -> particleGenerator.blue = message.value;
+                case 3 -> particleGenerator.motionX = (float) message.value / 1000F;
+                case 4 -> particleGenerator.motionY = (float) message.value / 1000F;
+                case 5 -> particleGenerator.motionZ = (float) message.value / 1000F;
+                case 6 -> particleGenerator.scale = (float) message.value / 100F;
+                case 7 -> particleGenerator.life = message.value;
+                case 10 -> particleGenerator.randomRed = message.value;
+                case 11 -> particleGenerator.randomGreen = message.value;
+                case 12 -> particleGenerator.randomBlue = message.value;
+                case 13 -> particleGenerator.randomMotionX = (float) message.value / 1000F;
+                case 14 -> particleGenerator.randomMotionY = (float) message.value / 1000F;
+                case 15 -> particleGenerator.randomMotionZ = (float) message.value / 1000F;
+                case 16 -> particleGenerator.randomScale = (float) message.value / 100F;
+                case 17 -> particleGenerator.randomLife = message.value;
+                case 20 -> particleGenerator.spawnX = (float) message.value / 10F;
+                case 21 -> particleGenerator.spawnY = (float) message.value / 10F;
+                case 22 -> particleGenerator.spawnZ = (float) message.value / 10F;
+                case 23 -> particleGenerator.spawnRate = message.value;
+                case 24 -> particleGenerator.fade = message.value;
+                case 25 -> particleGenerator.gravity = (float) message.value / 1000F;
+                case 30 -> particleGenerator.randomSpawnX = (float) message.value / 10F;
+                case 31 -> particleGenerator.randomSpawnY = (float) message.value / 10F;
+                case 32 -> particleGenerator.randomSpawnZ = (float) message.value / 10F;
+                case 40 -> particleGenerator.beamRed = message.value;
+                case 41 -> particleGenerator.beamGreen = message.value;
+                case 42 -> particleGenerator.beamBlue = message.value;
+                case 43 -> particleGenerator.beamPitch = (float) message.value / 10F;
+                case 44 -> particleGenerator.beamYaw = (float) message.value / 10F;
+                case 45 -> particleGenerator.beamRotation = (float) message.value / 100F;
+                case 46 -> particleGenerator.beamScale = (float) message.value / 100F;
+                case 47 -> particleGenerator.beamLength = (float) message.value / 100F;
+                case 100, 101, 102, 103 -> particleGenerator.page = message.value;
+                case 110 -> particleGenerator.canParticleCollide = message.value == 1;
+                case 111 -> particleGenerator.selectedParticle = message.value;
+                case 112 -> particleGenerator.isParticlesEnabled = message.value == 1;
+                case 120 -> particleGenerator.isBeamEnabled = message.value == 1;
+                case 121 -> particleGenerator.shouldRenderCore = message.value == 1;
             }
 
             EntityPlayerMP player = ctx.getServerHandler().playerEntity;
@@ -203,8 +122,7 @@ public class ParticleGenPacket implements IMessage {
             ItemStack stack = new ItemStack(Items.paper);
             stack.setTagCompound(new NBTTagCompound());
             TileEntity tile = player.worldObj.getTileEntity(message.tileX, message.tileY, message.tileZ);
-            if (tile instanceof TileParticleGenerator) {
-                TileParticleGenerator particleGenerator = (TileParticleGenerator) tile;
+            if (tile instanceof TileParticleGenerator particleGenerator) {
                 particleGenerator.getBlockNBT(stack.getTagCompound());
                 stack.setStackDisplayName("Saved Particle Gen Settings");
                 player.worldObj.spawnEntityInWorld(

--- a/src/main/java/com/brandon3055/draconicevolution/common/network/ParticleGenPacket.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/network/ParticleGenPacket.java
@@ -1,7 +1,7 @@
 package com.brandon3055.draconicevolution.common.network;
 
 import net.minecraft.entity.item.EntityItem;
-import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -9,7 +9,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentText;
 
 import com.brandon3055.draconicevolution.common.tileentities.TileParticleGenerator;
-import com.brandon3055.draconicevolution.common.utills.LogHelper;
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
@@ -18,7 +17,7 @@ import io.netty.buffer.ByteBuf;
 
 public class ParticleGenPacket implements IMessage {
 
-    byte buttonId = 0;
+    byte id = 0;
     short value = 0;
     int tileX = 0;
     int tileY = 0;
@@ -26,8 +25,8 @@ public class ParticleGenPacket implements IMessage {
 
     public ParticleGenPacket() {}
 
-    public ParticleGenPacket(byte buttonId, short value, int x, int y, int z) {
-        this.buttonId = buttonId;
+    public ParticleGenPacket(byte id, short value, int x, int y, int z) {
+        this.id = id;
         this.value = value;
         this.tileX = x;
         this.tileY = y;
@@ -36,7 +35,7 @@ public class ParticleGenPacket implements IMessage {
 
     @Override
     public void toBytes(ByteBuf bytes) {
-        bytes.writeByte(buttonId);
+        bytes.writeByte(id);
         bytes.writeShort(value);
         bytes.writeInt(tileX);
         bytes.writeInt(tileY);
@@ -45,7 +44,7 @@ public class ParticleGenPacket implements IMessage {
 
     @Override
     public void fromBytes(ByteBuf bytes) {
-        this.buttonId = bytes.readByte();
+        this.id = bytes.readByte();
         this.value = bytes.readShort();
         this.tileX = bytes.readInt();
         this.tileY = bytes.readInt();
@@ -58,267 +57,155 @@ public class ParticleGenPacket implements IMessage {
         public IMessage onMessage(ParticleGenPacket message, MessageContext ctx) {
             TileEntity tile = ctx.getServerHandler().playerEntity.worldObj
                     .getTileEntity(message.tileX, message.tileY, message.tileZ);
-            TileParticleGenerator gen = (tile != null && tile instanceof TileParticleGenerator)
-                    ? (TileParticleGenerator) tile
-                    : null;
-            if (gen != null) {
-                // System.out.println(buttonId + " " + value);
-                switch (message.buttonId) {
-                    case 0: // red
-                        gen.red = (int) message.value;
-                        break;
-                    case 1: // green
-                        gen.green = (int) message.value;
-                        break;
-                    case 2: // blue
-                        gen.blue = (int) message.value;
-                        break;
-                    case 3: // mx
-                        gen.motion_x = (float) message.value / 1000F;
-                        break;
-                    case 4: // my
-                        gen.motion_y = (float) message.value / 1000F;
-                        break;
-                    case 5: // mz
-                        gen.motion_z = (float) message.value / 1000F;
-                        break;
-                    case 6: // ged
-                        gen.red = (int) message.value;
-                        break;
-                    case 7: // green
-                        gen.green = (int) message.value;
-                        break;
-                    case 8: // blue
-                        gen.blue = (int) message.value;
-                        break;
-                    case 9: // mx
-                        gen.motion_x = (float) message.value / 1000F;
-                        break;
-                    case 10: // my
-                        gen.motion_y = (float) message.value / 1000F;
-                        break;
-                    case 11: // mz
-                        gen.motion_z = (float) message.value / 1000F;
-                        break;
-                    case 12: // red
-                        gen.random_red = (int) message.value;
-                        break;
-                    case 13: // green
-                        gen.random_green = (int) message.value;
-                        break;
-                    case 14: // blue
-                        gen.random_blue = (int) message.value;
-                        break;
-                    case 15: // mx
-                        gen.random_motion_x = (float) message.value / 1000F;
-                        break;
-                    case 16: // my
-                        gen.random_motion_y = (float) message.value / 1000F;
-                        break;
-                    case 17: // mz
-                        gen.random_motion_z = (float) message.value / 1000F;
-                        break;
-                    case 18: // ged
-                        gen.random_red = (int) message.value;
-                        break;
-                    case 19: // green
-                        gen.random_green = (int) message.value;
-                        break;
-                    case 20: // blue
-                        gen.random_blue = (int) message.value;
-                        break;
-                    case 21: // mx
-                        gen.random_motion_x = (float) message.value / 1000F;
-                        break;
-                    case 22: // my
-                        gen.random_motion_y = (float) message.value / 1000F;
-                        break;
-                    case 23: // mz
-                        gen.random_motion_z = (float) message.value / 1000F;
-                        break;
-                    case 24: // Life +
-                        gen.life = (int) message.value;
-                        break;
-                    case 25: // Life -
-                        gen.life = (int) message.value;
-                        break;
-                    case 26: // RLife +
-                        gen.random_life = (int) message.value;
-                        break;
-                    case 27: // RLife -
-                        gen.random_life = (int) message.value;
-                        break;
-                    case 28: // Size +
-                        gen.scale = (float) message.value / 100F;
-                        break;
-                    case 29: // Size -
-                        gen.scale = (float) message.value / 100F;
-                        break;
-                    case 30: // RSize +
-                        gen.random_scale = (float) message.value / 100F;
-                        break;
-                    case 31: // RSize -
-                        gen.random_scale = (float) message.value / 100F;
-                        break;
-                    case 32: // SX +
-                        gen.page = (int) message.value;
-                        break;
-                    case 33: // SX -
-                        gen.page = (int) message.value;
-                        break;
-                    case 34: // SX +
-                        gen.spawn_x = (float) message.value / 100F;
-                        break;
-                    case 35: // SX -
-                        gen.spawn_x = (float) message.value / 100F;
-                        break;
-                    case 36: // RSX +
-                        gen.random_spawn_x = (float) message.value / 100F;
-                        break;
-                    case 37: // RSX -
-                        gen.random_spawn_x = (float) message.value / 100F;
-                        break;
-                    case 38: // SY +
-                        gen.spawn_y = (float) message.value / 100F;
-                        break;
-                    case 39: // SY -
-                        gen.spawn_y = (float) message.value / 100F;
-                        break;
-                    case 40: // RSY +
-                        gen.random_spawn_y = (float) message.value / 100F;
-                        break;
-                    case 41: // RSY -
-                        gen.random_spawn_y = (float) message.value / 100F;
-                        break;
-                    case 42: // SZ +
-                        gen.spawn_z = (float) message.value / 100F;
-                        break;
-                    case 43: // SZ -
-                        gen.spawn_z = (float) message.value / 100F;
-                        break;
-                    case 44: // RSZ +
-                        gen.random_spawn_z = (float) message.value / 100F;
-                        break;
-                    case 45: // RSZ -
-                        gen.random_spawn_z = (float) message.value / 100F;
-                        break;
-                    case 46: // Delay -
-                        gen.spawn_rate = (int) message.value;
-                        break;
-                    case 47: // Delay -
-                        gen.spawn_rate = (int) message.value;
-                        break;
-                    case 48: // Fade -
-                        gen.fade = (int) message.value;
-                        break;
-                    case 49: // Fade -
-                        gen.fade = (int) message.value;
-                        break;
-                    case 50: // Collision -
-                        gen.collide = message.value == 0 ? false : true;
-                        break;
-                    case 51: // Particle Selected -
-                        gen.selected_particle = (int) message.value;
-                        break;
-                    case 52: // Gravity +
-                        gen.gravity = (float) message.value / 1000F;
-                        break;
-                    case 53: // Gravity -
-                        gen.gravity = (float) message.value / 1000F;
-                        break;
-                    case 54: // Info Page (3)
-                        gen.page = (int) message.value;
-                        break;
-                    case 55: // Back
-                        gen.page = (int) message.value;
-                        break;
-                    case 58: // Back
-                        LogHelper.info(message.value);
-                        gen.particles_enabled = message.value == 1;
-                        break;
+            if (!(tile instanceof TileParticleGenerator)) {
+                return null;
+            }
+            TileParticleGenerator particleGenerator = (TileParticleGenerator) tile;
+            switch (message.id) {
+                case 0:
+                    particleGenerator.red = message.value;
+                    break;
+                case 1:
+                    particleGenerator.green = message.value;
+                    break;
+                case 2:
+                    particleGenerator.blue = message.value;
+                    break;
+                case 3:
+                    particleGenerator.motionX = (float) message.value / 1000F;
+                    break;
+                case 4:
+                    particleGenerator.motionY = (float) message.value / 1000F;
+                    break;
+                case 5:
+                    particleGenerator.motionZ = (float) message.value / 1000F;
+                    break;
+                case 6:
+                    particleGenerator.scale = (float) message.value / 100F;
+                    break;
+                case 7:
+                    particleGenerator.life = message.value;
+                    break;
+                case 10:
+                    particleGenerator.randomRed = message.value;
+                    break;
+                case 11:
+                    particleGenerator.randomGreen = message.value;
+                    break;
+                case 12:
+                    particleGenerator.randomBlue = message.value;
+                    break;
+                case 13:
+                    particleGenerator.randomMotionX = (float) message.value / 1000F;
+                    break;
+                case 14:
+                    particleGenerator.randomMotionY = (float) message.value / 1000F;
+                    break;
+                case 15:
+                    particleGenerator.randomMotionZ = (float) message.value / 1000F;
+                    break;
+                case 16:
+                    particleGenerator.randomScale = (float) message.value / 100F;
+                    break;
+                case 17:
+                    particleGenerator.randomLife = message.value;
+                    break;
+                case 20:
+                    particleGenerator.spawnX = (float) message.value / 10F;
+                    break;
+                case 21:
+                    particleGenerator.spawnY = (float) message.value / 10F;
+                    break;
+                case 22:
+                    particleGenerator.spawnZ = (float) message.value / 10F;
+                    break;
+                case 23:
+                    particleGenerator.spawnRate = message.value;
+                    break;
+                case 24:
+                    particleGenerator.fade = message.value;
+                    break;
+                case 25:
+                    particleGenerator.gravity = (float) message.value / 1000F;
+                case 30:
+                    particleGenerator.randomSpawnX = (float) message.value / 10F;
+                    break;
+                case 31:
+                    particleGenerator.randomSpawnY = (float) message.value / 10F;
+                    break;
+                case 32:
+                    particleGenerator.randomSpawnZ = (float) message.value / 10F;
+                    break;
+                case 40:
+                    particleGenerator.beamRed = message.value;
+                    break;
+                case 41:
+                    particleGenerator.beamGreen = message.value;
+                    break;
+                case 42:
+                    particleGenerator.beamBlue = message.value;
+                    break;
+                case 43:
+                    particleGenerator.beamPitch = (float) message.value / 10F;
+                    break;
+                case 44:
+                    particleGenerator.beamYaw = (float) message.value / 10F;
+                    break;
+                case 45:
+                    particleGenerator.beamRotation = (float) message.value / 100F;
+                    break;
+                case 46:
+                    particleGenerator.beamScale = (float) message.value / 100F;
+                    break;
+                case 47:
+                    particleGenerator.beamLength = (float) message.value / 100F;
+                    break;
+                case 100:
+                case 101:
+                case 102:
+                case 103:
+                    particleGenerator.page = message.value;
+                    break;
+                case 110:
+                    particleGenerator.canParticleCollide = message.value == 1;
+                    break;
+                case 111:
+                    particleGenerator.selectedParticle = message.value;
+                    break;
+                case 112:
+                    particleGenerator.isParticlesEnabled = message.value == 1;
+                    break;
+                case 120:
+                    particleGenerator.isBeamEnabled = message.value == 1;
+                    break;
+                case 121:
+                    particleGenerator.shouldRenderCore = message.value == 1;
+                    break;
+            }
 
-                    case 100: // beam red +
-                        gen.beam_red = message.value;
-                        break;
-                    case 101: // beam green +
-                        gen.beam_green = message.value;
-                        break;
-                    case 102: // beam blue +
-                        gen.beam_blue = message.value;
-                        break;
-                    case 103: // beam pitch +
-                        gen.beam_pitch = (float) message.value / 100F;
-                        break;
-                    case 104: // beam yaw +
-                        gen.beam_yaw = (float) message.value / 100F;
-                        break;
-                    case 105: // beam length +
-                        gen.beam_length = (float) message.value / 100F;
-                        break;
-                    case 106: // beam rotation +
-                        gen.beam_rotation = (float) message.value / 100F;
-                        break;
-                    case 107: // beam scale +
-                        gen.beam_scale = (float) message.value / 100F;
-                        break;
-                    case 108: // beam red -
-                        gen.beam_red = message.value;
-                        break;
-                    case 109: // beam green -
-                        gen.beam_green = message.value;
-                        break;
-                    case 110: // beam blue -
-                        gen.beam_blue = message.value;
-                        break;
-                    case 111: // beam pitch -
-                        gen.beam_pitch = (float) message.value / 100F;
-                        break;
-                    case 112: // beam yaw -
-                        gen.beam_yaw = (float) message.value / 100F;
-                        break;
-                    case 113: // beam length -
-                        gen.beam_length = (float) message.value / 100F;
-                        break;
-                    case 114: // beam rotation -
-                        gen.beam_rotation = (float) message.value / 100F;
-                        break;
-                    case 115: // beam scale -
-                        gen.beam_scale = (float) message.value / 100F;
-                        break;
-                    case 116: // beam enabled
-                        gen.beam_enabled = message.value == 1;
-                        break;
-                    case 117: // beam enabled
-                        gen.render_core = message.value == 1;
-                        break;
-                }
-
-                if (message.buttonId == 127) {
-                    if (ctx.getServerHandler().playerEntity.capabilities.isCreativeMode
-                            || ctx.getServerHandler().playerEntity.inventory.hasItem(Items.paper)) {
-                        giveNote(message, ctx);
-                    } else ctx.getServerHandler().playerEntity.addChatComponentMessage(
+            EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+            if (message.id == 127) {
+                if (player.capabilities.isCreativeMode || player.inventory.hasItem(Items.paper)) {
+                    giveNote(message, player);
+                } else {
+                    player.addChatComponentMessage(
                             new ChatComponentText("You need paper in your inventory to do that"));
                 }
-
-                ctx.getServerHandler().playerEntity.worldObj
-                        .markBlockForUpdate(message.tileX, message.tileY, message.tileZ);
             }
+            player.worldObj.markBlockForUpdate(message.tileX, message.tileY, message.tileZ);
             return null;
         }
 
-        private void giveNote(ParticleGenPacket message, MessageContext ctx) {
-            EntityPlayer player = ctx.getServerHandler().playerEntity;
-            if (!player.capabilities.isCreativeMode) player.inventory.consumeInventoryItem(Items.paper);
+        private void giveNote(ParticleGenPacket message, EntityPlayerMP player) {
+            if (!player.capabilities.isCreativeMode) {
+                player.inventory.consumeInventoryItem(Items.paper);
+            }
             ItemStack stack = new ItemStack(Items.paper);
             stack.setTagCompound(new NBTTagCompound());
-            TileEntity tile = ctx.getServerHandler().playerEntity.worldObj
-                    .getTileEntity(message.tileX, message.tileY, message.tileZ);
-            TileParticleGenerator gen = (tile != null && tile instanceof TileParticleGenerator)
-                    ? (TileParticleGenerator) tile
-                    : null;
-            if (gen != null) {
-                gen.getBlockNBT(stack.getTagCompound());
+            TileEntity tile = player.worldObj.getTileEntity(message.tileX, message.tileY, message.tileZ);
+            if (tile instanceof TileParticleGenerator) {
+                TileParticleGenerator particleGenerator = (TileParticleGenerator) tile;
+                particleGenerator.getBlockNBT(stack.getTagCompound());
                 stack.setStackDisplayName("Saved Particle Gen Settings");
                 player.worldObj.spawnEntityInWorld(
                         new EntityItem(player.worldObj, player.posX, player.posY, player.posZ, stack));

--- a/src/main/java/com/brandon3055/draconicevolution/common/network/PlayerDetectorButtonPacket.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/network/PlayerDetectorButtonPacket.java
@@ -36,26 +36,20 @@ public class PlayerDetectorButtonPacket implements IMessage {
 
         @Override
         public IMessage onMessage(PlayerDetectorButtonPacket message, MessageContext ctx) {
-            ContainerPlayerDetector container = (ctx
-                    .getServerHandler().playerEntity.openContainer instanceof ContainerPlayerDetector)
-                            ? (ContainerPlayerDetector) ctx.getServerHandler().playerEntity.openContainer
-                            : null;
-            TilePlayerDetectorAdvanced tile = (container != null) ? container.getDetector() : null;
-
-            if (tile != null) {
-                switch (message.index) {
-                    case 0:
-                        tile.range = message.value;
-                        break;
-                    case 1:
-                        tile.isInWhiteListMode = message.value == 1;
-                        break;
-                    case 2:
-                        tile.isOutputInverted = message.value == 1;
-                        break;
-                }
-                ctx.getServerHandler().playerEntity.worldObj.markBlockForUpdate(tile.xCoord, tile.yCoord, tile.zCoord);
+            if (!(ctx.getServerHandler().playerEntity.openContainer instanceof ContainerPlayerDetector container)) {
+                return null;
             }
+            TilePlayerDetectorAdvanced tile = container.getDetector();
+            if (tile == null) {
+                return null;
+            }
+
+            switch (message.index) {
+                case 0 -> tile.range = message.value;
+                case 1 -> tile.isInWhiteListMode = message.value == 1;
+                case 2 -> tile.isOutputInverted = message.value == 1;
+            }
+            ctx.getServerHandler().playerEntity.worldObj.markBlockForUpdate(tile.xCoord, tile.yCoord, tile.zCoord);
             return null;
         }
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/network/PlayerDetectorButtonPacket.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/network/PlayerDetectorButtonPacket.java
@@ -40,9 +40,7 @@ public class PlayerDetectorButtonPacket implements IMessage {
                     .getServerHandler().playerEntity.openContainer instanceof ContainerPlayerDetector)
                             ? (ContainerPlayerDetector) ctx.getServerHandler().playerEntity.openContainer
                             : null;
-            TilePlayerDetectorAdvanced tile = (container != null)
-                    ? ((ContainerPlayerDetector) container).getTileDetector()
-                    : null;
+            TilePlayerDetectorAdvanced tile = (container != null) ? container.getDetector() : null;
 
             if (tile != null) {
                 switch (message.index) {
@@ -50,10 +48,10 @@ public class PlayerDetectorButtonPacket implements IMessage {
                         tile.range = message.value;
                         break;
                     case 1:
-                        tile.whiteList = message.value == 1;
+                        tile.isInWhiteListMode = message.value == 1;
                         break;
                     case 2:
-                        tile.outputInverted = message.value == 1;
+                        tile.isOutputInverted = message.value == 1;
                         break;
                 }
                 ctx.getServerHandler().playerEntity.worldObj.markBlockForUpdate(tile.xCoord, tile.yCoord, tile.zCoord);

--- a/src/main/java/com/brandon3055/draconicevolution/common/network/PlayerDetectorStringPacket.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/network/PlayerDetectorStringPacket.java
@@ -1,7 +1,5 @@
 package com.brandon3055.draconicevolution.common.network;
 
-import net.minecraft.inventory.Container;
-
 import com.brandon3055.draconicevolution.common.container.ContainerPlayerDetector;
 import com.brandon3055.draconicevolution.common.tileentities.TilePlayerDetectorAdvanced;
 
@@ -39,15 +37,16 @@ public class PlayerDetectorStringPacket implements IMessage {
 
         @Override
         public IMessage onMessage(PlayerDetectorStringPacket message, MessageContext ctx) {
-            Container container = ctx.getServerHandler().playerEntity.openContainer;
-            if (container instanceof ContainerPlayerDetector) {
-                TilePlayerDetectorAdvanced detector = ((ContainerPlayerDetector) container).getDetector();
-                if (detector != null) {
-                    detector.names[message.index] = message.name;
-                    ctx.getServerHandler().playerEntity.worldObj
-                            .markBlockForUpdate(detector.xCoord, detector.yCoord, detector.zCoord);
-                }
+            if (!(ctx.getServerHandler().playerEntity.openContainer instanceof ContainerPlayerDetector container)) {
+                return null;
             }
+            TilePlayerDetectorAdvanced detector = container.getDetector();
+            if (detector == null) {
+                return null;
+            }
+            detector.names[message.index] = message.name;
+            ctx.getServerHandler().playerEntity.worldObj
+                    .markBlockForUpdate(detector.xCoord, detector.yCoord, detector.zCoord);
             return null;
         }
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/network/PlayerDetectorStringPacket.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/network/PlayerDetectorStringPacket.java
@@ -1,5 +1,7 @@
 package com.brandon3055.draconicevolution.common.network;
 
+import net.minecraft.inventory.Container;
+
 import com.brandon3055.draconicevolution.common.container.ContainerPlayerDetector;
 import com.brandon3055.draconicevolution.common.tileentities.TilePlayerDetectorAdvanced;
 
@@ -37,15 +39,14 @@ public class PlayerDetectorStringPacket implements IMessage {
 
         @Override
         public IMessage onMessage(PlayerDetectorStringPacket message, MessageContext ctx) {
-            ContainerPlayerDetector container = (ctx
-                    .getServerHandler().playerEntity.openContainer instanceof ContainerPlayerDetector)
-                            ? (ContainerPlayerDetector) ctx.getServerHandler().playerEntity.openContainer
-                            : null;
-            TilePlayerDetectorAdvanced tile = (container != null) ? container.getTileDetector() : null;
-
-            if (tile != null) {
-                tile.names[message.index] = message.name;
-                ctx.getServerHandler().playerEntity.worldObj.markBlockForUpdate(tile.xCoord, tile.yCoord, tile.zCoord);
+            Container container = ctx.getServerHandler().playerEntity.openContainer;
+            if (container instanceof ContainerPlayerDetector) {
+                TilePlayerDetectorAdvanced detector = ((ContainerPlayerDetector) container).getDetector();
+                if (detector != null) {
+                    detector.names[message.index] = message.name;
+                    ctx.getServerHandler().playerEntity.worldObj
+                            .markBlockForUpdate(detector.xCoord, detector.yCoord, detector.zCoord);
+                }
             }
             return null;
         }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TileCKeyStone.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TileCKeyStone.java
@@ -25,85 +25,57 @@ public class TileCKeyStone extends TileEntity {
 
     @Override
     public void updateEntity() {
-        if (isActivated && (getMeta() == 1 || getMeta() == 3)) {
+        if (isActivated && (blockMetadata == 1 || blockMetadata == 3)) {
             activeTicks++;
             if (activeTicks >= delay) {
                 activeTicks = 0;
                 isActivated = false;
                 updateBlocks();
-                worldObj.playSoundEffect(
-                        (double) xCoord + 0.5D,
-                        (double) yCoord + 0.5D,
-                        (double) zCoord + 0.5D,
-                        "random.click",
-                        0.3F,
-                        0.5F);
+                worldObj.playSoundEffect(xCoord + 0.5D, yCoord + 0.5D, zCoord + 0.5D, "random.click", 0.3F, 0.5F);
             }
         }
     }
 
     public boolean onActivated(ItemStack stack, EntityPlayer player) {
-        if (stack == null || stack.getItem() != ModItems.key) {
-            if (player.capabilities.isCreativeMode && stack == null
-                    && player.isSneaking()
-                    && (getMeta() == 1 || getMeta() == 3))
+        if (stack == null && player.capabilities.isCreativeMode) {
+            if (player.isSneaking() && (blockMetadata == 1 || blockMetadata == 3)) {
                 delay += 5;
-            if (player.capabilities.isCreativeMode && stack == null) giveInformation(player);
+            }
+            giveInformation(player);
+        }
+        if (stack == null || stack.getItem() != ModItems.key) {
             return false;
         }
-        if (isMasterKey(stack)) return true;
-        if (setKey(stack)) return true;
-        if (!isKeyValid(stack, player)) return false;
+        if (isMasterKey(stack)) {
+            return true;
+        }
+        if (setKey(stack)) {
+            return true;
+        }
+        if (!isKeyValid(stack, player)) {
+            return false;
+        }
 
-        switch (getMeta()) {
+        switch (blockMetadata) {
             case 0: // Permanent Activation
-                isActivated = true;
-                player.destroyCurrentEquippedItem();
-                worldObj.playSoundEffect(
-                        (double) xCoord + 0.5D,
-                        (double) yCoord + 0.5D,
-                        (double) zCoord + 0.5D,
-                        "random.click",
-                        0.3F,
-                        0.6F);
-                break;
-            case 1: // Button Activation
-                isActivated = true;
-                worldObj.playSoundEffect(
-                        (double) xCoord + 0.5D,
-                        (double) yCoord + 0.5D,
-                        (double) zCoord + 0.5D,
-                        "random.click",
-                        0.3F,
-                        0.6F);
-                break;
-            case 2: // Toggle Activation
-                if (!isActivated) worldObj.playSoundEffect(
-                        (double) xCoord + 0.5D,
-                        (double) yCoord + 0.5D,
-                        (double) zCoord + 0.5D,
-                        "random.click",
-                        0.3F,
-                        0.6F);
-                else worldObj.playSoundEffect(
-                        (double) xCoord + 0.5D,
-                        (double) yCoord + 0.5D,
-                        (double) zCoord + 0.5D,
-                        "random.click",
-                        0.3F,
-                        0.5F);
-                isActivated = !isActivated;
-                break;
             case 3: // Button Activation (Consume Key)
                 isActivated = true;
                 player.destroyCurrentEquippedItem();
+                worldObj.playSoundEffect(xCoord + 0.5D, yCoord + 0.5D, zCoord + 0.5D, "random.click", 0.3F, 0.6F);
+                break;
+            case 1: // Button Activation
+                isActivated = true;
+                worldObj.playSoundEffect(xCoord + 0.5D, yCoord + 0.5D, zCoord + 0.5D, "random.click", 0.3F, 0.6F);
+                break;
+            case 2: // Toggle Activation
+                isActivated = !isActivated;
                 worldObj.playSoundEffect(
-                        (double) xCoord + 0.5D,
-                        (double) yCoord + 0.5D,
-                        (double) zCoord + 0.5D,
+                        xCoord + 0.5D,
+                        yCoord + 0.5D,
+                        zCoord + 0.5D,
                         "random.click",
                         0.3F,
-                        0.6F);
+                        isActivated ? 0.6F : 0.5F);
                 break;
             case 4:
                 break;
@@ -115,30 +87,25 @@ public class TileCKeyStone extends TileEntity {
 
     private void giveInformation(EntityPlayer player) {
         if (worldObj.isRemote) {
-            player.addChatComponentMessage(new ChatComponentTranslation("msg.cKeyStoneType" + getMeta() + ".txt"));
+            player.addChatComponentMessage(new ChatComponentTranslation("msg.cKeyStoneType" + blockMetadata + ".txt"));
             player.addChatComponentMessage(new ChatComponentText("Key: " + keyCode));
-            if (getMeta() == 1 || getMeta() == 3) player.addChatComponentMessage(
-                    new ChatComponentText("Delay: " + delay + "t (" + (((double) delay) / 20D) + "s)"));
+            if (blockMetadata == 1 || blockMetadata == 3) {
+                player.addChatComponentMessage(
+                        new ChatComponentText("Delay: " + delay + "t (" + (((double) delay) / 20D) + "s)"));
+            }
         }
     }
 
     private boolean isMasterKey(ItemStack key) {
         if (key.getItemDamage() == 1) {
-            if (!isActivated) worldObj.playSoundEffect(
-                    (double) xCoord + 0.5D,
-                    (double) yCoord + 0.5D,
-                    (double) zCoord + 0.5D,
-                    "random.click",
-                    0.3F,
-                    0.6F);
-            else worldObj.playSoundEffect(
-                    (double) xCoord + 0.5D,
-                    (double) yCoord + 0.5D,
-                    (double) zCoord + 0.5D,
-                    "random.click",
-                    0.3F,
-                    0.5F);
             isActivated = !isActivated;
+            worldObj.playSoundEffect(
+                    xCoord + 0.5D,
+                    yCoord + 0.5D,
+                    zCoord + 0.5D,
+                    "random.click",
+                    0.3F,
+                    isActivated ? 0.6F : 0.5F);
             updateBlocks();
             return true;
         }
@@ -146,36 +113,38 @@ public class TileCKeyStone extends TileEntity {
     }
 
     private boolean setKey(ItemStack key) {
-        if (keyCode == 0 && ItemNBTHelper.getInteger(key, "KeyCode", 0) == 0) {
-            keyCode = worldObj.rand.nextInt();
-            ItemNBTHelper.setInteger(key, "KeyCode", keyCode);
-            ItemNBTHelper.setInteger(key, "X", xCoord);
-            ItemNBTHelper.setInteger(key, "Y", yCoord);
-            ItemNBTHelper.setInteger(key, "Z", zCoord);
-            worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
-            return true;
-        } else if (keyCode == 0 && ItemNBTHelper.getInteger(key, "KeyCode", 0) != 0) {
-            keyCode = ItemNBTHelper.getInteger(key, "KeyCode", 0);
-            ItemNBTHelper.setInteger(key, "LockCount", ItemNBTHelper.getInteger(key, "LockCount", 0) + 1);
-            ItemNBTHelper.setInteger(key, "X_" + ItemNBTHelper.getInteger(key, "LockCount", 0), xCoord);
-            ItemNBTHelper.setInteger(key, "Y_" + ItemNBTHelper.getInteger(key, "LockCount", 0), yCoord);
-            ItemNBTHelper.setInteger(key, "Z_" + ItemNBTHelper.getInteger(key, "LockCount", 0), zCoord);
-            worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
-            return true;
+        if (keyCode == 0) {
+            if (ItemNBTHelper.getInteger(key, "KeyCode", 0) == 0) {
+                keyCode = worldObj.rand.nextInt();
+                ItemNBTHelper.setInteger(key, "KeyCode", keyCode);
+                ItemNBTHelper.setInteger(key, "X", xCoord);
+                ItemNBTHelper.setInteger(key, "Y", yCoord);
+                ItemNBTHelper.setInteger(key, "Z", zCoord);
+                worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+                return true;
+            }
+            if (ItemNBTHelper.getInteger(key, "KeyCode", 0) != 0) {
+                keyCode = ItemNBTHelper.getInteger(key, "KeyCode", 0);
+                int lockCount = ItemNBTHelper.getInteger(key, "LockCount", 0) + 1;
+                ItemNBTHelper.setInteger(key, "LockCount", lockCount);
+                ItemNBTHelper.setInteger(key, "X_" + lockCount, xCoord);
+                ItemNBTHelper.setInteger(key, "Y_" + lockCount, yCoord);
+                ItemNBTHelper.setInteger(key, "Z_" + lockCount, zCoord);
+                worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+                return true;
+            }
         }
         return false;
     }
 
     private boolean isKeyValid(ItemStack key, EntityPlayer player) {
         if (ItemNBTHelper.getInteger(key, "KeyCode", 0) != keyCode) {
-            if (worldObj.isRemote) player.addChatComponentMessage(new ChatComponentTranslation("msg.wrongKey.txt"));
+            if (worldObj.isRemote) {
+                player.addChatComponentMessage(new ChatComponentTranslation("msg.wrongKey.txt"));
+            }
             return false;
         }
         return true;
-    }
-
-    private int getMeta() {
-        return worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
     }
 
     public int getKeyCode() {
@@ -212,12 +181,6 @@ public class TileCKeyStone extends TileEntity {
 
     public void updateBlocks() {
         worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord - 1, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord + 1, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord - 1, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord + 1, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord - 1, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord + 1, worldObj.getBlock(xCoord, yCoord, zCoord));
+        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, blockType);
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TileParticleGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TileParticleGenerator.java
@@ -23,80 +23,80 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 public class TileParticleGenerator extends TileEntity implements IDEPeripheral {
 
-    public boolean particles_enabled = true;
+    public static final int MAXIMUM_PARTICLE_INDEX = 3;
+    public boolean isParticlesEnabled = true;
 
     public int red = 0;
     public int green = 0;
     public int blue = 0;
-    public int random_red = 0;
-    public int random_green = 0;
-    public int random_blue = 0;
-    public float motion_x = 0.0F;
-    public float motion_y = 0.0F;
-    public float motion_z = 0.0F;
-    public float random_motion_x = 0.0F;
-    public float random_motion_y = 0.0F;
-    public float random_motion_z = 0.0F;
+    public int randomRed = 0;
+    public int randomGreen = 0;
+    public int randomBlue = 0;
+    public float motionX = 0.0F;
+    public float motionY = 0.0F;
+    public float motionZ = 0.0F;
+    public float randomMotionX = 0.0F;
+    public float randomMotionY = 0.0F;
+    public float randomMotionZ = 0.0F;
     public float scale = 1F;
-    public float random_scale = 0F;
+    public float randomScale = 0F;
     public int life = 100;
-    public int random_life = 0;
-    public float spawn_x = 0;
-    public float spawn_y = 0;
-    public float spawn_z = 0;
-    public float random_spawn_x = 0;
-    public float random_spawn_y = 0;
-    public float random_spawn_z = 0;
+    public int randomLife = 0;
+    public float spawnX = 0;
+    public float spawnY = 0;
+    public float spawnZ = 0;
+    public float randomSpawnX = 0;
+    public float randomSpawnY = 0;
+    public float randomSpawnZ = 0;
     public int page = 1;
     public int fade = 0;
-    public int spawn_rate = 1;
-    public boolean collide = false;
-    public int selected_particle = 1;
-    public int selected_max = 3;
+    public int spawnRate = 1;
+    public boolean canParticleCollide = false;
+    public int selectedParticle = 1;
     public float gravity = 0F;
-    public boolean active = true;
-    public boolean signal = false;
-    public boolean inverted = false;
+    public boolean isActive = true;
+    public boolean hasRedstoneSignal = false;
+    public boolean isInverted = false;
     TileLocation master = new TileLocation();
     public float rotation = 0;
-    public boolean stabalizerMode = false;
+    public boolean isInStabilizerMode = false;
 
     // beam
-    public boolean beam_enabled = false;
-    public boolean render_core = false;
+    public boolean isBeamEnabled = false;
+    public boolean shouldRenderCore = false;
 
-    public int beam_red = 0;
-    public int beam_green = 0;
-    public int beam_blue = 0;
-    public float beam_scale = 1F;
-    public float beam_pitch = 0F;
-    public float beam_yaw = 0F;
-    public float beam_length = 0F;
-    public float beam_rotation = 0F;
+    public int beamRed = 0;
+    public int beamGreen = 0;
+    public int beamBlue = 0;
+    public float beamScale = 1F;
+    public float beamPitch = 0F;
+    public float beamYaw = 0F;
+    public float beamLength = 0F;
+    public float beamRotation = 0F;
 
     private int tick = 0;
 
-    @SideOnly(Side.SERVER)
     @Override
+    @SideOnly(Side.SERVER)
     public boolean canUpdate() {
         return false;
     }
 
-    @SideOnly(Side.CLIENT)
     @Override
+    @SideOnly(Side.CLIENT)
     public void updateEntity() {
         if (!worldObj.isRemote) {
             return;
         }
         rotation += 0.5F;
-        if (stabalizerMode) {
+        if (isInStabilizerMode) {
             spawnStabilizerParticle();
             return;
         }
 
-        active = signal != inverted;
+        isActive = hasRedstoneSignal != isInverted;
 
-        if (tick < spawn_rate || !active || !particles_enabled) {
+        if (tick < spawnRate || !isActive || !isParticlesEnabled) {
             tick++;
             return;
         }
@@ -104,13 +104,13 @@ public class TileParticleGenerator extends TileEntity implements IDEPeripheral {
         tick = 0;
         Random rand = worldObj.rand;
 
-        float motionX = motion_x + (random_motion_x * rand.nextFloat());
-        float motionY = motion_y + (random_motion_y * rand.nextFloat());
-        float motionZ = motion_z + (random_motion_z * rand.nextFloat());
-        float scale = this.scale + (random_scale * rand.nextFloat());
-        double spawnX = xCoord + spawn_x + (random_spawn_x * rand.nextFloat());
-        double spawnY = yCoord + spawn_y + (random_spawn_y * rand.nextFloat());
-        double spawnZ = zCoord + spawn_z + (random_spawn_z * rand.nextFloat());
+        float motionX = this.motionX + (randomMotionX * rand.nextFloat());
+        float motionY = this.motionY + (randomMotionY * rand.nextFloat());
+        float motionZ = this.motionZ + (randomMotionZ * rand.nextFloat());
+        float scale = this.scale + (randomScale * rand.nextFloat());
+        double spawnX = xCoord + this.spawnX + (randomSpawnX * rand.nextFloat());
+        double spawnY = yCoord + this.spawnY + (randomSpawnY * rand.nextFloat());
+        double spawnZ = zCoord + this.spawnZ + (randomSpawnZ * rand.nextFloat());
 
         ParticleCustom particle = new ParticleCustom(
                 worldObj,
@@ -121,12 +121,12 @@ public class TileParticleGenerator extends TileEntity implements IDEPeripheral {
                 motionY,
                 motionZ,
                 scale,
-                collide,
-                this.selected_particle);
-        particle.red = this.red + rand.nextInt(random_red + 1);
-        particle.green = this.green + rand.nextInt(random_green + 1);
-        particle.blue = this.blue + rand.nextInt(random_blue + 1);
-        particle.maxAge = this.life + rand.nextInt(random_life + 1);
+                canParticleCollide,
+                this.selectedParticle);
+        particle.red = this.red + rand.nextInt(randomRed + 1);
+        particle.green = this.green + rand.nextInt(randomGreen + 1);
+        particle.blue = this.blue + rand.nextInt(randomBlue + 1);
+        particle.maxAge = this.life + rand.nextInt(randomLife + 1);
         particle.fadeTime = this.fade;
         particle.fadeLength = this.fade;
         particle.gravity = this.gravity;
@@ -176,7 +176,7 @@ public class TileParticleGenerator extends TileEntity implements IDEPeripheral {
     }
 
     public void toggleInverted() {
-        inverted = !inverted;
+        isInverted = !isInverted;
     }
 
     @Override
@@ -195,7 +195,7 @@ public class TileParticleGenerator extends TileEntity implements IDEPeripheral {
     @Override
     public void writeToNBT(NBTTagCompound compound) {
         master.writeToNBT(compound, "Key");
-        compound.setBoolean("StabalizerMode", stabalizerMode);
+        compound.setBoolean("StabalizerMode", isInStabilizerMode);
         getBlockNBT(compound);
 
         super.writeToNBT(compound);
@@ -204,7 +204,7 @@ public class TileParticleGenerator extends TileEntity implements IDEPeripheral {
     @Override
     public void readFromNBT(NBTTagCompound compound) {
         master.readFromNBT(compound, "Key");
-        stabalizerMode = compound.getBoolean("StabalizerMode");
+        isInStabilizerMode = compound.getBoolean("StabalizerMode");
         setBlockNBT(compound);
         super.readFromNBT(compound);
     }
@@ -227,92 +227,92 @@ public class TileParticleGenerator extends TileEntity implements IDEPeripheral {
         compound.setInteger("Red", red);
         compound.setInteger("Green", green);
         compound.setInteger("Blue", blue);
-        compound.setInteger("RandomRed", random_red);
-        compound.setInteger("RandomGreen", random_green);
-        compound.setInteger("RandomBlue", random_blue);
-        compound.setFloat("MotionX", motion_x);
-        compound.setFloat("MotionY", motion_y);
-        compound.setFloat("MotionZ", motion_z);
-        compound.setFloat("RandomMotionX", random_motion_x);
-        compound.setFloat("RandomMotionY", random_motion_y);
-        compound.setFloat("RandomMotionZ", random_motion_z);
+        compound.setInteger("RandomRed", randomRed);
+        compound.setInteger("RandomGreen", randomGreen);
+        compound.setInteger("RandomBlue", randomBlue);
+        compound.setFloat("MotionX", motionX);
+        compound.setFloat("MotionY", motionY);
+        compound.setFloat("MotionZ", motionZ);
+        compound.setFloat("RandomMotionX", randomMotionX);
+        compound.setFloat("RandomMotionY", randomMotionY);
+        compound.setFloat("RandomMotionZ", randomMotionZ);
         compound.setFloat("Scale", scale);
-        compound.setFloat("RandomScale", random_scale);
+        compound.setFloat("RandomScale", randomScale);
         compound.setInteger("Life", life);
-        compound.setInteger("RandomLife", random_life);
-        compound.setFloat("SpawnX", spawn_x);
-        compound.setFloat("SpawnY", spawn_y);
-        compound.setFloat("SpawnZ", spawn_z);
-        compound.setFloat("RandomSpawnX", random_spawn_x);
-        compound.setFloat("RandomSpawnY", random_spawn_y);
-        compound.setFloat("RandomSpawnZ", random_spawn_z);
+        compound.setInteger("RandomLife", randomLife);
+        compound.setFloat("SpawnX", spawnX);
+        compound.setFloat("SpawnY", spawnY);
+        compound.setFloat("SpawnZ", spawnZ);
+        compound.setFloat("RandomSpawnX", randomSpawnX);
+        compound.setFloat("RandomSpawnY", randomSpawnY);
+        compound.setFloat("RandomSpawnZ", randomSpawnZ);
         compound.setInteger("Page", page);
-        compound.setInteger("SpawnRate", spawn_rate);
-        compound.setBoolean("CanCollide", collide);
+        compound.setInteger("SpawnRate", spawnRate);
+        compound.setBoolean("CanCollide", canParticleCollide);
         compound.setInteger("Fade", fade);
-        compound.setInteger("SelectedParticle", selected_particle);
+        compound.setInteger("SelectedParticle", selectedParticle);
         compound.setFloat("Gravity", gravity);
-        compound.setBoolean("Active", active);
-        compound.setBoolean("Signal", signal);
-        compound.setBoolean("Inverted", inverted);
-        compound.setBoolean("particles_enabled", particles_enabled);
+        compound.setBoolean("Active", isActive);
+        compound.setBoolean("Signal", hasRedstoneSignal);
+        compound.setBoolean("Inverted", isInverted);
+        compound.setBoolean("particles_enabled", isParticlesEnabled);
 
-        compound.setBoolean("beam_enabled", beam_enabled);
-        compound.setBoolean("render_core", render_core);
-        compound.setInteger("beam_red", beam_red);
-        compound.setInteger("beam_green", beam_green);
-        compound.setInteger("beam_blue", beam_blue);
-        compound.setFloat("beam_scale", beam_scale);
-        compound.setFloat("beam_pitch", beam_pitch);
-        compound.setFloat("beam_yaw", beam_yaw);
-        compound.setFloat("beam_length", beam_length);
-        compound.setFloat("beam_rotation", beam_rotation);
+        compound.setBoolean("beam_enabled", isBeamEnabled);
+        compound.setBoolean("render_core", shouldRenderCore);
+        compound.setInteger("beam_red", beamRed);
+        compound.setInteger("beam_green", beamGreen);
+        compound.setInteger("beam_blue", beamBlue);
+        compound.setFloat("beam_scale", beamScale);
+        compound.setFloat("beam_pitch", beamPitch);
+        compound.setFloat("beam_yaw", beamYaw);
+        compound.setFloat("beam_length", beamLength);
+        compound.setFloat("beam_rotation", beamRotation);
     }
 
     public void setBlockNBT(NBTTagCompound compound) {
         red = compound.getInteger("Red");
         green = compound.getInteger("Green");
         blue = compound.getInteger("Blue");
-        random_red = compound.getInteger("RandomRed");
-        random_green = compound.getInteger("RandomGreen");
-        random_blue = compound.getInteger("RandomBlue");
-        motion_x = compound.getFloat("MotionX");
-        motion_y = compound.getFloat("MotionY");
-        motion_z = compound.getFloat("MotionZ");
-        random_motion_x = compound.getFloat("RandomMotionX");
-        random_motion_y = compound.getFloat("RandomMotionY");
-        random_motion_z = compound.getFloat("RandomMotionZ");
+        randomRed = compound.getInteger("RandomRed");
+        randomGreen = compound.getInteger("RandomGreen");
+        randomBlue = compound.getInteger("RandomBlue");
+        motionX = compound.getFloat("MotionX");
+        motionY = compound.getFloat("MotionY");
+        motionZ = compound.getFloat("MotionZ");
+        randomMotionX = compound.getFloat("RandomMotionX");
+        randomMotionY = compound.getFloat("RandomMotionY");
+        randomMotionZ = compound.getFloat("RandomMotionZ");
         scale = compound.getFloat("Scale");
-        random_scale = compound.getFloat("RandomScale");
+        randomScale = compound.getFloat("RandomScale");
         life = compound.getInteger("Life");
-        random_life = compound.getInteger("RandomLife");
-        spawn_x = compound.getFloat("SpawnX");
-        spawn_y = compound.getFloat("SpawnY");
-        spawn_z = compound.getFloat("SpawnZ");
-        random_spawn_x = compound.getFloat("RandomSpawnX");
-        random_spawn_y = compound.getFloat("RandomSpawnY");
-        random_spawn_z = compound.getFloat("RandomSpawnZ");
+        randomLife = compound.getInteger("RandomLife");
+        spawnX = compound.getFloat("SpawnX");
+        spawnY = compound.getFloat("SpawnY");
+        spawnZ = compound.getFloat("SpawnZ");
+        randomSpawnX = compound.getFloat("RandomSpawnX");
+        randomSpawnY = compound.getFloat("RandomSpawnY");
+        randomSpawnZ = compound.getFloat("RandomSpawnZ");
         page = compound.getInteger("Page");
-        spawn_rate = compound.getInteger("SpawnRate");
-        collide = compound.getBoolean("CanCollide");
+        spawnRate = compound.getInteger("SpawnRate");
+        canParticleCollide = compound.getBoolean("CanCollide");
         fade = compound.getInteger("Fade");
-        selected_particle = compound.getInteger("SelectedParticle");
+        selectedParticle = compound.getInteger("SelectedParticle");
         gravity = compound.getFloat("Gravity");
-        active = compound.getBoolean("Active");
-        signal = compound.getBoolean("Signal");
-        inverted = compound.getBoolean("Inverted");
-        particles_enabled = compound.getBoolean("particles_enabled");
+        isActive = compound.getBoolean("Active");
+        hasRedstoneSignal = compound.getBoolean("Signal");
+        isInverted = compound.getBoolean("Inverted");
+        isParticlesEnabled = compound.getBoolean("particles_enabled");
 
-        beam_enabled = compound.getBoolean("beam_enabled");
-        render_core = compound.getBoolean("render_core");
-        beam_red = compound.getInteger("beam_red");
-        beam_green = compound.getInteger("beam_green");
-        beam_blue = compound.getInteger("beam_blue");
-        beam_scale = compound.getFloat("beam_scale");
-        beam_pitch = compound.getFloat("beam_pitch");
-        beam_yaw = compound.getFloat("beam_yaw");
-        beam_length = compound.getFloat("beam_length");
-        beam_rotation = compound.getFloat("beam_rotation");
+        isBeamEnabled = compound.getBoolean("beam_enabled");
+        shouldRenderCore = compound.getBoolean("render_core");
+        beamRed = compound.getInteger("beam_red");
+        beamGreen = compound.getInteger("beam_green");
+        beamBlue = compound.getInteger("beam_blue");
+        beamScale = compound.getFloat("beam_scale");
+        beamPitch = compound.getFloat("beam_pitch");
+        beamYaw = compound.getFloat("beam_yaw");
+        beamLength = compound.getFloat("beam_length");
+        beamRotation = compound.getFloat("beam_rotation");
     }
 
     @SideOnly(Side.CLIENT)
@@ -349,7 +349,7 @@ public class TileParticleGenerator extends TileEntity implements IDEPeripheral {
 
             /* Particles */
             if (args[0].equals("particles_enabled") && args[1] instanceof Boolean) {
-                particles_enabled = (Boolean) args[1];
+                isParticlesEnabled = (boolean) args[1];
             } else if (args[0].equals("red") && args[1] instanceof Double) {
                 red = limit(((Double) args[1]).intValue(), 0, 255);
             } else if (args[0].equals("green") && args[1] instanceof Double) {
@@ -357,75 +357,75 @@ public class TileParticleGenerator extends TileEntity implements IDEPeripheral {
             } else if (args[0].equals("blue") && args[1] instanceof Double) {
                 blue = limit(((Double) args[1]).intValue(), 0, 255);
             } else if (args[0].equals("random_red") && args[1] instanceof Double) {
-                random_red = limit(((Double) args[1]).intValue(), 0, 255);
+                randomRed = limit(((Double) args[1]).intValue(), 0, 255);
             } else if (args[0].equals("random_green") && args[1] instanceof Double) {
-                random_green = limit(((Double) args[1]).intValue(), 0, 255);
+                randomGreen = limit(((Double) args[1]).intValue(), 0, 255);
             } else if (args[0].equals("random_blue") && args[1] instanceof Double) {
-                random_blue = limit(((Double) args[1]).intValue(), 0, 255);
+                randomBlue = limit(((Double) args[1]).intValue(), 0, 255);
             } else if (args[0].equals("motion_x") && args[1] instanceof Double) {
-                motion_x = (float) limit((Double) args[1], -5F, 5F);
+                motionX = (float) limit((Double) args[1], -5F, 5F);
             } else if (args[0].equals("motion_y") && args[1] instanceof Double) {
-                motion_y = (float) limit((Double) args[1], -5F, 5F);
+                motionY = (float) limit((Double) args[1], -5F, 5F);
             } else if (args[0].equals("motion_z") && args[1] instanceof Double) {
-                motion_z = (float) limit((Double) args[1], -5F, 5F);
+                motionZ = (float) limit((Double) args[1], -5F, 5F);
             } else if (args[0].equals("random_motion_x") && args[1] instanceof Double) {
-                random_motion_x = (float) limit((Double) args[1], -5F, 5F);
+                randomMotionX = (float) limit((Double) args[1], -5F, 5F);
             } else if (args[0].equals("random_motion_y") && args[1] instanceof Double) {
-                random_motion_y = (float) limit((Double) args[1], -5F, 5F);
+                randomMotionY = (float) limit((Double) args[1], -5F, 5F);
             } else if (args[0].equals("random_motion_z") && args[1] instanceof Double) {
-                random_motion_z = (float) limit((Double) args[1], -5F, 5F);
+                randomMotionZ = (float) limit((Double) args[1], -5F, 5F);
             } else if (args[0].equals("scale") && args[1] instanceof Double) {
                 scale = (float) limit((Double) args[1], 0.01F, 50F);
             } else if (args[0].equals("random_scale") && args[1] instanceof Double) {
-                random_scale = (float) limit((Double) args[1], 0.01F, 50F);
+                randomScale = (float) limit((Double) args[1], 0.01F, 50F);
             } else if (args[0].equals("life") && args[1] instanceof Double) {
                 life = limit(((Double) args[1]).intValue(), 0, 1000);
             } else if (args[0].equals("random_life") && args[1] instanceof Double) {
-                random_life = limit(((Double) args[1]).intValue(), 0, 1000);
+                randomLife = limit(((Double) args[1]).intValue(), 0, 1000);
             } else if (args[0].equals("spawn_x") && args[1] instanceof Double) {
-                spawn_x = (float) limit((Double) args[1], -50F, 50F);
+                spawnX = (float) limit((Double) args[1], -50F, 50F);
             } else if (args[0].equals("spawn_y") && args[1] instanceof Double) {
-                spawn_y = (float) limit((Double) args[1], -50F, 50F);
+                spawnY = (float) limit((Double) args[1], -50F, 50F);
             } else if (args[0].equals("spawn_z") && args[1] instanceof Double) {
-                spawn_z = (float) limit((Double) args[1], -50F, 50F);
+                spawnZ = (float) limit((Double) args[1], -50F, 50F);
             } else if (args[0].equals("random_spawn_x") && args[1] instanceof Double) {
-                random_spawn_x = (float) limit((Double) args[1], -50F, 50F);
+                randomSpawnX = (float) limit((Double) args[1], -50F, 50F);
             } else if (args[0].equals("random_spawn_y") && args[1] instanceof Double) {
-                random_spawn_y = (float) limit((Double) args[1], -50F, 50F);
+                randomSpawnY = (float) limit((Double) args[1], -50F, 50F);
             } else if (args[0].equals("random_spawn_z") && args[1] instanceof Double) {
-                random_spawn_z = (float) limit((Double) args[1], -50F, 50F);
+                randomSpawnZ = (float) limit((Double) args[1], -50F, 50F);
             } else if (args[0].equals("fade") && args[1] instanceof Double) {
                 fade = limit(((Double) args[1]).intValue(), 0, 100);
             } else if (args[0].equals("spawn_rate") && args[1] instanceof Double) {
-                spawn_rate = limit(((Double) args[1]).intValue(), 1, 200);
+                spawnRate = limit(((Double) args[1]).intValue(), 1, 200);
             } else if (args[0].equals("collide") && args[1] instanceof Boolean) {
-                collide = (Boolean) args[1];
+                canParticleCollide = (Boolean) args[1];
             } else if (args[0].equals("selected_particle") && args[1] instanceof Double) {
-                selected_particle = limit(((Double) args[1]).intValue(), 1, selected_max);
+                selectedParticle = limit(((Double) args[1]).intValue(), 1, MAXIMUM_PARTICLE_INDEX);
             } else if (args[0].equals("gravity") && args[1] instanceof Double) {
                 gravity = (float) limit((Double) args[1], -5F, 5F);
             }
             /* Beam */
             else if (args[0].equals("beam_enabled") && args[1] instanceof Boolean) {
-                beam_enabled = (Boolean) args[1];
+                isBeamEnabled = (Boolean) args[1];
             } else if (args[0].equals("render_core") && args[1] instanceof Boolean) {
-                render_core = (Boolean) args[1];
+                shouldRenderCore = (Boolean) args[1];
             } else if (args[0].equals("beam_red") && args[1] instanceof Double) {
-                beam_red = limit(((Double) args[1]).intValue(), 0, 255);
+                beamRed = limit(((Double) args[1]).intValue(), 0, 255);
             } else if (args[0].equals("beam_green") && args[1] instanceof Double) {
-                beam_green = limit(((Double) args[1]).intValue(), 0, 255);
+                beamGreen = limit(((Double) args[1]).intValue(), 0, 255);
             } else if (args[0].equals("beam_blue") && args[1] instanceof Double) {
-                beam_blue = limit(((Double) args[1]).intValue(), 0, 255);
+                beamBlue = limit(((Double) args[1]).intValue(), 0, 255);
             } else if (args[0].equals("beam_scale") && args[1] instanceof Double) {
-                beam_scale = (float) limit((Double) args[1], -0F, 5F);
+                beamScale = (float) limit((Double) args[1], -0F, 5F);
             } else if (args[0].equals("beam_pitch") && args[1] instanceof Double) {
-                beam_pitch = (float) limit((Double) args[1], -180F, 180F);
+                beamPitch = (float) limit((Double) args[1], -180F, 180F);
             } else if (args[0].equals("beam_yaw") && args[1] instanceof Double) {
-                beam_yaw = (float) limit((Double) args[1], -180F, 180F);
+                beamYaw = (float) limit((Double) args[1], -180F, 180F);
             } else if (args[0].equals("beam_length") && args[1] instanceof Double) {
-                beam_length = (float) limit((Double) args[1], -0F, 320F);
+                beamLength = (float) limit((Double) args[1], -0F, 320F);
             } else if (args[0].equals("beam_rotation") && args[1] instanceof Double) {
-                beam_rotation = (float) limit((Double) args[1], -1F, 1F);
+                beamRotation = (float) limit((Double) args[1], -1F, 1F);
             } else {
                 return new Object[] { false };
             }
@@ -436,91 +436,91 @@ public class TileParticleGenerator extends TileEntity implements IDEPeripheral {
             Map<Object, Object> map = new HashMap<>();
 
             /* Particles */
-            map.put("particles_enabled", particles_enabled);
+            map.put("particles_enabled", isParticlesEnabled);
             map.put("red", red);
             map.put("green", green);
             map.put("blue", blue);
-            map.put("random_red", random_red);
-            map.put("random_green", random_green);
-            map.put("random_blue", random_blue);
-            map.put("motion_x", motion_x);
-            map.put("motion_y", motion_y);
-            map.put("motion_z", motion_z);
-            map.put("random_motion_x", random_motion_x);
-            map.put("random_motion_y", random_motion_y);
-            map.put("random_motion_z", random_motion_z);
+            map.put("random_red", randomRed);
+            map.put("random_green", randomGreen);
+            map.put("random_blue", randomBlue);
+            map.put("motion_x", motionX);
+            map.put("motion_y", motionY);
+            map.put("motion_z", motionZ);
+            map.put("random_motion_x", randomMotionX);
+            map.put("random_motion_y", randomMotionY);
+            map.put("random_motion_z", randomMotionZ);
             map.put("scale", scale);
-            map.put("random_scale", random_scale);
+            map.put("random_scale", randomScale);
             map.put("life", life);
-            map.put("random_life", random_life);
-            map.put("spawn_x", spawn_x);
-            map.put("spawn_y", spawn_y);
-            map.put("spawn_z", spawn_z);
-            map.put("random_spawn_x", random_spawn_x);
-            map.put("random_spawn_y", random_spawn_y);
-            map.put("random_spawn_z", random_spawn_z);
+            map.put("random_life", randomLife);
+            map.put("spawn_x", spawnX);
+            map.put("spawn_y", spawnY);
+            map.put("spawn_z", spawnZ);
+            map.put("random_spawn_x", randomSpawnX);
+            map.put("random_spawn_y", randomSpawnY);
+            map.put("random_spawn_z", randomSpawnZ);
             map.put("fade", fade);
-            map.put("spawn_rate", spawn_rate);
-            map.put("collide", collide);
-            map.put("selected_particle", selected_particle);
+            map.put("spawn_rate", spawnRate);
+            map.put("collide", canParticleCollide);
+            map.put("selected_particle", selectedParticle);
             map.put("gravity", gravity);
 
             /* Beam */
-            map.put("beam_enabled", beam_enabled);
-            map.put("render_core", render_core);
-            map.put("beam_red", beam_red);
-            map.put("beam_green", beam_green);
-            map.put("beam_blue", beam_blue);
-            map.put("beam_scale", beam_scale);
-            map.put("beam_pitch", beam_pitch);
-            map.put("beam_yaw", beam_yaw);
-            map.put("beam_length", beam_length);
-            map.put("beam_rotation", beam_rotation);
+            map.put("beam_enabled", isBeamEnabled);
+            map.put("render_core", shouldRenderCore);
+            map.put("beam_red", beamRed);
+            map.put("beam_green", beamGreen);
+            map.put("beam_blue", beamBlue);
+            map.put("beam_scale", beamScale);
+            map.put("beam_pitch", beamPitch);
+            map.put("beam_yaw", beamYaw);
+            map.put("beam_length", beamLength);
+            map.put("beam_rotation", beamRotation);
 
             return new Object[] { map };
         } else if (method.startsWith("resetGeneratorState")) {
-            particles_enabled = true;
+            isParticlesEnabled = true;
             red = 0;
             green = 0;
             blue = 0;
-            random_red = 0;
-            random_green = 0;
-            random_blue = 0;
-            motion_x = 0.0F;
-            motion_y = 0.0F;
-            motion_z = 0.0F;
-            random_motion_x = 0.0F;
-            random_motion_y = 0.0F;
-            random_motion_z = 0.0F;
+            randomRed = 0;
+            randomGreen = 0;
+            randomBlue = 0;
+            motionX = 0.0F;
+            motionY = 0.0F;
+            motionZ = 0.0F;
+            randomMotionX = 0.0F;
+            randomMotionY = 0.0F;
+            randomMotionZ = 0.0F;
             scale = 1F;
-            random_scale = 0F;
+            randomScale = 0F;
             life = 100;
-            random_life = 0;
-            spawn_x = 0;
-            spawn_y = 0;
-            spawn_z = 0;
-            random_spawn_x = 0;
-            random_spawn_y = 0;
-            random_spawn_z = 0;
+            randomLife = 0;
+            spawnX = 0;
+            spawnY = 0;
+            spawnZ = 0;
+            randomSpawnX = 0;
+            randomSpawnY = 0;
+            randomSpawnZ = 0;
             page = 1;
             fade = 0;
-            spawn_rate = 1;
-            collide = false;
-            selected_particle = 1;
+            spawnRate = 1;
+            canParticleCollide = false;
+            selectedParticle = 1;
             gravity = 0F;
 
             // beam
-            beam_enabled = false;
-            render_core = false;
+            isBeamEnabled = false;
+            shouldRenderCore = false;
 
-            beam_red = 0;
-            beam_green = 0;
-            beam_blue = 0;
-            beam_scale = 1F;
-            beam_pitch = 0F;
-            beam_yaw = 0F;
-            beam_length = 0F;
-            beam_rotation = 0F;
+            beamRed = 0;
+            beamGreen = 0;
+            beamBlue = 0;
+            beamScale = 1F;
+            beamPitch = 0F;
+            beamYaw = 0F;
+            beamLength = 0F;
+            beamRotation = 0F;
 
             worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
             return new Object[] { true };

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TileParticleGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TileParticleGenerator.java
@@ -211,7 +211,7 @@ public class TileParticleGenerator extends TileEntity implements IDEPeripheral {
 
     public TileEnergyStorageCore getMaster() {
         TileEntity tile = master.getTileEntity(worldObj);
-        return tile instanceof TileEnergyStorageCore ? (TileEnergyStorageCore) tile : null;
+        return tile instanceof TileEnergyStorageCore core ? core : null;
     }
 
     public void setMaster(TileLocation master) {

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetector.java
@@ -12,7 +12,7 @@ public class TilePlayerDetector extends TileEntity {
 
     public static final int MAXIMUM_RANGE = 10;
     public static final int MINIMUM_RANGE = 1;
-    private static final int ScanRate = 5;
+    private static final int scanRate = 5;
 
     private int tick = 0;
     private boolean shouldOutput = false;
@@ -24,7 +24,7 @@ public class TilePlayerDetector extends TileEntity {
             return;
         }
 
-        if (tick >= ScanRate) {
+        if (tick >= scanRate) {
             tick = 0;
             EntityPlayer player = worldObj.getClosestPlayer(xCoord + 0.5D, yCoord + 0.5D, zCoord + 0.5D, range + 0.5D);
             if (player != null) {

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetector.java
@@ -6,53 +6,74 @@ import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
 
 public class TilePlayerDetector extends TileEntity {
 
+    public static final int MAXIMUM_RANGE = 10;
+    public static final int MINIMUM_RANGE = 1;
+    private static final int ScanRate = 5;
+
     private int tick = 0;
-    public boolean output = false;
-    private int scanRate = 5;
+    private boolean shouldOutput = false;
     private int range = 1;
 
     @Override
     public void updateEntity() {
-        if (worldObj.isRemote) return;
+        if (worldObj.isRemote) {
+            return;
+        }
 
-        if (tick >= scanRate) {
+        if (tick >= ScanRate) {
             tick = 0;
             EntityPlayer player = worldObj.getClosestPlayer(xCoord + 0.5D, yCoord + 0.5D, zCoord + 0.5D, range + 0.5D);
             if (player != null) {
-                if (!output) setOutput(true);
+                if (!shouldOutput) setShouldOutput(true);
             } else {
-                if (output) setOutput(false);
+                if (shouldOutput) setShouldOutput(false);
             }
-        } else tick++;
+        } else {
+            tick++;
+        }
     }
 
-    private void setOutput(boolean out) {
-        output = out;
-        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+    public boolean shouldOutput() {
+        return shouldOutput;
+    }
+
+    public void setShouldOutput(boolean shouldOutputSignal) {
+        shouldOutput = shouldOutputSignal;
         updateBlocks();
-    }
-
-    public void setRange(int value) {
-        this.range = value;
     }
 
     public int getRange() {
         return range;
     }
 
-    public void updateBlocks() {
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord - 1, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord + 1, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord - 1, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord + 1, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord - 1, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord + 1, worldObj.getBlock(xCoord, yCoord, zCoord));
+    public void setRange(int value) {
+        if (value > MAXIMUM_RANGE) {
+            value = MINIMUM_RANGE;
+        }
+        if (value < MINIMUM_RANGE) {
+            value = MAXIMUM_RANGE;
+        }
+        this.range = value;
+        updateBlocks();
     }
 
+    private void updateBlocks() {
+        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, blockType);
+        for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
+            worldObj.notifyBlocksOfNeighborChange(
+                    xCoord + direction.offsetX,
+                    yCoord + direction.offsetY,
+                    zCoord + direction.offsetZ,
+                    blockType);
+        }
+    }
+
+    @Override
     public Packet getDescriptionPacket() {
         NBTTagCompound tagCompound = new NBTTagCompound();
         this.writeToNBT(tagCompound);
@@ -62,22 +83,19 @@ public class TilePlayerDetector extends TileEntity {
     @Override
     public void onDataPacket(NetworkManager net, S35PacketUpdateTileEntity pkt) {
         readFromNBT(pkt.func_148857_g());
-        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
     }
 
     @Override
     public void writeToNBT(NBTTagCompound compound) {
-        compound.setBoolean("OutPut", output);
+        compound.setBoolean("OutPut", shouldOutput);
         compound.setInteger("Range", range);
-
         super.writeToNBT(compound);
     }
 
     @Override
     public void readFromNBT(NBTTagCompound compound) {
-        output = compound.getBoolean("OutPut");
+        shouldOutput = compound.getBoolean("OutPut");
         range = compound.getInteger("Range");
-
         super.readFromNBT(compound);
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetector.java
@@ -69,7 +69,8 @@ public class TilePlayerDetector extends TileEntity {
                     xCoord + direction.offsetX,
                     yCoord + direction.offsetY,
                     zCoord + direction.offsetZ,
-                    blockType);
+                    blockType,
+                    direction.getOpposite().ordinal());
         }
     }
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetectorAdvanced.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetectorAdvanced.java
@@ -22,7 +22,7 @@ public class TilePlayerDetectorAdvanced extends TileEntity implements IInventory
 
     public static final int MAXIMUM_RANGE = 20;
     public static final int MINIMUM_RANGE = 1;
-    private static final int ScanRate = 5;
+    private static final int scanRate = 5;
 
     public String[] names = new String[42];
     public boolean isInWhiteListMode = false;
@@ -48,7 +48,7 @@ public class TilePlayerDetectorAdvanced extends TileEntity implements IInventory
             return;
         }
 
-        if (tick >= ScanRate) {
+        if (tick >= scanRate) {
             tick = 0;
             if (shouldEmit()) {
                 if (!shouldOutput) setShouldOutput(true);

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetectorAdvanced.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetectorAdvanced.java
@@ -1,10 +1,8 @@
 package com.brandon3055.draconicevolution.common.tileentities;
 
-import java.util.Iterator;
 import java.util.List;
 
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
@@ -16,101 +14,107 @@ import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import com.brandon3055.draconicevolution.common.container.ContainerPlayerDetector;
 
 public class TilePlayerDetectorAdvanced extends TileEntity implements IInventory {
 
+    public static final int MAXIMUM_RANGE = 20;
+    public static final int MINIMUM_RANGE = 1;
+    private static final int ScanRate = 5;
+
     public String[] names = new String[42];
-    private ItemStack[] items;
-    public boolean whiteList = false;
+    public boolean isInWhiteListMode = false;
+    public boolean isOutputInverted = false;
     public int range = 10;
+    private final ItemStack[] items;
     private int tick = 0;
-    private int scanRate = 5;
-    public boolean output = false;
-    public boolean outputInverted = false;
-    private List<EntityLiving> EntityList;
+    private boolean shouldOutput = false;
+    private List<EntityLivingBase> entityList;
 
     public TilePlayerDetectorAdvanced() {
-        for (int i = 0; i < names.length; i++) if (names[i] == null) names[i] = "";
-
+        for (int i = 0; i < names.length; i++) {
+            if (names[i] == null) {
+                names[i] = "";
+            }
+        }
         items = new ItemStack[1];
     }
 
     @Override
     public void updateEntity() {
-        if (worldObj.isRemote) return;
-
-        if (tick >= scanRate) {
-
-            tick = 0;
-
-            if (shouldEmit()) {
-                if (!output) setOutput(true);
-            } else {
-                if (output) setOutput(false);
-            }
-        } else tick++;
-    }
-
-    public boolean shouldEmit() {
-        findEntitys();
-
-        boolean b = false;
-        Iterator<EntityLiving> i = EntityList.iterator();
-        while (i.hasNext()) {
-            Entity ent = i.next();
-            if (!(ent instanceof EntityPlayer)) return false;
-
-            String name = ((EntityPlayer) ent).getCommandSenderName();
-            if (whiteList) {
-                if (isPlayerListed(name)) return true;
-            } else {
-                if (!isPlayerListed(name)) return true;
-            }
+        if (worldObj.isRemote) {
+            return;
         }
-        return b;
+
+        if (tick >= ScanRate) {
+            tick = 0;
+            if (shouldEmit()) {
+                if (!shouldOutput) setShouldOutput(true);
+            } else {
+                if (shouldOutput) setShouldOutput(false);
+            }
+        } else {
+            tick++;
+        }
     }
 
-    private void findEntitys() {
-        double x1 = xCoord + 0.5 - range;
-        double y1 = yCoord + 0.5 - range;
-        double z1 = zCoord + 0.5 - range;
-        double x2 = xCoord + 0.5 + range;
-        double y2 = yCoord + 0.5 + range;
-        double z2 = zCoord + 0.5 + range;
+    private boolean shouldEmit() {
+        findEntities();
 
-        // System.out.println(x1 + " " + y1 + " " + z1 + " " + x2 + " " + y2 + " " + z2);
-
-        // ScanBox = AxisAlignedBB.getBoundingBox(x1, y1, z1, x2, y2, z2);
-        // ScanBox = AxisAlignedBB.getAABBPool().getAABB(xCoord + 0.5 - range, yCoord + 0.5 - range, zCoord + 0.5 -
-        // range, xCoord + 0.5 + range, yCoord + 0.5 + range, zCoord + 0.5 + range);
-        EntityList = worldObj
-                .getEntitiesWithinAABB(EntityPlayer.class, AxisAlignedBB.getBoundingBox(x1, y1, z1, x2, y2, z2));
-        // System.out.println(EntityList);
+        for (EntityLivingBase entity : entityList) {
+            if (!(entity instanceof EntityPlayer)) {
+                return false;
+            }
+            String name = entity.getCommandSenderName();
+            return (isInWhiteListMode == isPlayerListed(name)) != isOutputInverted;
+        }
+        return isOutputInverted;
     }
 
-    private void setOutput(boolean out) {
-        output = out;
-        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+    private void findEntities() {
+        double startX = xCoord + 0.5 - range;
+        double startY = yCoord + 0.5 - range;
+        double startZ = zCoord + 0.5 - range;
+        double endX = xCoord + 0.5 + range;
+        double endY = yCoord + 0.5 + range;
+        double endZ = zCoord + 0.5 + range;
+        entityList = worldObj.getEntitiesWithinAABB(
+                EntityPlayer.class,
+                AxisAlignedBB.getBoundingBox(startX, startY, startZ, endX, endY, endZ));
+    }
+
+    public boolean shouldOutput() {
+        return shouldOutput;
+    }
+
+    public void setShouldOutput(boolean shouldOutputSignal) {
+        shouldOutput = shouldOutputSignal;
         updateBlocks();
     }
 
-    public void updateBlocks() {
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord - 1, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord + 1, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord - 1, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord + 1, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord - 1, worldObj.getBlock(xCoord, yCoord, zCoord));
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord + 1, worldObj.getBlock(xCoord, yCoord, zCoord));
+    private void updateBlocks() {
+        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, blockType);
+        for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
+            worldObj.notifyBlocksOfNeighborChange(
+                    xCoord + direction.offsetX,
+                    yCoord + direction.offsetY,
+                    zCoord + direction.offsetZ,
+                    blockType);
+        }
     }
 
-    public boolean isPlayerListed(String name) {
-        if (name == null) return false;
+    private boolean isPlayerListed(String name) {
+        if (name == null) {
+            return false;
+        }
 
-        for (int i = 0; i < names.length; i++) {
-            if (names[i].equals(name)) return true;
+        for (String listedName : names) {
+            if (listedName.equals(name)) {
+                return true;
+            }
         }
         return false;
     }
@@ -121,39 +125,40 @@ public class TilePlayerDetectorAdvanced extends TileEntity implements IInventory
     }
 
     @Override
-    public ItemStack getStackInSlot(int i) {
-        return items[i];
+    public ItemStack getStackInSlot(int slot) {
+        return items[slot];
     }
 
     @Override
-    public ItemStack decrStackSize(int i, int count) {
-        ItemStack itemstack = getStackInSlot(i);
-
-        if (itemstack != null) {
-            if (itemstack.stackSize <= count) {
-                setInventorySlotContents(i, null);
+    public ItemStack decrStackSize(int slot, int count) {
+        ItemStack stack = items[slot];
+        if (stack != null) {
+            if (stack.stackSize <= count) {
+                setInventorySlotContents(slot, null);
             } else {
-                itemstack = itemstack.splitStack(count);
-                if (itemstack.stackSize == 0) {
-                    setInventorySlotContents(i, null);
+                stack = stack.splitStack(count);
+                if (stack.stackSize == 0) {
+                    setInventorySlotContents(slot, null);
                 }
             }
         }
-        return itemstack;
+        return stack;
     }
 
     @Override
-    public ItemStack getStackInSlotOnClosing(int i) {
-        ItemStack item = getStackInSlot(i);
-        if (item != null) setInventorySlotContents(i, null);
-        return item;
+    public ItemStack getStackInSlotOnClosing(int slot) {
+        ItemStack stack = getStackInSlot(slot);
+        if (stack != null) {
+            setInventorySlotContents(slot, null);
+        }
+        return stack;
     }
 
     @Override
-    public void setInventorySlotContents(int i, ItemStack itemstack) {
-        items[i] = itemstack;
-        if (itemstack != null && itemstack.stackSize > getInventoryStackLimit()) {
-            itemstack.stackSize = getInventoryStackLimit();
+    public void setInventorySlotContents(int slot, ItemStack stack) {
+        items[slot] = stack;
+        if (stack != null && stack.stackSize > getInventoryStackLimit()) {
+            stack.stackSize = getInventoryStackLimit();
         }
         worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
     }
@@ -191,7 +196,7 @@ public class TilePlayerDetectorAdvanced extends TileEntity implements IInventory
     public void closeInventory() {}
 
     @Override
-    public boolean isItemValidForSlot(int i, ItemStack itemstack) {
+    public boolean isItemValidForSlot(int slot, ItemStack stack) {
         return false;
     }
 
@@ -206,11 +211,10 @@ public class TilePlayerDetectorAdvanced extends TileEntity implements IInventory
     @Override
     public void onDataPacket(NetworkManager net, S35PacketUpdateTileEntity pkt) {
         readFromNBT(pkt.func_148857_g());
-        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
     }
 
-    public Container getGuiContainer(InventoryPlayer inventoryplayer) {
-        return new ContainerPlayerDetector(inventoryplayer, this);
+    public Container getGuiContainer(InventoryPlayer playerInventory) {
+        return new ContainerPlayerDetector(playerInventory, this);
     }
 
     @Override
@@ -232,10 +236,10 @@ public class TilePlayerDetectorAdvanced extends TileEntity implements IInventory
             compound.setString("Name_" + i, name);
         }
 
-        compound.setBoolean("WhiteList", whiteList);
-        compound.setBoolean("Output", output);
+        compound.setBoolean("WhiteList", isInWhiteListMode);
+        compound.setBoolean("Output", shouldOutput);
         compound.setInteger("Range", range);
-        compound.setBoolean("OutputInverted", outputInverted);
+        compound.setBoolean("OutputInverted", isOutputInverted);
 
         super.writeToNBT(compound);
     }
@@ -251,10 +255,10 @@ public class TilePlayerDetectorAdvanced extends TileEntity implements IInventory
 
         for (int i = 0; i < names.length; i++) names[i] = compound.getString("Name_" + i);
 
-        whiteList = compound.getBoolean("WhiteList");
+        isInWhiteListMode = compound.getBoolean("WhiteList");
         range = compound.getInteger("Range");
-        output = compound.getBoolean("Output");
-        outputInverted = compound.getBoolean("OutputInverted");
+        shouldOutput = compound.getBoolean("Output");
+        isOutputInverted = compound.getBoolean("OutputInverted");
 
         super.readFromNBT(compound);
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetectorAdvanced.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetectorAdvanced.java
@@ -102,7 +102,8 @@ public class TilePlayerDetectorAdvanced extends TileEntity implements IInventory
                     xCoord + direction.offsetX,
                     yCoord + direction.offsetY,
                     zCoord + direction.offsetZ,
-                    blockType);
+                    blockType,
+                    direction.getOpposite().ordinal());
         }
     }
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileDislocatorReceptacle.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileDislocatorReceptacle.java
@@ -27,27 +27,37 @@ public class TileDislocatorReceptacle extends TileEntity implements IInventory {
 
     @Override
     public void updateEntity() {
-        if (worldObj.isRemote) return;
-        if (coolDown > 0) coolDown--;
-        if (ticksTillStart > -1) ticksTillStart--;
-        if (ticksTillStart == 0)
+        if (worldObj.isRemote) {
+            return;
+        }
+        if (coolDown > 0) {
+            coolDown--;
+        }
+        if (ticksTillStart > -1) {
+            ticksTillStart--;
+        }
+        if (ticksTillStart == 0) {
             worldObj.scheduleBlockUpdate(xCoord, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord), 1);
+        }
     }
 
     public void validateActivePortal() {
-        if (updating) return;
-        if (structure == null) {
-            isActive = false;
+        if (updating) {
             return;
         }
-        isActive = structure.checkFrameIsValid(worldObj, xCoord, yCoord, zCoord)
+
+        final boolean isActiveBeforeValidation = isActive;
+        isActive = structure != null && structure.checkFrameIsValid(worldObj, xCoord, yCoord, zCoord)
                 && structure.scanPortal(worldObj, xCoord, yCoord, zCoord, false, true);
-        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+        if (isActive != isActiveBeforeValidation) {
+            worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+        }
     }
 
     public void updateState() {
-        if (structure == null || !isActive)
+        if (structure == null || !isActive) {
             structure = PortalHelper.getValidStructure(worldObj, xCoord, yCoord, zCoord);
+        }
         if (structure == null) {
             isActive = false;
             worldObj.notifyBlockChange(xCoord, yCoord, zCoord, blockType);
@@ -55,25 +65,30 @@ public class TileDislocatorReceptacle extends TileEntity implements IInventory {
             return;
         }
 
+        final boolean isActiveBeforeUpdate = isActive;
         if (isActive) {
-            if (getStackInSlot(0) == null || !structure.checkFrameIsValid(worldObj, xCoord, yCoord, zCoord))
+            if (dislocator == null || !structure.checkFrameIsValid(worldObj, xCoord, yCoord, zCoord)) {
                 isActive = false;
+            }
         } else {
-            boolean frameValid = structure.checkFrameIsValid(worldObj, xCoord, yCoord, zCoord);
-            boolean portalEmpty = structure.scanPortal(worldObj, xCoord, yCoord, zCoord, false, false);
+            boolean isFrameValid = structure.checkFrameIsValid(worldObj, xCoord, yCoord, zCoord);
+            boolean isPortalEmpty = structure.scanPortal(worldObj, xCoord, yCoord, zCoord, false, false);
 
-            if (getLocation() != null && frameValid && portalEmpty) {
+            if (getLocation() != null && isFrameValid && isPortalEmpty) {
                 isActive = true;
                 structure.scanPortal(worldObj, xCoord, yCoord, zCoord, true, false);
             }
         }
-        worldObj.notifyBlockChange(xCoord, yCoord, zCoord, blockType);
-        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+        if (isActive != isActiveBeforeUpdate) {
+            worldObj.notifyBlockChange(xCoord, yCoord, zCoord, blockType);
+            worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+        }
     }
 
     public Teleporter.TeleportLocation getLocation() {
-        if (getStackInSlot(0) != null && getStackInSlot(0).getItem() instanceof TeleporterMKI)
-            return ((TeleporterMKI) getStackInSlot(0).getItem()).getLocation(getStackInSlot(0));
+        if (dislocator != null && dislocator.getItem() instanceof TeleporterMKI) {
+            return ((TeleporterMKI) dislocator.getItem()).getLocation(dislocator);
+        }
         return null;
     }
 
@@ -100,40 +115,40 @@ public class TileDislocatorReceptacle extends TileEntity implements IInventory {
     }
 
     @Override
-    public ItemStack decrStackSize(int i, int count) {
-        ItemStack itemstack = getStackInSlot(i);
-
-        if (itemstack != null) {
-            if (itemstack.stackSize <= count) {
-                setInventorySlotContents(i, null);
-            } else {
-                itemstack = itemstack.splitStack(count);
-                if (itemstack.stackSize == 0) {
-                    setInventorySlotContents(i, null);
-                }
+    public ItemStack decrStackSize(int index, int count) {
+        ItemStack stack = null;
+        if (index == 0 && dislocator != null) {
+            stack = dislocator;
+            if (count >= 1) {
+                setInventorySlotContents(index, null);
             }
         }
-        if (isActive) updateState();
-        else ticksTillStart = 1;
-        return itemstack;
+        return stack;
     }
 
     @Override
-    public ItemStack getStackInSlotOnClosing(int i) {
-        ItemStack item = getStackInSlot(i);
-        if (item != null) setInventorySlotContents(i, null);
-        return item;
-    }
-
-    @Override
-    public void setInventorySlotContents(int i, ItemStack itemstack) {
-        if (i != 0) return;
-        dislocator = itemstack;
-        if (itemstack != null && itemstack.stackSize > getInventoryStackLimit()) {
-            itemstack.stackSize = getInventoryStackLimit();
+    public ItemStack getStackInSlotOnClosing(int index) {
+        ItemStack stack = getStackInSlot(index);
+        if (stack != null) {
+            setInventorySlotContents(index, null);
         }
-        if (isActive) updateState();
-        else ticksTillStart = 1;
+        return stack;
+    }
+
+    @Override
+    public void setInventorySlotContents(int index, ItemStack stack) {
+        if (index != 0) {
+            return;
+        }
+        dislocator = stack;
+        if (stack != null && stack.stackSize > getInventoryStackLimit()) {
+            stack.stackSize = getInventoryStackLimit();
+        }
+        if (isActive) {
+            updateState();
+        } else {
+            ticksTillStart = 1;
+        }
     }
 
     @Override
@@ -169,9 +184,10 @@ public class TileDislocatorReceptacle extends TileEntity implements IInventory {
     public void closeInventory() {}
 
     @Override
-    public boolean isItemValidForSlot(int i, ItemStack itemstack) {
-        return itemstack != null && itemstack.getItem() instanceof TeleporterMKI
-                && ((TeleporterMKI) itemstack.getItem()).getLocation(itemstack) != null;
+    public boolean isItemValidForSlot(int index, ItemStack stack) {
+        return index == 0 && stack != null
+                && stack.getItem() instanceof TeleporterMKI
+                && ((TeleporterMKI) stack.getItem()).getLocation(stack) != null;
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileDislocatorReceptacle.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileDislocatorReceptacle.java
@@ -86,8 +86,8 @@ public class TileDislocatorReceptacle extends TileEntity implements IInventory {
     }
 
     public Teleporter.TeleportLocation getLocation() {
-        if (dislocator != null && dislocator.getItem() instanceof TeleporterMKI) {
-            return ((TeleporterMKI) dislocator.getItem()).getLocation(dislocator);
+        if (dislocator != null && dislocator.getItem() instanceof TeleporterMKI teleporter) {
+            return teleporter.getLocation(dislocator);
         }
         return null;
     }
@@ -186,8 +186,8 @@ public class TileDislocatorReceptacle extends TileEntity implements IInventory {
     @Override
     public boolean isItemValidForSlot(int index, ItemStack stack) {
         return index == 0 && stack != null
-                && stack.getItem() instanceof TeleporterMKI
-                && ((TeleporterMKI) stack.getItem()).getLocation(stack) != null;
+                && stack.getItem() instanceof TeleporterMKI teleporter
+                && teleporter.getLocation(stack) != null;
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyPylon.java
@@ -14,7 +14,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import com.brandon3055.draconicevolution.api.IExtendedRFStorage;
 import com.brandon3055.draconicevolution.client.handler.ParticleHandler;
-import com.brandon3055.draconicevolution.client.render.particle.Particles;
+import com.brandon3055.draconicevolution.client.render.particle.Particles.EnergyTransferParticle;
 import com.brandon3055.draconicevolution.common.ModBlocks;
 import com.brandon3055.draconicevolution.common.blocks.multiblock.MultiblockHelper.TileLocation;
 import com.brandon3055.draconicevolution.common.lib.References;
@@ -38,7 +38,7 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
     public boolean lastTickReciveEnergy = false;
     public float modelRotation = 0;
     public float modelScale = 0;
-    private List<TileLocation> coreLocatios = new ArrayList<TileLocation>();
+    private List<TileLocation> coreLocations = new ArrayList<>();
     private int selectedCore = 0;
     private byte particleRate = 0;
     private byte lastTickParticleRate = 0;
@@ -47,68 +47,42 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
 
     @Override
     public void updateEntity() {
-        if (active && worldObj.isRemote) {
-            modelRotation += 1.5;
-            modelScale += !reciveEnergy ? -0.01F : 0.01F;
-            if ((modelScale < 0 && !reciveEnergy)) modelScale = 10000F;
-            if ((modelScale < 0 && reciveEnergy)) modelScale = 0F;
-            spawnParticles();
-        } else if (worldObj.isRemote) modelScale = 0.5F;
-
-        if (worldObj.isRemote) return;
+        if (worldObj.isRemote) {
+            if (active) {
+                modelRotation += 1.5;
+                modelScale += reciveEnergy ? 0.01F : -0.01F;
+                if (modelScale < 0) {
+                    modelScale = reciveEnergy ? 0F : 10000F;
+                }
+                spawnParticles();
+            } else {
+                modelScale = 0.5F;
+            }
+            return;
+        }
 
         tick++;
         if (tick % 20 == 0) {
-            int cOut = (int) (getEnergyStored() / getMaxEnergyStored() * 15D);
-            if (cOut != lastCheckCompOverride) {
+            int comparatorOut = (int) (getEnergyStored() / getMaxEnergyStored() * 15D);
+            if (comparatorOut != lastCheckCompOverride) {
                 worldObj.notifyBlocksOfNeighborChange(
                         xCoord,
                         yCoord,
                         zCoord,
                         worldObj.getBlock(xCoord, yCoord, zCoord));
-                worldObj.notifyBlocksOfNeighborChange(
-                        xCoord - 1,
-                        yCoord,
-                        zCoord,
-                        worldObj.getBlock(xCoord, yCoord, zCoord));
-                worldObj.notifyBlocksOfNeighborChange(
-                        xCoord + 1,
-                        yCoord,
-                        zCoord,
-                        worldObj.getBlock(xCoord, yCoord, zCoord));
-                worldObj.notifyBlocksOfNeighborChange(
-                        xCoord,
-                        yCoord - 1,
-                        zCoord,
-                        worldObj.getBlock(xCoord, yCoord, zCoord));
-                worldObj.notifyBlocksOfNeighborChange(
-                        xCoord,
-                        yCoord + 1,
-                        zCoord,
-                        worldObj.getBlock(xCoord, yCoord, zCoord));
-                worldObj.notifyBlocksOfNeighborChange(
-                        xCoord,
-                        yCoord,
-                        zCoord - 1,
-                        worldObj.getBlock(xCoord, yCoord, zCoord));
-                worldObj.notifyBlocksOfNeighborChange(
-                        xCoord,
-                        yCoord,
-                        zCoord + 1,
-                        worldObj.getBlock(xCoord, yCoord, zCoord));
-                lastCheckCompOverride = cOut;
+                lastCheckCompOverride = comparatorOut;
             }
         }
 
         if (active && !reciveEnergy) {
-            for (ForgeDirection d : ForgeDirection.VALID_DIRECTIONS) {
-                TileEntity tile = worldObj.getTileEntity(xCoord + d.offsetX, yCoord + d.offsetY, zCoord + d.offsetZ);
-                if (tile != null && tile instanceof IEnergyReceiver) {
-                    extractEnergy(
-                            d,
-                            ((IEnergyReceiver) tile)
-                                    .receiveEnergy(d.getOpposite(), extractEnergy(d, Integer.MAX_VALUE, true), false),
-                            false);
+            for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
+                TileEntity tile = worldObj
+                        .getTileEntity(xCoord + side.offsetX, yCoord + side.offsetY, zCoord + side.offsetZ);
+                if (tile instanceof IEnergyReceiver) {
+                    int energyToReceive = extractEnergy(side, Integer.MAX_VALUE, true);
+                    int energyReceived = ((IEnergyReceiver) tile)
+                            .receiveEnergy(side.getOpposite(), energyToReceive, false);
+                    extractEnergy(side, energyReceived, false);
                 }
             }
         }
@@ -125,19 +99,22 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
     }
 
     private TileEnergyStorageCore getMaster() {
-        if (coreLocatios.isEmpty()) return null;
-        if (selectedCore >= coreLocatios.size()) selectedCore = coreLocatios.size() - 1;
-        TileLocation core = coreLocatios.get(selectedCore);
-        if (core == null || !(worldObj
-                .getTileEntity(core.getXCoord(), core.getYCoord(), core.getZCoord()) instanceof TileEnergyStorageCore))
-            return null;
-        return (TileEnergyStorageCore) worldObj.getTileEntity(core.getXCoord(), core.getYCoord(), core.getZCoord());
+        if (coreLocations.isEmpty()) return null;
+        if (selectedCore >= coreLocations.size()) selectedCore = coreLocations.size() - 1;
+        TileLocation location = coreLocations.get(selectedCore);
+        if (location != null) {
+            TileEntity tile = location.getTileEntity(worldObj);
+            if (tile instanceof TileEnergyStorageCore) {
+                return (TileEnergyStorageCore) tile;
+            }
+        }
+        return null;
     }
 
     private void findCores() {
         int yMod = worldObj.getBlockMetadata(xCoord, yCoord, zCoord) == 1 ? 15 : -15;
         int range = 15;
-        List<TileLocation> locations = new ArrayList<TileLocation>();
+        List<TileLocation> locations = new ArrayList<>();
         for (int x = xCoord - range; x <= xCoord + range; x++) {
             for (int y = yCoord + yMod - range; y <= yCoord + yMod + range; y++) {
                 for (int z = zCoord - range; z <= zCoord + range; z++) {
@@ -148,10 +125,10 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
             }
         }
 
-        if (locations != coreLocatios) {
-            coreLocatios.clear();
-            coreLocatios.addAll(locations);
-            selectedCore = selectedCore >= coreLocatios.size() ? 0 : selectedCore;
+        if (locations != coreLocations) {
+            coreLocations.clear();
+            coreLocations.addAll(locations);
+            selectedCore = selectedCore >= coreLocations.size() ? 0 : selectedCore;
             worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
         }
     }
@@ -159,135 +136,82 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
     public void nextCore() {
         findCores();
         selectedCore++;
-        if (selectedCore >= coreLocatios.size()) selectedCore = 0;
+        if (selectedCore >= coreLocations.size()) selectedCore = 0;
         worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
     }
 
     @SideOnly(Side.CLIENT)
     private void spawnParticles() {
         Random rand = worldObj.rand;
-        if (getMaster() == null || !getMaster().isOnline()) return;
 
-        int x = getMaster().xCoord;
-        int y = getMaster().yCoord;
-        int z = getMaster().zCoord;
+        TileEnergyStorageCore core = getMaster();
+        if (core == null || !core.isOnline()) return;
+
+        int x = core.xCoord;
+        int y = core.yCoord;
+        int z = core.zCoord;
         int cYCoord = worldObj.getBlockMetadata(xCoord, yCoord, zCoord) == 1 ? yCoord + 1 : yCoord - 1;
 
-        float disMod = getMaster().getTier() == 0 ? 0.5F
-                : getMaster().getTier() == 1 ? 1F
-                        : getMaster().getTier() == 2 ? 1F
-                                : getMaster().getTier() == 3 ? 2F
-                                        : getMaster().getTier() == 4 ? 2F : getMaster().getTier() == 5 ? 3F : 4F;
-        double spawnX;
-        double spawnY;
-        double spawnZ;
-        double targetX;
-        double targetY;
-        double targetZ;
+        float disMod;
+        switch (core.getTier()) {
+            case 0:
+                disMod = 0.5F;
+                break;
+            case 1:
+            case 2:
+                disMod = 1F;
+                break;
+            case 3:
+            case 4:
+                disMod = 2F;
+                break;
+            case 5:
+                disMod = 3F;
+                break;
+            default:
+                disMod = 4F;
+                break;
+        }
+
         if (particleRate > 20) particleRate = 20;
-        if (!reciveEnergy) {
-            spawnX = x + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-            spawnY = y + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-            spawnZ = z + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-            targetX = xCoord + 0.5;
-            targetY = cYCoord + 0.5;
-            targetZ = zCoord + 0.5;
-            if (rand.nextFloat() < 0.05F) {
-                Particles.EnergyTransferParticle passiveParticle = new Particles.EnergyTransferParticle(
-                        worldObj,
-                        spawnX,
-                        spawnY,
-                        spawnZ,
-                        targetX,
-                        targetY,
-                        targetZ,
-                        true);
-                ParticleHandler.spawnCustomParticle(passiveParticle, 35);
-            }
-            if (particleRate > 0) {
-                if (particleRate > 10) {
-                    for (int i = 0; i <= particleRate / 10; i++) {
-                        spawnX = x + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-                        spawnY = y + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-                        spawnZ = z + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-                        Particles.EnergyTransferParticle passiveParticle = new Particles.EnergyTransferParticle(
-                                worldObj,
-                                spawnX,
-                                spawnY,
-                                spawnZ,
-                                targetX,
-                                targetY,
-                                targetZ,
-                                false);
-                        ParticleHandler.spawnCustomParticle(passiveParticle, 35);
-                    }
-                } else if (rand.nextInt(Math.max(1, 10 - particleRate)) == 0) {
-                    spawnX = x + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-                    spawnY = y + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-                    spawnZ = z + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-                    Particles.EnergyTransferParticle passiveParticle = new Particles.EnergyTransferParticle(
-                            worldObj,
-                            spawnX,
-                            spawnY,
-                            spawnZ,
-                            targetX,
-                            targetY,
-                            targetZ,
-                            false);
-                    ParticleHandler.spawnCustomParticle(passiveParticle, 35);
-                }
-            }
-
-        } else {
-            targetX = x + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-            targetY = y + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-            targetZ = z + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-            spawnX = xCoord + 0.5;
-            spawnY = cYCoord + 0.5;
-            spawnZ = zCoord + 0.5;
-            if (rand.nextFloat() < 0.05F) {
-                Particles.EnergyTransferParticle passiveParticle = new Particles.EnergyTransferParticle(
-                        worldObj,
-                        spawnX,
-                        spawnY,
-                        spawnZ,
-                        targetX,
-                        targetY,
-                        targetZ,
-                        true);
-                ParticleHandler.spawnCustomParticle(passiveParticle, 35);
-            }
-
-            if (particleRate > 0) {
-                if (particleRate > 10) {
-                    for (int i = 0; i <= particleRate / 10; i++) {
-                        targetX = x + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-                        targetY = y + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-                        targetZ = z + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-                        Particles.EnergyTransferParticle passiveParticle = new Particles.EnergyTransferParticle(
-                                worldObj,
-                                spawnX,
-                                spawnY,
-                                spawnZ,
-                                targetX,
-                                targetY,
-                                targetZ,
-                                false);
-                        ParticleHandler.spawnCustomParticle(passiveParticle, 35);
-                    }
-                } else if (rand.nextInt(Math.max(1, 10 - particleRate)) == 0) {
-                    targetX = x + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-                    targetY = y + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-                    targetZ = z + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
-                    Particles.EnergyTransferParticle passiveParticle = new Particles.EnergyTransferParticle(
-                            worldObj,
-                            spawnX,
-                            spawnY,
-                            spawnZ,
-                            targetX,
-                            targetY,
-                            targetZ,
-                            false);
+        double sourceX = x + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
+        double sourceY = y + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
+        double sourceZ = z + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
+        double targetX = xCoord + 0.5;
+        double targetY = cYCoord + 0.5;
+        double targetZ = zCoord + 0.5;
+        if (rand.nextFloat() < 0.05F) {
+            EnergyTransferParticle passiveParticle = reciveEnergy
+                    ? new EnergyTransferParticle(worldObj, targetX, targetY, targetZ, sourceX, sourceY, sourceZ, true)
+                    : new EnergyTransferParticle(worldObj, sourceX, sourceY, sourceZ, targetX, targetY, targetZ, true);
+            ParticleHandler.spawnCustomParticle(passiveParticle, 35);
+        }
+        if (particleRate > 0) {
+            if (particleRate > 10 || rand.nextInt(Math.max(1, 10 - particleRate)) == 0) {
+                int iterations = particleRate > 10 ? particleRate / 10 : 1;
+                for (int i = 0; i <= iterations; i++) {
+                    sourceX = x + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
+                    sourceY = y + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
+                    sourceZ = z + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
+                    EnergyTransferParticle passiveParticle = reciveEnergy
+                            ? new EnergyTransferParticle(
+                                    worldObj,
+                                    targetX,
+                                    targetY,
+                                    targetZ,
+                                    sourceX,
+                                    sourceY,
+                                    sourceZ,
+                                    false)
+                            : new EnergyTransferParticle(
+                                    worldObj,
+                                    sourceX,
+                                    sourceY,
+                                    sourceZ,
+                                    targetX,
+                                    targetY,
+                                    targetZ,
+                                    false);
                     ParticleHandler.spawnCustomParticle(passiveParticle, 35);
                 }
             }
@@ -295,8 +219,9 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
     }
 
     private boolean isValidStructure() {
-        return (isGlass(xCoord, yCoord + 1, zCoord) || isGlass(xCoord, yCoord - 1, zCoord))
-                && (!isGlass(xCoord, yCoord + 1, zCoord) || !isGlass(xCoord, yCoord - 1, zCoord));
+        boolean hasGlassAbove = isGlass(xCoord, yCoord + 1, zCoord);
+        boolean hasGlassBelow = isGlass(xCoord, yCoord - 1, zCoord);
+        return hasGlassAbove != hasGlassBelow;
     }
 
     private boolean isGlass(int x, int y, int z) {
@@ -309,13 +234,13 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
         active = compound.getBoolean("Active");
         reciveEnergy = compound.getBoolean("Input");
         int i = compound.getInteger("Cores");
-        List<TileLocation> list = new ArrayList<TileLocation>();
+        List<TileLocation> list = new ArrayList<>();
         for (int j = 0; j < i; j++) {
             TileLocation l = new TileLocation();
             l.readFromNBT(compound, "Core" + j);
             list.add(l);
         }
-        coreLocatios = list;
+        coreLocations = list;
         selectedCore = compound.getInteger("SelectedCore");
         particleRate = compound.getByte("ParticleRate");
     }
@@ -326,10 +251,10 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
         super.writeToNBT(compound);
         compound.setBoolean("Active", active);
         compound.setBoolean("Input", reciveEnergy);
-        int i = coreLocatios.size();
+        int i = coreLocations.size();
         compound.setInteger("Cores", i);
         for (int j = 0; j < i; j++) {
-            coreLocatios.get(j).writeToNBT(compound, "Core" + j);
+            coreLocations.get(j).writeToNBT(compound, "Core" + j);
         }
         compound.setInteger("SelectedCore", selectedCore);
         compound.setByte("ParticleRate", particleRate);
@@ -357,8 +282,7 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
     public int receiveEnergy(ForgeDirection from, int maxReceive, boolean simulate) {
         if (getMaster() == null) return 0;
         int received = reciveEnergy ? getMaster().receiveEnergy(maxReceive, simulate) : 0;
-        if (!simulate && received > 0)
-            particleRate = (byte) Math.min(20, received < 500 && received > 0 ? 1 : received / 500);
+        if (!simulate && received > 0) particleRate = (byte) Math.min(20, received < 500 ? 1 : received / 500);
         return received;
     }
 
@@ -366,8 +290,7 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
     public int extractEnergy(ForgeDirection from, int maxExtract, boolean simulate) {
         if (getMaster() == null || !getMaster().isOnline()) return 0;
         int extracted = reciveEnergy ? 0 : getMaster().extractEnergy(maxExtract, simulate);
-        if (!simulate && extracted > 0)
-            particleRate = (byte) Math.min(20, extracted < 500 && extracted > 0 ? 1 : extracted / 500);
+        if (!simulate && extracted > 0) particleRate = (byte) Math.min(20, extracted < 500 ? 1 : extracted / 500);
         return extracted;
     }
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyPylon.java
@@ -74,10 +74,9 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
             for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
                 TileEntity tile = worldObj
                         .getTileEntity(xCoord + side.offsetX, yCoord + side.offsetY, zCoord + side.offsetZ);
-                if (tile instanceof IEnergyReceiver) {
+                if (tile instanceof IEnergyReceiver receiver) {
                     int energyToReceive = extractEnergy(side, Integer.MAX_VALUE, true);
-                    int energyReceived = ((IEnergyReceiver) tile)
-                            .receiveEnergy(side.getOpposite(), energyToReceive, false);
+                    int energyReceived = receiver.receiveEnergy(side.getOpposite(), energyToReceive, false);
                     extractEnergy(side, energyReceived, false);
                 }
             }
@@ -100,8 +99,8 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
         TileLocation location = coreLocations.get(selectedCore);
         if (location != null) {
             TileEntity tile = location.getTileEntity(worldObj);
-            if (tile instanceof TileEnergyStorageCore) {
-                return (TileEnergyStorageCore) tile;
+            if (tile instanceof TileEnergyStorageCore core) {
+                return core;
             }
         }
         return null;
@@ -148,26 +147,13 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
         int z = core.zCoord;
         int cYCoord = worldObj.getBlockMetadata(xCoord, yCoord, zCoord) == 1 ? yCoord + 1 : yCoord - 1;
 
-        float disMod;
-        switch (core.getTier()) {
-            case 0:
-                disMod = 0.5F;
-                break;
-            case 1:
-            case 2:
-                disMod = 1F;
-                break;
-            case 3:
-            case 4:
-                disMod = 2F;
-                break;
-            case 5:
-                disMod = 3F;
-                break;
-            default:
-                disMod = 4F;
-                break;
-        }
+        float disMod = switch (core.getTier()) {
+            case 0 -> 0.5F;
+            case 1, 2 -> 1F;
+            case 3, 4 -> 2F;
+            case 5 -> 3F;
+            default -> 4F;
+        };
 
         if (particleRate > 20) particleRate = 20;
         double sourceX = x + 0.5 - disMod + (rand.nextFloat() * (disMod * 2));
@@ -326,15 +312,9 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
     @Override
     public void receiveObjectFromServer(int index, Object object) {
         switch (index) {
-            case 0:
-                active = (Boolean) object;
-                break;
-            case 1:
-                isReceivingEnergy = (Boolean) object;
-                break;
-            case 2:
-                particleRate = (Byte) object;
-                break;
+            case 0 -> active = (Boolean) object;
+            case 1 -> isReceivingEnergy = (Boolean) object;
+            case 2 -> particleRate = (Byte) object;
         }
     }
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyPylon.java
@@ -65,11 +65,7 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
         if (tick % 20 == 0) {
             int comparatorOut = (int) (getEnergyStored() / getMaxEnergyStored() * 15D);
             if (comparatorOut != lastCheckCompOverride) {
-                worldObj.notifyBlocksOfNeighborChange(
-                        xCoord,
-                        yCoord,
-                        zCoord,
-                        worldObj.getBlock(xCoord, yCoord, zCoord));
+                worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, blockType);
                 lastCheckCompOverride = comparatorOut;
             }
         }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyStorageCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyStorageCore.java
@@ -370,7 +370,7 @@ public class TileEnergyStorageCore extends TileObjectSync {
                 return;
             }
             TileParticleGenerator generator = (TileParticleGenerator) tile;
-            generator.stabalizerMode = true;
+            generator.isInStabilizerMode = true;
             generator.setMaster(new TileLocation(xCoord, yCoord, zCoord));
             worldObj.setBlockMetadataWithNotify(
                     stabilizer.getXCoord(),
@@ -416,7 +416,7 @@ public class TileEnergyStorageCore extends TileObjectSync {
             TileEntity tile = stabilizer.getTileEntity(worldObj);
             if (tile instanceof TileParticleGenerator) {
                 TileParticleGenerator generator = (TileParticleGenerator) tile;
-                generator.stabalizerMode = false;
+                generator.isInStabilizerMode = false;
                 worldObj.setBlockMetadataWithNotify(
                         stabilizer.getXCoord(),
                         stabilizer.getYCoord(),
@@ -434,7 +434,7 @@ public class TileEnergyStorageCore extends TileObjectSync {
                 return false;
             }
             TileParticleGenerator generator = (TileParticleGenerator) tile;
-            if (!generator.stabalizerMode || stabilizer.getBlockMetadata(worldObj) != 1) {
+            if (!generator.isInStabilizerMode || stabilizer.getBlockMetadata(worldObj) != 1) {
                 return false;
             }
             TileEnergyStorageCore core = generator.getMaster();

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyStorageCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyStorageCore.java
@@ -62,20 +62,12 @@ public class TileEnergyStorageCore extends TileObjectSync {
             modelRotation += 0.5;
             return;
         }
-        detectAndRendChanges();
+        detectAndSendChanges();
     }
 
     /**
      * ######################MultiBlock Methods#######################
      */
-    public boolean tryActivate() {
-        return tryActivate(false);
-    }
-
-    public boolean creativeActivate() {
-        return tryActivate(true);
-    }
-
     public boolean tryActivate(boolean isCreativeMode) {
         if (!findStabilizers()) {
             return false;
@@ -99,7 +91,7 @@ public class TileEnergyStorageCore extends TileObjectSync {
         return false;
     }
 
-    public boolean isStructureStillValid(boolean update) {
+    public void validateStructure(boolean update) {
         online = areStabilizersActive() && scanStructure(this::isInnerBlock, this::isOuterBlock);
         worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
         if (!online) {
@@ -108,7 +100,6 @@ public class TileEnergyStorageCore extends TileObjectSync {
                 reIntegrate();
             }
         }
-        return online;
     }
 
     private void reIntegrate() {
@@ -553,12 +544,14 @@ public class TileEnergyStorageCore extends TileObjectSync {
         return 40960.0D;
     }
 
-    private void detectAndRendChanges() {
-        if (lastTickCapacity != energy) lastTickCapacity = (Long) sendObjectToClient(
-                References.LONG_ID,
-                0,
-                energy,
-                new NetworkRegistry.TargetPoint(worldObj.provider.dimensionId, xCoord, yCoord, zCoord, 20));
+    private void detectAndSendChanges() {
+        if (lastTickCapacity != energy) {
+            lastTickCapacity = (long) sendObjectToClient(
+                    References.LONG_ID,
+                    0,
+                    energy,
+                    new NetworkRegistry.TargetPoint(worldObj.provider.dimensionId, xCoord, yCoord, zCoord, 20));
+        }
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyStorageCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyStorageCore.java
@@ -1,12 +1,20 @@
 package com.brandon3055.draconicevolution.common.tileentities.multiblocktiles;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.StatCollector;
 
+import com.brandon3055.brandonscore.common.utills.InfoHelper;
+import com.brandon3055.brandonscore.common.utills.Utills;
 import com.brandon3055.draconicevolution.common.ModBlocks;
 import com.brandon3055.draconicevolution.common.blocks.multiblock.MultiblockHelper.TileLocation;
 import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
@@ -22,6 +30,12 @@ import cpw.mods.fml.common.network.NetworkRegistry;
  */
 public class TileEnergyStorageCore extends TileObjectSync {
 
+    private enum MultiblockPartType {
+        AIR,
+        REDSTONE,
+        DRACONIUM
+    }
+
     protected TileLocation[] stabilizers = new TileLocation[4];
     protected int tier = 0;
     protected boolean online = false;
@@ -29,7 +43,6 @@ public class TileEnergyStorageCore extends TileObjectSync {
     private long energy = 0;
     private long capacity = 0;
     private long lastTickCapacity = 0;
-    private int tick = 0;
 
     public TileEnergyStorageCore() {
         for (int i = 0; i < stabilizers.length; i++) {
@@ -39,18 +52,19 @@ public class TileEnergyStorageCore extends TileObjectSync {
 
     @Override
     public void updateEntity() {
-        // energy = 200000000;
         if (!online) return;
-        if (worldObj.isRemote) modelRotation += 0.5;
-        if (!worldObj.isRemote) detectAndRendChanges();
-        tick++;
+        if (worldObj.isRemote) {
+            modelRotation += 0.5;
+            return;
+        }
+        detectAndRendChanges();
     }
 
     /**
      * ######################MultiBlock Methods#######################
      */
     public boolean tryActivate() {
-        if (!findStabalyzers()) return false;
+        if (!findStabilizers()) return false;
         if (!setTier(false)) return false;
         if (!testOrActivateStructureIfValid(false, false)) return false;
         online = true;
@@ -65,7 +79,7 @@ public class TileEnergyStorageCore extends TileObjectSync {
     }
 
     public boolean creativeActivate() {
-        if (!findStabalyzers()) return false;
+        if (!findStabilizers()) return false;
         if (!setTier(false)) return false;
         if (!testOrActivateStructureIfValid(true, false)) return false;
         online = true;
@@ -86,9 +100,6 @@ public class TileEnergyStorageCore extends TileObjectSync {
         worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
         if (!online) deactivateStabilizers();
         if (update && !online) reIntegrate();
-        // if (update && !online && worldObj.getTileEntity(xCoord, yCoord + 1, zCoord) != null &&
-        // worldObj.getTileEntity(xCoord, yCoord + 1, zCoord) instanceof TileInvisibleMultiblock)
-        // ((TileInvisibleMultiblock)worldObj.getTileEntity(xCoord, yCoord + 1, zCoord)).isStructureStillValid();
         return online;
     }
 
@@ -120,7 +131,7 @@ public class TileEnergyStorageCore extends TileObjectSync {
         }
     }
 
-    private boolean findStabalyzers() {
+    private boolean findStabilizers() {
         boolean flag = true;
         for (int x = xCoord; x <= xCoord + 11; x++) {
             if (worldObj.getBlock(x, yCoord, zCoord) == ModBlocks.particleGenerator) {
@@ -238,7 +249,7 @@ public class TileEnergyStorageCore extends TileObjectSync {
     private boolean testOrActivateStructureIfValid(boolean setBlocks, boolean activate) {
         switch (tier) {
             case 0:
-                if (!testOrActivateRect(1, 1, 1, "air", setBlocks, activate)) return false;
+                if (!testOrActivateRect(1, 1, 1, MultiblockPartType.AIR, setBlocks, activate)) return false;
                 break;
             case 1:
                 if (!testForOrActivateDraconium(xCoord + 1, yCoord, zCoord, setBlocks, activate)
@@ -248,80 +259,86 @@ public class TileEnergyStorageCore extends TileObjectSync {
                         || !testForOrActivateDraconium(xCoord, yCoord, zCoord + 1, setBlocks, activate)
                         || !testForOrActivateDraconium(xCoord, yCoord, zCoord - 1, setBlocks, activate))
                     return false;
-                if (!isReplacable(xCoord + 1, yCoord + 1, zCoord, setBlocks)
-                        || !isReplacable(xCoord, yCoord + 1, zCoord + 1, setBlocks)
-                        || !isReplacable(xCoord - 1, yCoord + 1, zCoord, setBlocks)
-                        || !isReplacable(xCoord, yCoord + 1, zCoord - 1, setBlocks)
-                        || !isReplacable(xCoord + 1, yCoord - 1, zCoord, setBlocks)
-                        || !isReplacable(xCoord, yCoord - 1, zCoord + 1, setBlocks)
-                        || !isReplacable(xCoord - 1, yCoord - 1, zCoord, setBlocks)
-                        || !isReplacable(xCoord, yCoord - 1, zCoord - 1, setBlocks)
-                        || !isReplacable(xCoord + 1, yCoord, zCoord + 1, setBlocks)
-                        || !isReplacable(xCoord - 1, yCoord, zCoord - 1, setBlocks)
-                        || !isReplacable(xCoord + 1, yCoord, zCoord - 1, setBlocks)
-                        || !isReplacable(xCoord - 1, yCoord, zCoord + 1, setBlocks))
+                if (!isReplaceable(xCoord + 1, yCoord + 1, zCoord, setBlocks)
+                        || !isReplaceable(xCoord, yCoord + 1, zCoord + 1, setBlocks)
+                        || !isReplaceable(xCoord - 1, yCoord + 1, zCoord, setBlocks)
+                        || !isReplaceable(xCoord, yCoord + 1, zCoord - 1, setBlocks)
+                        || !isReplaceable(xCoord + 1, yCoord - 1, zCoord, setBlocks)
+                        || !isReplaceable(xCoord, yCoord - 1, zCoord + 1, setBlocks)
+                        || !isReplaceable(xCoord - 1, yCoord - 1, zCoord, setBlocks)
+                        || !isReplaceable(xCoord, yCoord - 1, zCoord - 1, setBlocks)
+                        || !isReplaceable(xCoord + 1, yCoord, zCoord + 1, setBlocks)
+                        || !isReplaceable(xCoord - 1, yCoord, zCoord - 1, setBlocks)
+                        || !isReplaceable(xCoord + 1, yCoord, zCoord - 1, setBlocks)
+                        || !isReplaceable(xCoord - 1, yCoord, zCoord + 1, setBlocks))
                     return false;
-                if (!isReplacable(xCoord + 1, yCoord + 1, zCoord + 1, setBlocks)
-                        || !isReplacable(xCoord - 1, yCoord + 1, zCoord - 1, setBlocks)
-                        || !isReplacable(xCoord + 1, yCoord + 1, zCoord - 1, setBlocks)
-                        || !isReplacable(xCoord - 1, yCoord + 1, zCoord + 1, setBlocks)
-                        || !isReplacable(xCoord + 1, yCoord - 1, zCoord + 1, setBlocks)
-                        || !isReplacable(xCoord - 1, yCoord - 1, zCoord - 1, setBlocks)
-                        || !isReplacable(xCoord + 1, yCoord - 1, zCoord - 1, setBlocks)
-                        || !isReplacable(xCoord - 1, yCoord - 1, zCoord + 1, setBlocks))
+                if (!isReplaceable(xCoord + 1, yCoord + 1, zCoord + 1, setBlocks)
+                        || !isReplaceable(xCoord - 1, yCoord + 1, zCoord - 1, setBlocks)
+                        || !isReplaceable(xCoord + 1, yCoord + 1, zCoord - 1, setBlocks)
+                        || !isReplaceable(xCoord - 1, yCoord + 1, zCoord + 1, setBlocks)
+                        || !isReplaceable(xCoord + 1, yCoord - 1, zCoord + 1, setBlocks)
+                        || !isReplaceable(xCoord - 1, yCoord - 1, zCoord - 1, setBlocks)
+                        || !isReplaceable(xCoord + 1, yCoord - 1, zCoord - 1, setBlocks)
+                        || !isReplaceable(xCoord - 1, yCoord - 1, zCoord + 1, setBlocks))
                     return false;
                 break;
             case 2:
-                if (!testOrActivateRect(1, 1, 1, "draconiumBlock", setBlocks, activate)) return false;
+                if (!testOrActivateRect(1, 1, 1, MultiblockPartType.DRACONIUM, setBlocks, activate)) return false;
                 break;
             case 3:
-                if (!testOrActivateSides(1, "draconiumBlock", setBlocks, activate)) return false;
-                if (!testOrActivateRect(1, 1, 1, "redstone", setBlocks, activate)) return false;
+                if (!testOrActivateSides(1, MultiblockPartType.DRACONIUM, setBlocks, activate)) return false;
+                if (!testOrActivateRect(1, 1, 1, MultiblockPartType.REDSTONE, setBlocks, activate)) return false;
                 break;
             case 4:
-                if (!testOrActivateSides(2, "draconiumBlock", setBlocks, activate)) return false;
-                if (!testOrActivateRect(2, 1, 1, "redstone", setBlocks, activate)) return false;
-                if (!testOrActivateRect(1, 2, 1, "redstone", setBlocks, activate)) return false;
-                if (!testOrActivateRect(1, 1, 2, "redstone", setBlocks, activate)) return false;
-                if (!testOrActivateRings(2, 2, "draconiumBlock", setBlocks, activate)) return false;
+                if (!testOrActivateSides(2, MultiblockPartType.DRACONIUM, setBlocks, activate)) return false;
+                if (!testOrActivateRect(2, 1, 1, MultiblockPartType.REDSTONE, setBlocks, activate)) return false;
+                if (!testOrActivateRect(1, 2, 1, MultiblockPartType.REDSTONE, setBlocks, activate)) return false;
+                if (!testOrActivateRect(1, 1, 2, MultiblockPartType.REDSTONE, setBlocks, activate)) return false;
+                if (!testOrActivateRings(2, 2, MultiblockPartType.DRACONIUM, setBlocks, activate)) return false;
                 break;
             case 5:
-                if (!testOrActivateSides(3, "draconiumBlock", setBlocks, activate)) return false;
-                if (!testOrActivateSides(2, "redstone", setBlocks, activate)) return false;
-                if (!testOrActivateRect(2, 2, 2, "redstone", setBlocks, activate)) return false;
-                if (!testOrActivateRings(2, 3, "draconiumBlock", setBlocks, activate)) return false;
+                if (!testOrActivateSides(3, MultiblockPartType.DRACONIUM, setBlocks, activate)) return false;
+                if (!testOrActivateSides(2, MultiblockPartType.REDSTONE, setBlocks, activate)) return false;
+                if (!testOrActivateRect(2, 2, 2, MultiblockPartType.REDSTONE, setBlocks, activate)) return false;
+                if (!testOrActivateRings(2, 3, MultiblockPartType.DRACONIUM, setBlocks, activate)) return false;
                 break;
             case 6:
-                if (!testOrActivateSides(4, "draconiumBlock", setBlocks, activate)) return false;
-                if (!testOrActivateSides(3, "redstone", setBlocks, activate)) return false;
-                if (!testOrActivateRect(3, 2, 2, "redstone", setBlocks, activate)) return false;
-                if (!testOrActivateRect(2, 3, 2, "redstone", setBlocks, activate)) return false;
-                if (!testOrActivateRect(2, 2, 3, "redstone", setBlocks, activate)) return false;
-                if (!testOrActivateRings(2, 4, "draconiumBlock", setBlocks, activate)) return false;
-                if (!testOrActivateRings(3, 3, "draconiumBlock", setBlocks, activate)) return false;
+                if (!testOrActivateSides(4, MultiblockPartType.DRACONIUM, setBlocks, activate)) return false;
+                if (!testOrActivateSides(3, MultiblockPartType.REDSTONE, setBlocks, activate)) return false;
+                if (!testOrActivateRect(3, 2, 2, MultiblockPartType.REDSTONE, setBlocks, activate)) return false;
+                if (!testOrActivateRect(2, 3, 2, MultiblockPartType.REDSTONE, setBlocks, activate)) return false;
+                if (!testOrActivateRect(2, 2, 3, MultiblockPartType.REDSTONE, setBlocks, activate)) return false;
+                if (!testOrActivateRings(2, 4, MultiblockPartType.DRACONIUM, setBlocks, activate)) return false;
+                if (!testOrActivateRings(3, 3, MultiblockPartType.DRACONIUM, setBlocks, activate)) return false;
                 break;
         }
         return true;
     }
 
-    private boolean testOrActivateRect(int xDim, int yDim, int zDim, String block, boolean set, boolean activate) {
+    private boolean testOrActivateRect(int xDim, int yDim, int zDim, MultiblockPartType block, boolean set,
+            boolean activate) {
         for (int x = xCoord - xDim; x <= xCoord + xDim; x++) {
             for (int y = yCoord - yDim; y <= yCoord + yDim; y++) {
                 for (int z = zCoord - zDim; z <= zCoord + zDim; z++) {
 
-                    if (block.equals("air")) {
-                        if (!(x == xCoord && y == yCoord && z == zCoord) && !isReplacable(x, y, z, set)) return false;
-                    } else if (block.equals("redstone")) {
-                        if (!(x == xCoord && y == yCoord && z == zCoord)
-                                && !testForOrActivateRedstone(x, y, z, set, activate))
+                    switch (block) {
+                        case AIR:
+                            if (!(x == xCoord && y == yCoord && z == zCoord) && !isReplaceable(x, y, z, set))
+                                return false;
+                            break;
+                        case REDSTONE:
+                            if (!(x == xCoord && y == yCoord && z == zCoord)
+                                    && !testForOrActivateRedstone(x, y, z, set, activate))
+                                return false;
+                            break;
+                        case DRACONIUM:
+                            if (!(x == xCoord && y == yCoord && z == zCoord)
+                                    && !testForOrActivateDraconium(x, y, z, set, activate))
+                                return false;
+                            break;
+                        default:
+                            LogHelper.error("Invalid String In Multiblock Structure Code!!!");
                             return false;
-                    } else if (block.equals("draconiumBlock")) {
-                        if (!(x == xCoord && y == yCoord && z == zCoord)
-                                && !testForOrActivateDraconium(x, y, z, set, activate))
-                            return false;
-                    } else if (!block.equals("draconiumBlock") && !block.equals("redstone") && !block.equals("air")) {
-                        LogHelper.error("Invalid String In Multiblock Structure Code!!!");
-                        return false;
                     }
                 }
             }
@@ -329,26 +346,30 @@ public class TileEnergyStorageCore extends TileObjectSync {
         return true;
     }
 
-    private boolean testOrActivateRings(int size, int dist, String block, boolean set, boolean activate) {
+    private boolean testOrActivateRings(int size, int dist, MultiblockPartType block, boolean set, boolean activate) {
         for (int y = yCoord - size; y <= yCoord + size; y++) {
             for (int z = zCoord - size; z <= zCoord + size; z++) {
 
                 if (y == yCoord - size || y == yCoord + size || z == zCoord - size || z == zCoord + size) {
-                    if (block.equals("air")) {
-                        if (!(xCoord + dist == xCoord && y == yCoord && z == zCoord)
-                                && !isReplacable(xCoord + dist, y, z, set))
+                    switch (block) {
+                        case AIR:
+                            if (!(xCoord + dist == xCoord && y == yCoord && z == zCoord)
+                                    && !isReplaceable(xCoord + dist, y, z, set))
+                                return false;
+                            break;
+                        case REDSTONE:
+                            if (!(xCoord + dist == xCoord && y == yCoord && z == zCoord)
+                                    && !testForOrActivateRedstone(xCoord + dist, y, z, set, activate))
+                                return false;
+                            break;
+                        case DRACONIUM:
+                            if (!(xCoord + dist == xCoord && y == yCoord && z == zCoord)
+                                    && !testForOrActivateDraconium(xCoord + dist, y, z, set, activate))
+                                return false;
+                            break;
+                        default:
+                            LogHelper.error("Invalid String In Multiblock Structure Code!!!");
                             return false;
-                    } else if (block.equals("redstone")) {
-                        if (!(xCoord + dist == xCoord && y == yCoord && z == zCoord)
-                                && !testForOrActivateRedstone(xCoord + dist, y, z, set, activate))
-                            return false;
-                    } else if (block.equals("draconiumBlock")) {
-                        if (!(xCoord + dist == xCoord && y == yCoord && z == zCoord)
-                                && !testForOrActivateDraconium(xCoord + dist, y, z, set, activate))
-                            return false;
-                    } else if (!block.equals("draconiumBlock") && !block.equals("redstone") && !block.equals("air")) {
-                        LogHelper.error("Invalid String In Multiblock Structure Code!!!");
-                        return false;
                     }
                 }
             }
@@ -357,21 +378,25 @@ public class TileEnergyStorageCore extends TileObjectSync {
             for (int z = zCoord - size; z <= zCoord + size; z++) {
 
                 if (y == yCoord - size || y == yCoord + size || z == zCoord - size || z == zCoord + size) {
-                    if (block.equals("air")) {
-                        if (!(xCoord - dist == xCoord && y == yCoord && z == zCoord)
-                                && !isReplacable(xCoord - dist, y, z, set))
+                    switch (block) {
+                        case AIR:
+                            if (!(xCoord - dist == xCoord && y == yCoord && z == zCoord)
+                                    && !isReplaceable(xCoord - dist, y, z, set))
+                                return false;
+                            break;
+                        case REDSTONE:
+                            if (!(xCoord - dist == xCoord && y == yCoord && z == zCoord)
+                                    && !testForOrActivateRedstone(xCoord - dist, y, z, set, activate))
+                                return false;
+                            break;
+                        case DRACONIUM:
+                            if (!(xCoord - dist == xCoord && y == yCoord && z == zCoord)
+                                    && !testForOrActivateDraconium(xCoord - dist, y, z, set, activate))
+                                return false;
+                            break;
+                        default:
+                            LogHelper.error("Invalid String In Multiblock Structure Code!!!");
                             return false;
-                    } else if (block.equals("redstone")) {
-                        if (!(xCoord - dist == xCoord && y == yCoord && z == zCoord)
-                                && !testForOrActivateRedstone(xCoord - dist, y, z, set, activate))
-                            return false;
-                    } else if (block.equals("draconiumBlock")) {
-                        if (!(xCoord - dist == xCoord && y == yCoord && z == zCoord)
-                                && !testForOrActivateDraconium(xCoord - dist, y, z, set, activate))
-                            return false;
-                    } else if (!block.equals("draconiumBlock") && !block.equals("redstone") && !block.equals("air")) {
-                        LogHelper.error("Invalid String In Multiblock Structure Code!!!");
-                        return false;
                     }
                 }
             }
@@ -381,21 +406,25 @@ public class TileEnergyStorageCore extends TileObjectSync {
             for (int z = zCoord - size; z <= zCoord + size; z++) {
 
                 if (x == xCoord - size || x == xCoord + size || z == zCoord - size || z == zCoord + size) {
-                    if (block.equals("air")) {
-                        if (!(x == xCoord && yCoord + dist == yCoord && z == zCoord)
-                                && !isReplacable(x, yCoord + dist, z, set))
+                    switch (block) {
+                        case AIR:
+                            if (!(x == xCoord && yCoord + dist == yCoord && z == zCoord)
+                                    && !isReplaceable(x, yCoord + dist, z, set))
+                                return false;
+                            break;
+                        case REDSTONE:
+                            if (!(x == xCoord && yCoord + dist == yCoord && z == zCoord)
+                                    && !testForOrActivateRedstone(x, yCoord + dist, z, set, activate))
+                                return false;
+                            break;
+                        case DRACONIUM:
+                            if (!(x == xCoord && yCoord + dist == yCoord && z == zCoord)
+                                    && !testForOrActivateDraconium(x, yCoord + dist, z, set, activate))
+                                return false;
+                            break;
+                        default:
+                            LogHelper.error("Invalid String In Multiblock Structure Code!!!");
                             return false;
-                    } else if (block.equals("redstone")) {
-                        if (!(x == xCoord && yCoord + dist == yCoord && z == zCoord)
-                                && !testForOrActivateRedstone(x, yCoord + dist, z, set, activate))
-                            return false;
-                    } else if (block.equals("draconiumBlock")) {
-                        if (!(x == xCoord && yCoord + dist == yCoord && z == zCoord)
-                                && !testForOrActivateDraconium(x, yCoord + dist, z, set, activate))
-                            return false;
-                    } else if (!block.equals("draconiumBlock") && !block.equals("redstone") && !block.equals("air")) {
-                        LogHelper.error("Invalid String In Multiblock Structure Code!!!");
-                        return false;
                     }
                 }
             }
@@ -404,21 +433,25 @@ public class TileEnergyStorageCore extends TileObjectSync {
             for (int z = zCoord - size; z <= zCoord + size; z++) {
 
                 if (x == xCoord - size || x == xCoord + size || z == zCoord - size || z == zCoord + size) {
-                    if (block.equals("air")) {
-                        if (!(x == xCoord && yCoord - dist == yCoord && z == zCoord)
-                                && !isReplacable(x, yCoord - dist, z, set))
+                    switch (block) {
+                        case AIR:
+                            if (!(x == xCoord && yCoord - dist == yCoord && z == zCoord)
+                                    && !isReplaceable(x, yCoord - dist, z, set))
+                                return false;
+                            break;
+                        case REDSTONE:
+                            if (!(x == xCoord && yCoord - dist == yCoord && z == zCoord)
+                                    && !testForOrActivateRedstone(x, yCoord - dist, z, set, activate))
+                                return false;
+                            break;
+                        case DRACONIUM:
+                            if (!(x == xCoord && yCoord - dist == yCoord && z == zCoord)
+                                    && !testForOrActivateDraconium(x, yCoord - dist, z, set, activate))
+                                return false;
+                            break;
+                        default:
+                            LogHelper.error("Invalid String In Multiblock Structure Code!!!");
                             return false;
-                    } else if (block.equals("redstone")) {
-                        if (!(x == xCoord && yCoord - dist == yCoord && z == zCoord)
-                                && !testForOrActivateRedstone(x, yCoord - dist, z, set, activate))
-                            return false;
-                    } else if (block.equals("draconiumBlock")) {
-                        if (!(x == xCoord && yCoord - dist == yCoord && z == zCoord)
-                                && !testForOrActivateDraconium(x, yCoord - dist, z, set, activate))
-                            return false;
-                    } else if (!block.equals("draconiumBlock") && !block.equals("redstone") && !block.equals("air")) {
-                        LogHelper.error("Invalid String In Multiblock Structure Code!!!");
-                        return false;
                     }
                 }
             }
@@ -428,21 +461,25 @@ public class TileEnergyStorageCore extends TileObjectSync {
             for (int x = xCoord - size; x <= xCoord + size; x++) {
 
                 if (y == yCoord - size || y == yCoord + size || x == xCoord - size || x == xCoord + size) {
-                    if (block.equals("air")) {
-                        if (!(x == xCoord && y == yCoord && zCoord + dist == zCoord)
-                                && !isReplacable(x, y, zCoord + dist, set))
+                    switch (block) {
+                        case AIR:
+                            if (!(x == xCoord && y == yCoord && zCoord + dist == zCoord)
+                                    && !isReplaceable(x, y, zCoord + dist, set))
+                                return false;
+                            break;
+                        case REDSTONE:
+                            if (!(x == xCoord && y == yCoord && zCoord + dist == zCoord)
+                                    && !testForOrActivateRedstone(x, y, zCoord + dist, set, activate))
+                                return false;
+                            break;
+                        case DRACONIUM:
+                            if (!(x == xCoord && y == yCoord && zCoord + dist == zCoord)
+                                    && !testForOrActivateDraconium(x, y, zCoord + dist, set, activate))
+                                return false;
+                            break;
+                        default:
+                            LogHelper.error("Invalid String In Multiblock Structure Code!!!");
                             return false;
-                    } else if (block.equals("redstone")) {
-                        if (!(x == xCoord && y == yCoord && zCoord + dist == zCoord)
-                                && !testForOrActivateRedstone(x, y, zCoord + dist, set, activate))
-                            return false;
-                    } else if (block.equals("draconiumBlock")) {
-                        if (!(x == xCoord && y == yCoord && zCoord + dist == zCoord)
-                                && !testForOrActivateDraconium(x, y, zCoord + dist, set, activate))
-                            return false;
-                    } else if (!block.equals("draconiumBlock") && !block.equals("redstone") && !block.equals("air")) {
-                        LogHelper.error("Invalid String In Multiblock Structure Code!!!");
-                        return false;
                     }
                 }
             }
@@ -451,21 +488,25 @@ public class TileEnergyStorageCore extends TileObjectSync {
             for (int x = xCoord - size; x <= xCoord + size; x++) {
 
                 if (y == yCoord - size || y == yCoord + size || x == xCoord - size || x == xCoord + size) {
-                    if (block.equals("air")) {
-                        if (!(x == xCoord && y == yCoord && zCoord - dist == zCoord)
-                                && !isReplacable(x, y, zCoord - dist, set))
+                    switch (block) {
+                        case AIR:
+                            if (!(x == xCoord && y == yCoord && zCoord - dist == zCoord)
+                                    && !isReplaceable(x, y, zCoord - dist, set))
+                                return false;
+                            break;
+                        case REDSTONE:
+                            if (!(x == xCoord && y == yCoord && zCoord - dist == zCoord)
+                                    && !testForOrActivateRedstone(x, y, zCoord - dist, set, activate))
+                                return false;
+                            break;
+                        case DRACONIUM:
+                            if (!(x == xCoord && y == yCoord && zCoord - dist == zCoord)
+                                    && !testForOrActivateDraconium(x, y, zCoord - dist, set, activate))
+                                return false;
+                            break;
+                        default:
+                            LogHelper.error("Invalid String In Multiblock Structure Code!!!");
                             return false;
-                    } else if (block.equals("redstone")) {
-                        if (!(x == xCoord && y == yCoord && zCoord - dist == zCoord)
-                                && !testForOrActivateRedstone(x, y, zCoord - dist, set, activate))
-                            return false;
-                    } else if (block.equals("draconiumBlock")) {
-                        if (!(x == xCoord && y == yCoord && zCoord - dist == zCoord)
-                                && !testForOrActivateDraconium(x, y, zCoord - dist, set, activate))
-                            return false;
-                    } else if (!block.equals("draconiumBlock") && !block.equals("redstone") && !block.equals("air")) {
-                        LogHelper.error("Invalid String In Multiblock Structure Code!!!");
-                        return false;
                     }
                 }
             }
@@ -473,47 +514,55 @@ public class TileEnergyStorageCore extends TileObjectSync {
         return true;
     }
 
-    private boolean testOrActivateSides(int dist, String block, boolean set, boolean activate) {
+    private boolean testOrActivateSides(int dist, MultiblockPartType block, boolean set, boolean activate) {
         dist++;
         for (int y = yCoord - 1; y <= yCoord + 1; y++) {
             for (int z = zCoord - 1; z <= zCoord + 1; z++) {
 
-                if (block.equals("air")) {
-                    if (!(xCoord + dist == xCoord && y == yCoord && z == zCoord)
-                            && !isReplacable(xCoord + dist, y, z, set))
+                switch (block) {
+                    case AIR:
+                        if (!(xCoord + dist == xCoord && y == yCoord && z == zCoord)
+                                && !isReplaceable(xCoord + dist, y, z, set))
+                            return false;
+                        break;
+                    case REDSTONE:
+                        if (!(xCoord + dist == xCoord && y == yCoord && z == zCoord)
+                                && !testForOrActivateRedstone(xCoord + dist, y, z, set, activate))
+                            return false;
+                        break;
+                    case DRACONIUM:
+                        if (!(xCoord + dist == xCoord && y == yCoord && z == zCoord)
+                                && !testForOrActivateDraconium(xCoord + dist, y, z, set, activate))
+                            return false;
+                        break;
+                    default:
+                        LogHelper.error("Invalid String In Multiblock Structure Code!!!");
                         return false;
-                } else if (block.equals("redstone")) {
-                    if (!(xCoord + dist == xCoord && y == yCoord && z == zCoord)
-                            && !testForOrActivateRedstone(xCoord + dist, y, z, set, activate))
-                        return false;
-                } else if (block.equals("draconiumBlock")) {
-                    if (!(xCoord + dist == xCoord && y == yCoord && z == zCoord)
-                            && !testForOrActivateDraconium(xCoord + dist, y, z, set, activate))
-                        return false;
-                } else if (!block.equals("draconiumBlock") && !block.equals("redstone") && !block.equals("air")) {
-                    LogHelper.error("Invalid String In Multiblock Structure Code!!!");
-                    return false;
                 }
             }
         }
         for (int y = yCoord - 1; y <= yCoord + 1; y++) {
             for (int z = zCoord - 1; z <= zCoord + 1; z++) {
 
-                if (block.equals("air")) {
-                    if (!(xCoord - dist == xCoord && y == yCoord && z == zCoord)
-                            && !isReplacable(xCoord - dist, y, z, set))
+                switch (block) {
+                    case AIR:
+                        if (!(xCoord - dist == xCoord && y == yCoord && z == zCoord)
+                                && !isReplaceable(xCoord - dist, y, z, set))
+                            return false;
+                        break;
+                    case REDSTONE:
+                        if (!(xCoord - dist == xCoord && y == yCoord && z == zCoord)
+                                && !testForOrActivateRedstone(xCoord - dist, y, z, set, activate))
+                            return false;
+                        break;
+                    case DRACONIUM:
+                        if (!(xCoord - dist == xCoord && y == yCoord && z == zCoord)
+                                && !testForOrActivateDraconium(xCoord - dist, y, z, set, activate))
+                            return false;
+                        break;
+                    default:
+                        LogHelper.error("Invalid String In Multiblock Structure Code!!!");
                         return false;
-                } else if (block.equals("redstone")) {
-                    if (!(xCoord - dist == xCoord && y == yCoord && z == zCoord)
-                            && !testForOrActivateRedstone(xCoord - dist, y, z, set, activate))
-                        return false;
-                } else if (block.equals("draconiumBlock")) {
-                    if (!(xCoord - dist == xCoord && y == yCoord && z == zCoord)
-                            && !testForOrActivateDraconium(xCoord - dist, y, z, set, activate))
-                        return false;
-                } else if (!block.equals("draconiumBlock") && !block.equals("redstone") && !block.equals("air")) {
-                    LogHelper.error("Invalid String In Multiblock Structure Code!!!");
-                    return false;
                 }
             }
         }
@@ -521,42 +570,50 @@ public class TileEnergyStorageCore extends TileObjectSync {
         for (int x = xCoord - 1; x <= xCoord + 1; x++) {
             for (int z = zCoord - 1; z <= zCoord + 1; z++) {
 
-                if (block.equals("air")) {
-                    if (!(x == xCoord && yCoord + dist == yCoord && z == zCoord)
-                            && !isReplacable(x, yCoord + dist, z, set))
+                switch (block) {
+                    case AIR:
+                        if (!(x == xCoord && yCoord + dist == yCoord && z == zCoord)
+                                && !isReplaceable(x, yCoord + dist, z, set))
+                            return false;
+                        break;
+                    case REDSTONE:
+                        if (!(x == xCoord && yCoord + dist == yCoord && z == zCoord)
+                                && !testForOrActivateRedstone(x, yCoord + dist, z, set, activate))
+                            return false;
+                        break;
+                    case DRACONIUM:
+                        if (!(x == xCoord && yCoord + dist == yCoord && z == zCoord)
+                                && !testForOrActivateDraconium(x, yCoord + dist, z, set, activate))
+                            return false;
+                        break;
+                    default:
+                        LogHelper.error("Invalid String In Multiblock Structure Code!!!");
                         return false;
-                } else if (block.equals("redstone")) {
-                    if (!(x == xCoord && yCoord + dist == yCoord && z == zCoord)
-                            && !testForOrActivateRedstone(x, yCoord + dist, z, set, activate))
-                        return false;
-                } else if (block.equals("draconiumBlock")) {
-                    if (!(x == xCoord && yCoord + dist == yCoord && z == zCoord)
-                            && !testForOrActivateDraconium(x, yCoord + dist, z, set, activate))
-                        return false;
-                } else if (!block.equals("draconiumBlock") && !block.equals("redstone") && !block.equals("air")) {
-                    LogHelper.error("Invalid String In Multiblock Structure Code!!!");
-                    return false;
                 }
             }
         }
         for (int x = xCoord - 1; x <= xCoord + 1; x++) {
             for (int z = zCoord - 1; z <= zCoord + 1; z++) {
 
-                if (block.equals("air")) {
-                    if (!(x == xCoord && yCoord - dist == yCoord && z == zCoord)
-                            && !isReplacable(x, yCoord - dist, z, set))
+                switch (block) {
+                    case AIR:
+                        if (!(x == xCoord && yCoord - dist == yCoord && z == zCoord)
+                                && !isReplaceable(x, yCoord - dist, z, set))
+                            return false;
+                        break;
+                    case REDSTONE:
+                        if (!(x == xCoord && yCoord - dist == yCoord && z == zCoord)
+                                && !testForOrActivateRedstone(x, yCoord - dist, z, set, activate))
+                            return false;
+                        break;
+                    case DRACONIUM:
+                        if (!(x == xCoord && yCoord - dist == yCoord && z == zCoord)
+                                && !testForOrActivateDraconium(x, yCoord - dist, z, set, activate))
+                            return false;
+                        break;
+                    default:
+                        LogHelper.error("Invalid String In Multiblock Structure Code!!!");
                         return false;
-                } else if (block.equals("redstone")) {
-                    if (!(x == xCoord && yCoord - dist == yCoord && z == zCoord)
-                            && !testForOrActivateRedstone(x, yCoord - dist, z, set, activate))
-                        return false;
-                } else if (block.equals("draconiumBlock")) {
-                    if (!(x == xCoord && yCoord - dist == yCoord && z == zCoord)
-                            && !testForOrActivateDraconium(x, yCoord - dist, z, set, activate))
-                        return false;
-                } else if (!block.equals("draconiumBlock") && !block.equals("redstone") && !block.equals("air")) {
-                    LogHelper.error("Invalid String In Multiblock Structure Code!!!");
-                    return false;
                 }
             }
         }
@@ -564,42 +621,50 @@ public class TileEnergyStorageCore extends TileObjectSync {
         for (int y = yCoord - 1; y <= yCoord + 1; y++) {
             for (int x = xCoord - 1; x <= xCoord + 1; x++) {
 
-                if (block.equals("air")) {
-                    if (!(x == xCoord && y == yCoord && zCoord + dist == zCoord)
-                            && !isReplacable(x, y, zCoord + dist, set))
+                switch (block) {
+                    case AIR:
+                        if (!(x == xCoord && y == yCoord && zCoord + dist == zCoord)
+                                && !isReplaceable(x, y, zCoord + dist, set))
+                            return false;
+                        break;
+                    case REDSTONE:
+                        if (!(x == xCoord && y == yCoord && zCoord + dist == zCoord)
+                                && !testForOrActivateRedstone(x, y, zCoord + dist, set, activate))
+                            return false;
+                        break;
+                    case DRACONIUM:
+                        if (!(x == xCoord && y == yCoord && zCoord + dist == zCoord)
+                                && !testForOrActivateDraconium(x, y, zCoord + dist, set, activate))
+                            return false;
+                        break;
+                    default:
+                        LogHelper.error("Invalid String In Multiblock Structure Code!!!");
                         return false;
-                } else if (block.equals("redstone")) {
-                    if (!(x == xCoord && y == yCoord && zCoord + dist == zCoord)
-                            && !testForOrActivateRedstone(x, y, zCoord + dist, set, activate))
-                        return false;
-                } else if (block.equals("draconiumBlock")) {
-                    if (!(x == xCoord && y == yCoord && zCoord + dist == zCoord)
-                            && !testForOrActivateDraconium(x, y, zCoord + dist, set, activate))
-                        return false;
-                } else if (!block.equals("draconiumBlock") && !block.equals("redstone") && !block.equals("air")) {
-                    LogHelper.error("Invalid String In Multiblock Structure Code!!!");
-                    return false;
                 }
             }
         }
         for (int y = yCoord - 1; y <= yCoord + 1; y++) {
             for (int x = xCoord - 1; x <= xCoord + 1; x++) {
 
-                if (block.equals("air")) {
-                    if (!(x == xCoord && y == yCoord && zCoord - dist == zCoord)
-                            && !isReplacable(x, y, zCoord - dist, set))
+                switch (block) {
+                    case AIR:
+                        if (!(x == xCoord && y == yCoord && zCoord - dist == zCoord)
+                                && !isReplaceable(x, y, zCoord - dist, set))
+                            return false;
+                        break;
+                    case REDSTONE:
+                        if (!(x == xCoord && y == yCoord && zCoord - dist == zCoord)
+                                && !testForOrActivateRedstone(x, y, zCoord - dist, set, activate))
+                            return false;
+                        break;
+                    case DRACONIUM:
+                        if (!(x == xCoord && y == yCoord && zCoord - dist == zCoord)
+                                && !testForOrActivateDraconium(x, y, zCoord - dist, set, activate))
+                            return false;
+                        break;
+                    default:
+                        LogHelper.error("Invalid String In Multiblock Structure Code!!!");
                         return false;
-                } else if (block.equals("redstone")) {
-                    if (!(x == xCoord && y == yCoord && zCoord - dist == zCoord)
-                            && !testForOrActivateRedstone(x, y, zCoord - dist, set, activate))
-                        return false;
-                } else if (block.equals("draconiumBlock")) {
-                    if (!(x == xCoord && y == yCoord && zCoord - dist == zCoord)
-                            && !testForOrActivateDraconium(x, y, zCoord - dist, set, activate))
-                        return false;
-                } else if (!block.equals("draconiumBlock") && !block.equals("redstone") && !block.equals("air")) {
-                    LogHelper.error("Invalid String In Multiblock Structure Code!!!");
-                    return false;
                 }
             }
         }
@@ -618,14 +683,33 @@ public class TileEnergyStorageCore extends TileObjectSync {
                         BalanceConfigHandler.energyStorageStructureOuterBlockMetadata,
                         3);
                 return true;
-            } else return (worldObj.getBlock(x, y, z) == BalanceConfigHandler.energyStorageStructureOuterBlock
-                    && worldObj.getBlockMetadata(x, y, z)
-                            == BalanceConfigHandler.energyStorageStructureOuterBlockMetadata)
-                    || (worldObj.getBlock(x, y, z) == ModBlocks.invisibleMultiblock
-                            && worldObj.getBlockMetadata(x, y, z) == 0);
+            } else {
+                return isDraconiumBlock(x, y, z);
+            }
         } else {
             return activateDraconium(x, y, z);
         }
+    }
+
+    private boolean isDraconiumBlock(int x, int y, int z) {
+        Block block = worldObj.getBlock(x, y, z);
+        int metadata = worldObj.getBlockMetadata(x, y, z);
+        return (block == BalanceConfigHandler.energyStorageStructureOuterBlock
+                && metadata == BalanceConfigHandler.energyStorageStructureOuterBlockMetadata)
+                || (block == ModBlocks.invisibleMultiblock && metadata == 0);
+    }
+
+    private boolean activateDraconium(int x, int y, int z) {
+        if (isDraconiumBlock(x, y, z)) {
+            worldObj.setBlock(x, y, z, ModBlocks.invisibleMultiblock, 0, 2);
+            TileEntity tile = worldObj.getTileEntity(x, y, z);
+            if (tile instanceof TileInvisibleMultiblock) {
+                ((TileInvisibleMultiblock) tile).master = new TileLocation(xCoord, yCoord, zCoord);
+                return true;
+            }
+        }
+        LogHelper.error("Failed to activate structure (activateDraconium)");
+        return false;
     }
 
     private boolean testForOrActivateRedstone(int x, int y, int z, boolean set, boolean activate) {
@@ -640,50 +724,35 @@ public class TileEnergyStorageCore extends TileObjectSync {
                         3);
                 return true;
             } else {
-                return (worldObj.getBlock(x, y, z) == BalanceConfigHandler.energyStorageStructureBlock
-                        && worldObj.getBlockMetadata(x, y, z)
-                                == BalanceConfigHandler.energyStorageStructureBlockMetadata)
-                        || (worldObj.getBlock(x, y, z) == ModBlocks.invisibleMultiblock
-                                && worldObj.getBlockMetadata(x, y, z) == 1);
+                return isRedstoneBlock(x, y, z);
             }
         } else {
             return activateRedstone(x, y, z);
         }
     }
 
-    private boolean activateDraconium(int x, int y, int z) {
-        if (testForOrActivateDraconium(x, y, z, false, false)) {
-            worldObj.setBlock(x, y, z, ModBlocks.invisibleMultiblock, 0, 2);
-            TileInvisibleMultiblock tile = (worldObj.getTileEntity(x, y, z) != null
-                    && worldObj.getTileEntity(x, y, z) instanceof TileInvisibleMultiblock)
-                            ? (TileInvisibleMultiblock) worldObj.getTileEntity(x, y, z)
-                            : null;
-            if (tile != null) {
-                tile.master = new TileLocation(xCoord, yCoord, zCoord);
-            }
-            return true;
-        }
-        LogHelper.error("Failed to activate structure (activateDraconium)");
-        return false;
+    private boolean isRedstoneBlock(int x, int y, int z) {
+        Block block = worldObj.getBlock(x, y, z);
+        int metadata = worldObj.getBlockMetadata(x, y, z);
+        return (block == BalanceConfigHandler.energyStorageStructureBlock
+                && metadata == BalanceConfigHandler.energyStorageStructureBlockMetadata)
+                || (block == ModBlocks.invisibleMultiblock && metadata == 1);
     }
 
     private boolean activateRedstone(int x, int y, int z) {
-        if (testForOrActivateRedstone(x, y, z, false, false)) {
+        if (isRedstoneBlock(x, y, z)) {
             worldObj.setBlock(x, y, z, ModBlocks.invisibleMultiblock, 1, 2);
-            TileInvisibleMultiblock tile = (worldObj.getTileEntity(x, y, z) != null
-                    && worldObj.getTileEntity(x, y, z) instanceof TileInvisibleMultiblock)
-                            ? (TileInvisibleMultiblock) worldObj.getTileEntity(x, y, z)
-                            : null;
-            if (tile != null) {
-                tile.master = new TileLocation(xCoord, yCoord, zCoord);
+            TileEntity tile = worldObj.getTileEntity(x, y, z);
+            if (tile instanceof TileInvisibleMultiblock) {
+                ((TileInvisibleMultiblock) tile).master = new TileLocation(xCoord, yCoord, zCoord);
+                return true;
             }
-            return true;
         }
         LogHelper.error("Failed to activate structure (activateRedstone)");
         return false;
     }
 
-    private boolean isReplacable(int x, int y, int z, boolean set) {
+    private boolean isReplaceable(int x, int y, int z, boolean set) {
         if (set) {
             worldObj.setBlock(x, y, z, Blocks.air);
             return true;
@@ -695,33 +764,23 @@ public class TileEnergyStorageCore extends TileObjectSync {
     }
 
     private void activateStabilizers() {
-        for (int i = 0; i < stabilizers.length; i++) {
-            if (stabilizers[i] == null) {
-                LogHelper.error("activateStabilizers stabalizers[" + i + "] == null!!!");
+        for (TileLocation stabilizer : stabilizers) {
+            if (stabilizer == null) {
+                LogHelper.error("activateStabilizers: detected null stabilizer!");
                 return;
             }
-            TileParticleGenerator tile = (worldObj
-                    .getTileEntity(stabilizers[i].getXCoord(), stabilizers[i].getYCoord(), stabilizers[i].getZCoord())
-                    != null
-                    && worldObj.getTileEntity(
-                            stabilizers[i].getXCoord(),
-                            stabilizers[i].getYCoord(),
-                            stabilizers[i].getZCoord()) instanceof TileParticleGenerator)
-                                    ? (TileParticleGenerator) worldObj.getTileEntity(
-                                            stabilizers[i].getXCoord(),
-                                            stabilizers[i].getYCoord(),
-                                            stabilizers[i].getZCoord())
-                                    : null;
-            if (tile == null) {
+            TileEntity tile = stabilizer.getTileEntity(worldObj);
+            if (!(tile instanceof TileParticleGenerator)) {
                 LogHelper.error("Missing Tile Entity (Particle Generator)");
                 return;
             }
-            tile.stabalizerMode = true;
-            tile.setMaster(new TileLocation(xCoord, yCoord, zCoord));
+            TileParticleGenerator generator = (TileParticleGenerator) tile;
+            generator.stabalizerMode = true;
+            generator.setMaster(new TileLocation(xCoord, yCoord, zCoord));
             worldObj.setBlockMetadataWithNotify(
-                    stabilizers[i].getXCoord(),
-                    stabilizers[i].getYCoord(),
-                    stabilizers[i].getZCoord(),
+                    stabilizer.getXCoord(),
+                    stabilizer.getYCoord(),
+                    stabilizer.getZCoord(),
                     1,
                     2);
         }
@@ -758,88 +817,61 @@ public class TileEnergyStorageCore extends TileObjectSync {
     }
 
     public void deactivateStabilizers() {
-        for (int i = 0; i < stabilizers.length; i++) {
-            if (stabilizers[i] == null) {
-                LogHelper.error("activateStabilizers stabalizers[" + i + "] == null!!!");
-            } else {
-                TileParticleGenerator tile = (worldObj.getTileEntity(
-                        stabilizers[i].getXCoord(),
-                        stabilizers[i].getYCoord(),
-                        stabilizers[i].getZCoord()) != null
-                        && worldObj.getTileEntity(
-                                stabilizers[i].getXCoord(),
-                                stabilizers[i].getYCoord(),
-                                stabilizers[i].getZCoord()) instanceof TileParticleGenerator)
-                                        ? (TileParticleGenerator) worldObj.getTileEntity(
-                                                stabilizers[i].getXCoord(),
-                                                stabilizers[i].getYCoord(),
-                                                stabilizers[i].getZCoord())
-                                        : null;
-                if (tile == null) {
-                    // LogHelper.error("Missing Tile Entity (Particle Generator)");
-                } else {
-                    tile.stabalizerMode = false;
+        for (TileLocation stabilizer : stabilizers) {
+            if (stabilizer != null) {
+                TileEntity tile = stabilizer.getTileEntity(worldObj);
+                if (tile instanceof TileParticleGenerator) {
+                    TileParticleGenerator generator = (TileParticleGenerator) tile;
+                    generator.stabalizerMode = false;
                     worldObj.setBlockMetadataWithNotify(
-                            stabilizers[i].getXCoord(),
-                            stabilizers[i].getYCoord(),
-                            stabilizers[i].getZCoord(),
+                            stabilizer.getXCoord(),
+                            stabilizer.getYCoord(),
+                            stabilizer.getZCoord(),
                             0,
                             2);
                 }
+            } else {
+                LogHelper.error("deactivateStabilizers: detected null stabilizer!");
             }
         }
     }
 
     private boolean areStabilizersActive() {
-        for (int i = 0; i < stabilizers.length; i++) {
-            if (stabilizers[i] == null) {
-                LogHelper.error("activateStabilizers stabalizers[" + i + "] == null!!!");
+        for (TileLocation stabilizer : stabilizers) {
+            if (stabilizer == null) {
+                LogHelper.error("areStabilizersActive: detected null stabilizer!");
                 return false;
             }
-            TileParticleGenerator tile = (worldObj
-                    .getTileEntity(stabilizers[i].getXCoord(), stabilizers[i].getYCoord(), stabilizers[i].getZCoord())
-                    != null
-                    && worldObj.getTileEntity(
-                            stabilizers[i].getXCoord(),
-                            stabilizers[i].getYCoord(),
-                            stabilizers[i].getZCoord()) instanceof TileParticleGenerator)
-                                    ? (TileParticleGenerator) worldObj.getTileEntity(
-                                            stabilizers[i].getXCoord(),
-                                            stabilizers[i].getYCoord(),
-                                            stabilizers[i].getZCoord())
-                                    : null;
-            if (tile == null) {
-                // LogHelper.error("Missing Tile Entity (Particle Generator)");
+            TileEntity tile = stabilizer.getTileEntity(worldObj);
+            if (!(tile instanceof TileParticleGenerator)) {
                 return false;
             }
-            if (!tile.stabalizerMode || worldObj.getBlockMetadata(
-                    stabilizers[i].getXCoord(),
-                    stabilizers[i].getYCoord(),
-                    stabilizers[i].getZCoord()) != 1)
+            TileParticleGenerator generator = (TileParticleGenerator) tile;
+            if (!generator.stabalizerMode
+                    || worldObj.getBlockMetadata(stabilizer.getXCoord(), stabilizer.getYCoord(), stabilizer.getZCoord())
+                            != 1)
                 return false;
         }
         return true;
     }
 
     private boolean checkStabilizers() {
-        for (int i = 0; i < stabilizers.length; i++) {
-            if (stabilizers[i] == null) return false;
-            TileParticleGenerator gen = (worldObj
-                    .getTileEntity(stabilizers[i].getXCoord(), stabilizers[i].getYCoord(), stabilizers[i].getZCoord())
-                    != null
-                    && worldObj.getTileEntity(
-                            stabilizers[i].getXCoord(),
-                            stabilizers[i].getYCoord(),
-                            stabilizers[i].getZCoord()) instanceof TileParticleGenerator)
-                                    ? (TileParticleGenerator) worldObj.getTileEntity(
-                                            stabilizers[i].getXCoord(),
-                                            stabilizers[i].getYCoord(),
-                                            stabilizers[i].getZCoord())
-                                    : null;
-            if (gen == null || !gen.stabalizerMode) return false;
-            if (gen.getMaster().xCoord != xCoord || gen.getMaster().yCoord != yCoord
-                    || gen.getMaster().zCoord != zCoord)
+        for (TileLocation stabilizer : stabilizers) {
+            if (stabilizer == null) {
                 return false;
+            }
+            TileEntity tile = stabilizer.getTileEntity(worldObj);
+            if (!(tile instanceof TileParticleGenerator)) {
+                return false;
+            }
+            TileParticleGenerator generator = (TileParticleGenerator) tile;
+            if (!generator.stabalizerMode) {
+                return false;
+            }
+            TileEnergyStorageCore core = generator.getMaster();
+            if (core.xCoord != xCoord || core.yCoord != yCoord || core.zCoord != zCoord) {
+                return false;
+            }
         }
         return true;
     }
@@ -865,7 +897,7 @@ public class TileEnergyStorageCore extends TileObjectSync {
     @Override
     public void readFromNBT(NBTTagCompound compound) {
         online = compound.getBoolean("Online");
-        tier = (int) compound.getShort("Tier");
+        tier = compound.getShort("Tier");
         energy = compound.getLong("EnergyL");
         if (compound.hasKey("Energy")) energy = (long) compound.getDouble("Energy");
         for (int i = 0; i < stabilizers.length; i++) {
@@ -913,6 +945,24 @@ public class TileEnergyStorageCore extends TileObjectSync {
 
     public long getMaxEnergyStored() {
         return capacity;
+    }
+
+    public List<String> getDisplayInformation(boolean shouldShowName) {
+        List<String> information = new ArrayList<>();
+        if (shouldShowName) {
+            information.add(InfoHelper.HITC() + ModBlocks.energyStorageCore.getLocalizedName());
+        }
+        information.add(StatCollector.translateToLocal("info.de.tier.txt") + ": " + InfoHelper.ITC() + (tier + 1));
+        information.add(
+                StatCollector.translateToLocal("info.de.charge.txt") + ": "
+                        + InfoHelper.ITC()
+                        + Utills.formatNumber(energy)
+                        + " / "
+                        + Utills.formatNumber(capacity)
+                        + " ["
+                        + Utills.addCommas(energy)
+                        + " RF]");
+        return information;
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyStorageCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyStorageCore.java
@@ -145,60 +145,26 @@ public class TileEnergyStorageCore extends TileObjectSync {
 
     private boolean setTier() {
         final int range = 5;
-        int xPos = 0;
-        int xNeg = 0;
-        int yPos = 0;
-        int yNeg = 0;
-        int zPos = 0;
-        int zNeg = 0;
 
-        for (int x = 0; x <= range; x++) {
-            if (isOuterBlock(xCoord + x, yCoord, zCoord)) {
-                xPos = x;
-                break;
+        int[] outerBlocksDistances = new int[6];
+        for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
+            for (int distance = 1; distance <= range; distance++) {
+                int x = xCoord + direction.offsetX * distance;
+                int y = yCoord + direction.offsetY * distance;
+                int z = zCoord + direction.offsetZ * distance;
+                if (isOuterBlock(x, y, z)) {
+                    outerBlocksDistances[direction.ordinal()] = distance;
+                    break;
+                }
+            }
+        }
+        for (int i = 1; i < outerBlocksDistances.length; i++) {
+            if (outerBlocksDistances[i] != outerBlocksDistances[0]) {
+                return false;
             }
         }
 
-        for (int x = 0; x <= range; x++) {
-            if (isOuterBlock(xCoord - x, yCoord, zCoord)) {
-                xNeg = x;
-                break;
-            }
-        }
-
-        for (int y = 0; y <= range; y++) {
-            if (isOuterBlock(xCoord, yCoord + y, zCoord)) {
-                yPos = y;
-                break;
-            }
-        }
-
-        for (int y = 0; y <= range; y++) {
-            if (isOuterBlock(xCoord, yCoord - y, zCoord)) {
-                yNeg = y;
-                break;
-            }
-        }
-
-        for (int z = 0; z <= range; z++) {
-            if (isOuterBlock(xCoord, yCoord, zCoord + z)) {
-                zPos = z;
-                break;
-            }
-        }
-
-        for (int z = 0; z <= range; z++) {
-            if (isOuterBlock(xCoord, yCoord, zCoord - z)) {
-                zNeg = z;
-                break;
-            }
-        }
-
-        if (xPos != xNeg || yPos != yNeg || zPos != zNeg || xPos != yPos || xPos != zPos) {
-            return false;
-        }
-
-        tier = xPos;
+        tier = outerBlocksDistances[0];
         if (tier > 1) {
             tier++;
         }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyStorageCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyStorageCore.java
@@ -169,32 +169,24 @@ public class TileEnergyStorageCore extends TileObjectSync {
 
     private boolean scanStructure(IBlockAction innerBlock, IBlockAction outerBlock) {
         final IBlockAction isReplaceable = this::isReplaceable;
-        switch (tier) {
-            case 0:
-                return scanCube(isReplaceable, 1);
-            case 1:
-                return scanRings(isReplaceable, 1, 1) && scanSides(outerBlock, 0, 1);
-            case 2:
-                return scanCube(outerBlock, 1);
-            case 3:
-                return scanCube(innerBlock, 1) && scanSides(outerBlock, 1, 2);
-            case 4:
-                return scanCube(innerBlock, 1) && scanSides(innerBlock, 1, 2)
-                        && scanSides(outerBlock, 1, 3)
-                        && scanRings(outerBlock, 2, 2);
-            case 5:
-                return scanCube(innerBlock, 2) && scanSides(innerBlock, 1, 3)
-                        && scanSides(outerBlock, 1, 4)
-                        && scanRings(outerBlock, 2, 3);
-            case 6:
-                return scanCube(innerBlock, 2) && scanSides(innerBlock, 2, 3)
-                        && scanSides(innerBlock, 1, 4)
-                        && scanSides(outerBlock, 1, 5)
-                        && scanRings(outerBlock, 2, 4)
-                        && scanRings(outerBlock, 3, 3);
-            default:
-                return false;
-        }
+        return switch (tier) {
+            case 0 -> scanCube(isReplaceable, 1);
+            case 1 -> scanRings(isReplaceable, 1, 1) && scanSides(outerBlock, 0, 1);
+            case 2 -> scanCube(outerBlock, 1);
+            case 3 -> scanCube(innerBlock, 1) && scanSides(outerBlock, 1, 2);
+            case 4 -> scanCube(innerBlock, 1) && scanSides(innerBlock, 1, 2)
+                    && scanSides(outerBlock, 1, 3)
+                    && scanRings(outerBlock, 2, 2);
+            case 5 -> scanCube(innerBlock, 2) && scanSides(innerBlock, 1, 3)
+                    && scanSides(outerBlock, 1, 4)
+                    && scanRings(outerBlock, 2, 3);
+            case 6 -> scanCube(innerBlock, 2) && scanSides(innerBlock, 2, 3)
+                    && scanSides(innerBlock, 1, 4)
+                    && scanSides(outerBlock, 1, 5)
+                    && scanRings(outerBlock, 2, 4)
+                    && scanRings(outerBlock, 3, 3);
+            default -> false;
+        };
     }
 
     private boolean scanCube(IBlockAction action, int size) {
@@ -309,8 +301,8 @@ public class TileEnergyStorageCore extends TileObjectSync {
     private boolean activateInnerBlock(int x, int y, int z) {
         worldObj.setBlock(x, y, z, ModBlocks.invisibleMultiblock, 1, 2);
         TileEntity tile = worldObj.getTileEntity(x, y, z);
-        if (tile instanceof TileInvisibleMultiblock) {
-            ((TileInvisibleMultiblock) tile).master = new TileLocation(xCoord, yCoord, zCoord);
+        if (tile instanceof TileInvisibleMultiblock multiblock) {
+            multiblock.master = new TileLocation(xCoord, yCoord, zCoord);
             return true;
         }
         LogHelper.error("Failed to activate structure (activateRedstone)");
@@ -339,8 +331,8 @@ public class TileEnergyStorageCore extends TileObjectSync {
     private boolean activateOuterBlock(int x, int y, int z) {
         worldObj.setBlock(x, y, z, ModBlocks.invisibleMultiblock, 0, 2);
         TileEntity tile = worldObj.getTileEntity(x, y, z);
-        if (tile instanceof TileInvisibleMultiblock) {
-            ((TileInvisibleMultiblock) tile).master = new TileLocation(xCoord, yCoord, zCoord);
+        if (tile instanceof TileInvisibleMultiblock multiblock) {
+            multiblock.master = new TileLocation(xCoord, yCoord, zCoord);
             return true;
         }
         LogHelper.error("Failed to activate structure (activateDraconium)");
@@ -365,13 +357,12 @@ public class TileEnergyStorageCore extends TileObjectSync {
     private void activateStabilizers() {
         for (TileLocation stabilizer : stabilizers) {
             TileEntity tile = stabilizer.getTileEntity(worldObj);
-            if (!(tile instanceof TileParticleGenerator)) {
+            if (!(tile instanceof TileParticleGenerator particleGenerator)) {
                 LogHelper.error("Missing Tile Entity (Particle Generator)");
                 return;
             }
-            TileParticleGenerator generator = (TileParticleGenerator) tile;
-            generator.isInStabilizerMode = true;
-            generator.setMaster(new TileLocation(xCoord, yCoord, zCoord));
+            particleGenerator.isInStabilizerMode = true;
+            particleGenerator.setMaster(new TileLocation(xCoord, yCoord, zCoord));
             worldObj.setBlockMetadataWithNotify(
                     stabilizer.getXCoord(),
                     stabilizer.getYCoord(),
@@ -383,30 +374,16 @@ public class TileEnergyStorageCore extends TileObjectSync {
     }
 
     private void initializeCapacity() {
-        long capacity = 0;
-        switch (tier) {
-            case 0:
-                capacity = BalanceConfigHandler.energyStorageTier1Storage;
-                break;
-            case 1:
-                capacity = BalanceConfigHandler.energyStorageTier2Storage;
-                break;
-            case 2:
-                capacity = BalanceConfigHandler.energyStorageTier3Storage;
-                break;
-            case 3:
-                capacity = BalanceConfigHandler.energyStorageTier4Storage;
-                break;
-            case 4:
-                capacity = BalanceConfigHandler.energyStorageTier5Storage;
-                break;
-            case 5:
-                capacity = BalanceConfigHandler.energyStorageTier6Storage;
-                break;
-            case 6:
-                capacity = BalanceConfigHandler.energyStorageTier7Storage;
-                break;
-        }
+        long capacity = switch (tier) {
+            case 0 -> BalanceConfigHandler.energyStorageTier1Storage;
+            case 1 -> BalanceConfigHandler.energyStorageTier2Storage;
+            case 2 -> BalanceConfigHandler.energyStorageTier3Storage;
+            case 3 -> BalanceConfigHandler.energyStorageTier4Storage;
+            case 4 -> BalanceConfigHandler.energyStorageTier5Storage;
+            case 5 -> BalanceConfigHandler.energyStorageTier6Storage;
+            case 6 -> BalanceConfigHandler.energyStorageTier7Storage;
+            default -> 0;
+        };
         this.capacity = capacity;
         if (energy > capacity) energy = capacity;
     }
@@ -414,9 +391,8 @@ public class TileEnergyStorageCore extends TileObjectSync {
     public void deactivateStabilizers() {
         for (TileLocation stabilizer : stabilizers) {
             TileEntity tile = stabilizer.getTileEntity(worldObj);
-            if (tile instanceof TileParticleGenerator) {
-                TileParticleGenerator generator = (TileParticleGenerator) tile;
-                generator.isInStabilizerMode = false;
+            if (tile instanceof TileParticleGenerator particleGenerator) {
+                particleGenerator.isInStabilizerMode = false;
                 worldObj.setBlockMetadataWithNotify(
                         stabilizer.getXCoord(),
                         stabilizer.getYCoord(),
@@ -430,14 +406,13 @@ public class TileEnergyStorageCore extends TileObjectSync {
     private boolean areStabilizersActive() {
         for (TileLocation stabilizer : stabilizers) {
             TileEntity tile = stabilizer.getTileEntity(worldObj);
-            if (!(tile instanceof TileParticleGenerator)) {
+            if (!(tile instanceof TileParticleGenerator particleGenerator)) {
                 return false;
             }
-            TileParticleGenerator generator = (TileParticleGenerator) tile;
-            if (!generator.isInStabilizerMode || stabilizer.getBlockMetadata(worldObj) != 1) {
+            if (!particleGenerator.isInStabilizerMode || stabilizer.getBlockMetadata(worldObj) != 1) {
                 return false;
             }
-            TileEnergyStorageCore core = generator.getMaster();
+            TileEnergyStorageCore core = particleGenerator.getMaster();
             if (core == null || core.xCoord != xCoord || core.yCoord != yCoord || core.zCoord != zCoord) {
                 return false;
             }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileInvisibleMultiblock.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileInvisibleMultiblock.java
@@ -24,12 +24,12 @@ public class TileInvisibleMultiblock extends TileEntity {
 
     public boolean isMasterOnline() {
         TileEntity tile = master.getTileEntity(worldObj);
-        return tile instanceof TileEnergyStorageCore && ((TileEnergyStorageCore) tile).isOnline();
+        return tile instanceof TileEnergyStorageCore core && core.isOnline();
     }
 
     public TileEnergyStorageCore getMaster() {
         TileEntity tile = master.getTileEntity(worldObj);
-        return tile instanceof TileEnergyStorageCore ? (TileEnergyStorageCore) tile : null;
+        return tile instanceof TileEnergyStorageCore core ? core : null;
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileInvisibleMultiblock.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileInvisibleMultiblock.java
@@ -6,8 +6,8 @@ import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
 
+import com.brandon3055.draconicevolution.common.blocks.multiblock.InvisibleMultiblock;
 import com.brandon3055.draconicevolution.common.blocks.multiblock.MultiblockHelper.TileLocation;
-import com.brandon3055.draconicevolution.common.handler.BalanceConfigHandler;
 import com.brandon3055.draconicevolution.common.utills.LogHelper;
 
 /**
@@ -23,46 +23,24 @@ public class TileInvisibleMultiblock extends TileEntity {
     }
 
     public boolean isMasterOnline() {
-        TileEnergyStorageCore tile = (worldObj.getTileEntity(master.getXCoord(), master.getYCoord(), master.getZCoord())
-                != null
-                && worldObj.getTileEntity(
-                        master.getXCoord(),
-                        master.getYCoord(),
-                        master.getZCoord()) instanceof TileEnergyStorageCore)
-                                ? (TileEnergyStorageCore) worldObj
-                                        .getTileEntity(master.getXCoord(), master.getYCoord(), master.getZCoord())
-                                : null;
-        if (tile == null) {
-            return false;
-        }
-        return tile.online;
+        TileEntity tile = master.getTileEntity(worldObj);
+        return tile instanceof TileEnergyStorageCore && ((TileEnergyStorageCore) tile).isOnline();
     }
 
     public TileEnergyStorageCore getMaster() {
-        if (master == null) return null;
-        TileEnergyStorageCore tile = (worldObj.getTileEntity(master.getXCoord(), master.getYCoord(), master.getZCoord())
-                != null
-                && worldObj.getTileEntity(
-                        master.getXCoord(),
-                        master.getYCoord(),
-                        master.getZCoord()) instanceof TileEnergyStorageCore)
-                                ? (TileEnergyStorageCore) worldObj
-                                        .getTileEntity(master.getXCoord(), master.getYCoord(), master.getZCoord())
-                                : null;
-        return tile;
+        TileEntity tile = master.getTileEntity(worldObj);
+        return tile instanceof TileEnergyStorageCore ? (TileEnergyStorageCore) tile : null;
     }
 
     @Override
     public void writeToNBT(NBTTagCompound compound) {
         super.writeToNBT(compound);
-        // if (master != null)
         master.writeToNBT(compound, "Key");
     }
 
     @Override
     public void readFromNBT(NBTTagCompound compound) {
         super.readFromNBT(compound);
-        // if (master != null)
         master.readFromNBT(compound, "Key");
     }
 
@@ -79,32 +57,14 @@ public class TileInvisibleMultiblock extends TileEntity {
     }
 
     public void isStructureStillValid() {
-        if (getMaster() == null) {
+        TileEnergyStorageCore core = getMaster();
+        if (core == null) {
             LogHelper.error("{Tile} Master = null reverting!");
-            revert();
+            InvisibleMultiblock.revertStructure(worldObj, xCoord, yCoord, zCoord);
             return;
         }
-        if (!getMaster().isOnline()) revert();
-    }
-
-    private void revert() {
-        int meta = worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
-        if (meta == 0) {
-            worldObj.setBlock(
-                    xCoord,
-                    yCoord,
-                    zCoord,
-                    BalanceConfigHandler.energyStorageStructureOuterBlock,
-                    BalanceConfigHandler.energyStorageStructureOuterBlockMetadata,
-                    3);
-        } else if (meta == 1) {
-            worldObj.setBlock(
-                    xCoord,
-                    yCoord,
-                    zCoord,
-                    BalanceConfigHandler.energyStorageStructureBlock,
-                    BalanceConfigHandler.energyStorageStructureBlockMetadata,
-                    3);
+        if (!core.isOnline()) {
+            InvisibleMultiblock.revertStructure(worldObj, xCoord, yCoord, zCoord);
         }
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TilePortalBlock.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TilePortalBlock.java
@@ -29,7 +29,9 @@ public class TilePortalBlock extends TileEntity {
     @Override
     @SideOnly(Side.CLIENT)
     public void updateEntity() {
-        if (!worldObj.isRemote) return;
+        if (!worldObj.isRemote) {
+            return;
+        }
         double distanceMod = Utills.getDistanceAtoB(
                 xCoord + 0.5,
                 yCoord + 0.5,
@@ -38,92 +40,76 @@ public class TilePortalBlock extends TileEntity {
                 RenderManager.renderPosY,
                 RenderManager.renderPosZ);
         if (worldObj.rand.nextInt(Math.max((int) (distanceMod * (distanceMod / 5D)), 1)) == 0) {
-            if (blockMetadata == -1) blockMetadata = worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
+            getBlockMetadata();
 
-            double rD1 = worldObj.rand.nextDouble();
-            double rD2 = worldObj.rand.nextDouble();
-            double rO1 = -0.1 + worldObj.rand.nextDouble() * 0.2;
-            double rO2 = -0.1 + worldObj.rand.nextDouble() * 0.2;
+            double offset1 = worldObj.rand.nextDouble();
+            double offset2 = worldObj.rand.nextDouble();
+            double smallOffset1 = -0.1 + worldObj.rand.nextDouble() * 0.2;
+            double smallOffset2 = -0.1 + worldObj.rand.nextDouble() * 0.2;
 
-            if (blockMetadata == 1 && RenderManager.renderPosZ < zCoord + 0.5) DraconicEvolution.proxy.spawnParticle(
-                    new Particles.PortalParticle(
-                            worldObj,
-                            xCoord + rD1,
-                            yCoord + rD2,
-                            zCoord,
-                            xCoord + rD1 + rO1,
-                            yCoord + rD2 + rO2,
-                            zCoord + 0.75),
+            double sourceX = xCoord;
+            double sourceY = yCoord;
+            double sourceZ = zCoord;
+            double targetX = xCoord;
+            double targetY = yCoord;
+            double targetZ = zCoord;
+
+            switch (blockMetadata) {
+                case 1:
+                    sourceX += offset1;
+                    sourceY += offset2;
+                    targetX += offset1 + smallOffset1;
+                    targetY += offset2 + smallOffset2;
+                    if (RenderManager.renderPosZ < zCoord + 0.5) {
+                        targetZ += 0.75;
+                    } else {
+                        sourceZ += 1;
+                        targetZ += 0.25;
+                    }
+                    break;
+                case 2:
+                    sourceY += offset1;
+                    sourceZ += offset2;
+                    targetY += offset1 + smallOffset1;
+                    targetZ += offset2 + smallOffset2;
+                    if (RenderManager.renderPosX < xCoord + 0.5) {
+                        targetX += 0.75;
+                    } else {
+                        sourceX += 1;
+                        targetX += 0.25;
+                    }
+                    break;
+                case 3:
+                    sourceX += offset1;
+                    sourceZ += offset2;
+                    targetX += offset1 + smallOffset1;
+                    targetZ += offset2 + smallOffset2;
+                    if (RenderManager.renderPosY < yCoord + 0.5) {
+                        targetY += 0.75;
+                    } else {
+                        sourceY += 1;
+                        targetY += 0.25;
+                    }
+                    break;
+            }
+            DraconicEvolution.proxy.spawnParticle(
+                    new Particles.PortalParticle(worldObj, sourceX, sourceY, sourceZ, targetX, targetY, targetZ),
                     256);
-            else if (blockMetadata == 1 && RenderManager.renderPosZ > zCoord + 0.5)
-                DraconicEvolution.proxy.spawnParticle(
-                        new Particles.PortalParticle(
-                                worldObj,
-                                xCoord + rD1,
-                                yCoord + rD2,
-                                zCoord + 1,
-                                xCoord + rD1 + rO1,
-                                yCoord + rD2 + rO2,
-                                zCoord + 0.25),
-                        256);
-            else if (blockMetadata == 2 && RenderManager.renderPosX < xCoord + 0.5)
-                DraconicEvolution.proxy.spawnParticle(
-                        new Particles.PortalParticle(
-                                worldObj,
-                                xCoord,
-                                yCoord + rD1,
-                                zCoord + rD2,
-                                xCoord + 0.75,
-                                yCoord + rD1 + rO1,
-                                zCoord + rD2 + rO2),
-                        256);
-            else if (blockMetadata == 2 && RenderManager.renderPosX > xCoord + 0.5)
-                DraconicEvolution.proxy.spawnParticle(
-                        new Particles.PortalParticle(
-                                worldObj,
-                                xCoord + 1,
-                                yCoord + rD1,
-                                zCoord + rD2,
-                                xCoord + 0.25,
-                                yCoord + rD1 + rO1,
-                                zCoord + rD2 + rO2),
-                        256);
-            else if (blockMetadata == 3 && RenderManager.renderPosY > yCoord + 0.5)
-                DraconicEvolution.proxy.spawnParticle(
-                        new Particles.PortalParticle(
-                                worldObj,
-                                xCoord + rD1,
-                                yCoord + 1,
-                                zCoord + rD2,
-                                xCoord + rD1 + rO1,
-                                yCoord + 0.25,
-                                zCoord + rD2 + rO2),
-                        256);
-            else if (blockMetadata == 3 && RenderManager.renderPosY < yCoord + 0.5)
-                DraconicEvolution.proxy.spawnParticle(
-                        new Particles.PortalParticle(
-                                worldObj,
-                                xCoord + rD1,
-                                yCoord,
-                                zCoord + rD2,
-                                xCoord + rD1 + rO1,
-                                yCoord + 0.75,
-                                zCoord + rD2 + rO2),
-                        256);
         }
     }
 
     public TileDislocatorReceptacle getMaster() {
-        return worldObj.getTileEntity(masterX, masterY, masterZ) instanceof TileDislocatorReceptacle
-                ? (TileDislocatorReceptacle) worldObj.getTileEntity(masterX, masterY, masterZ)
-                : null;
+        TileEntity tile = worldObj.getTileEntity(masterX, masterY, masterZ);
+        return tile instanceof TileDislocatorReceptacle ? (TileDislocatorReceptacle) tile : null;
     }
 
     public boolean isPortalStillValid() {
-        TileDislocatorReceptacle master = getMaster();
-        if (master == null || !master.isActive) return false;
-        master.validateActivePortal();
-        return master.isActive;
+        TileDislocatorReceptacle receptacle = getMaster();
+        if (receptacle == null || !receptacle.isActive) {
+            return false;
+        }
+        receptacle.validateActivePortal();
+        return receptacle.isActive;
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TilePortalBlock.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TilePortalBlock.java
@@ -55,7 +55,7 @@ public class TilePortalBlock extends TileEntity {
             double targetZ = zCoord;
 
             switch (blockMetadata) {
-                case 1:
+                case 1 -> {
                     sourceX += offset1;
                     sourceY += offset2;
                     targetX += offset1 + smallOffset1;
@@ -66,8 +66,8 @@ public class TilePortalBlock extends TileEntity {
                         sourceZ += 1;
                         targetZ += 0.25;
                     }
-                    break;
-                case 2:
+                }
+                case 2 -> {
                     sourceY += offset1;
                     sourceZ += offset2;
                     targetY += offset1 + smallOffset1;
@@ -78,8 +78,8 @@ public class TilePortalBlock extends TileEntity {
                         sourceX += 1;
                         targetX += 0.25;
                     }
-                    break;
-                case 3:
+                }
+                case 3 -> {
                     sourceX += offset1;
                     sourceZ += offset2;
                     targetX += offset1 + smallOffset1;
@@ -90,7 +90,7 @@ public class TilePortalBlock extends TileEntity {
                         sourceY += 1;
                         targetY += 0.25;
                     }
-                    break;
+                }
             }
             DraconicEvolution.proxy.spawnParticle(
                     new Particles.PortalParticle(worldObj, sourceX, sourceY, sourceZ, targetX, targetY, targetZ),
@@ -100,7 +100,7 @@ public class TilePortalBlock extends TileEntity {
 
     public TileDislocatorReceptacle getMaster() {
         TileEntity tile = worldObj.getTileEntity(masterX, masterY, masterZ);
-        return tile instanceof TileDislocatorReceptacle ? (TileDislocatorReceptacle) tile : null;
+        return tile instanceof TileDislocatorReceptacle receptacle ? receptacle : null;
     }
 
     public boolean isPortalStillValid() {

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/ReactorExplosion.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/ReactorExplosion.java
@@ -1,7 +1,5 @@
 package com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor;
 
-import java.util.Random;
-
 import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
 
@@ -14,20 +12,19 @@ import com.brandon3055.brandonscore.common.utills.Utills;
  */
 public class ReactorExplosion implements IProcess {
 
-    public static DamageSource fusionExplosion = new DamageSource("damage.de.fusionExplode").setExplosion()
+    public static final DamageSource FUSION_EXPLOSION = new DamageSource("damage.de.fusionExplode").setExplosion()
             .setDamageBypassesArmor().setDamageIsAbsolute().setDamageAllowedInCreativeMode();
 
-    private World worldObj;
-    private int xCoord;
-    private int yCoord;
-    private int zCoord;
-    private float power;
-    private Random random = new Random();
-
+    private final World world;
+    private final int xCoord;
+    private final int yCoord;
+    private final int zCoord;
+    private final float power;
+    private boolean isDead;
     private double expansion = 0;
 
     public ReactorExplosion(World world, int x, int y, int z, float power) {
-        this.worldObj = world;
+        this.world = world;
         this.xCoord = x;
         this.yCoord = y;
         this.zCoord = z;
@@ -38,17 +35,14 @@ public class ReactorExplosion implements IProcess {
     @Override
     public void updateProcess() {
 
-        int OD = (int) expansion;
-        int ID = OD - 1;
         int size = (int) expansion;
-
         for (int x = xCoord - size; x < xCoord + size; x++) {
             for (int z = zCoord - size; z < zCoord + size; z++) {
-                double dist = Utills.getDistanceAtoB(x, z, xCoord, zCoord);
-                if (dist < OD && dist >= ID) {
+                double distance = Utills.getDistanceAtoB(x, z, xCoord, zCoord);
+                if (distance < expansion && distance >= size - 1) {
                     float tracePower = power - (float) (expansion / 10D);
-                    tracePower *= 1F + ((random.nextFloat() - 0.5F) * 0.2);
-                    ProcessHandler.addProcess(new ReactorExplosionTrace(worldObj, x, yCoord, z, tracePower, random));
+                    tracePower *= 1F + (world.rand.nextFloat() - 0.5F) * 0.2;
+                    ProcessHandler.addProcess(new ReactorExplosionTrace(world, x, yCoord, z, tracePower));
                 }
             }
         }
@@ -56,8 +50,6 @@ public class ReactorExplosion implements IProcess {
         isDead = expansion >= power * 10;
         expansion += 1;
     }
-
-    private boolean isDead = false;
 
     @Override
     public boolean isDead() {

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/ReactorExplosionTrace.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/ReactorExplosionTrace.java
@@ -1,7 +1,6 @@
 package com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor;
 
 import java.util.List;
-import java.util.Random;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
@@ -17,20 +16,19 @@ import com.brandon3055.brandonscore.common.handlers.IProcess;
  */
 public class ReactorExplosionTrace implements IProcess {
 
-    private World worldObj;
-    private int xCoord;
-    private int yCoord;
-    private int zCoord;
-    private float power;
-    private Random random;
+    private final World world;
+    private final int xCoord;
+    private final int yCoord;
+    private final int zCoord;
+    private final float power;
+    private boolean isDead = false;
 
-    public ReactorExplosionTrace(World world, int x, int y, int z, float power, Random random) {
-        this.worldObj = world;
+    public ReactorExplosionTrace(World world, int x, int y, int z, float power) {
+        this.world = world;
         this.xCoord = x;
         this.yCoord = y;
         this.zCoord = z;
         this.power = power;
-        this.random = random;
     }
 
     @Override
@@ -39,51 +37,53 @@ public class ReactorExplosionTrace implements IProcess {
         float energy = power * 10;
 
         for (int y = yCoord; y > 0 && energy > 0; y--) {
-            Block block = worldObj.getBlock(xCoord, y, zCoord);
+            Block block = world.getBlock(xCoord, y, zCoord);
 
-            List<Entity> entities = worldObj.getEntitiesWithinAABB(
+            List<Entity> entities = world.getEntitiesWithinAABB(
                     Entity.class,
                     AxisAlignedBB.getBoundingBox(xCoord, y, zCoord, xCoord + 1, y + 1, zCoord + 1));
-            for (Entity entity : entities) entity.attackEntityFrom(ReactorExplosion.fusionExplosion, power * 100);
+            for (Entity entity : entities) {
+                entity.attackEntityFrom(ReactorExplosion.FUSION_EXPLOSION, power * 100);
+            }
 
             energy -= block instanceof BlockLiquid ? 10 : block.getExplosionResistance(null);
 
             boolean blockRemoved = false;
             if (energy >= 0 && block != Blocks.air) {
-                worldObj.setBlockToAir(xCoord, y, zCoord);
+                world.setBlockToAir(xCoord, y, zCoord);
                 blockRemoved = true;
             }
-            energy -= 0.5F + (0.1F * (yCoord - y));
+            energy -= 0.5F + 0.1F * (yCoord - y);
 
-            if (energy <= 0 && random.nextInt(20) == 0 && blockRemoved) {
-                if (random.nextInt(3) > 0) worldObj.setBlock(xCoord, y, zCoord, Blocks.fire);
-                else {
-                    worldObj.setBlock(xCoord, y, zCoord, Blocks.flowing_lava);
-                    // worldObj.scheduleBlockUpdate(xCoord, y, zCoord, Blocks.flowing_lava, 100);
+            if (energy <= 0 && world.rand.nextInt(20) == 0 && blockRemoved) {
+                if (world.rand.nextInt(3) > 0) {
+                    world.setBlock(xCoord, y, zCoord, Blocks.fire);
+                } else {
+                    world.setBlock(xCoord, y, zCoord, Blocks.flowing_lava);
                 }
             }
         }
 
         energy = power * 20;
-        yCoord++;
-        for (int y = yCoord; y < 255 && energy > 0; y++) {
-            Block block = worldObj.getBlock(xCoord, y, zCoord);
+        for (int y = yCoord + 1; y < 255 && energy > 0; y++) {
+            Block block = world.getBlock(xCoord, y, zCoord);
 
-            List<Entity> entities = worldObj.getEntitiesWithinAABB(
+            List<Entity> entities = world.getEntitiesWithinAABB(
                     Entity.class,
                     AxisAlignedBB.getBoundingBox(xCoord, y, zCoord, xCoord + 1, y + 1, zCoord + 1));
-            for (Entity entity : entities) entity.attackEntityFrom(ReactorExplosion.fusionExplosion, power * 100);
+            for (Entity entity : entities) {
+                entity.attackEntityFrom(ReactorExplosion.FUSION_EXPLOSION, power * 100);
+            }
 
             energy -= block instanceof BlockLiquid ? 10 : block.getExplosionResistance(null);
-            if (energy >= 0) worldObj.setBlockToAir(xCoord, y, zCoord);
-
+            if (energy >= 0) {
+                world.setBlockToAir(xCoord, y, zCoord);
+            }
             energy -= 0.5F + (0.1F * (y - yCoord));
         }
 
         isDead = true;
     }
-
-    private boolean isDead = false;
 
     @Override
     public boolean isDead() {

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorCore.java
@@ -389,7 +389,6 @@ public class TileReactorCore extends TileObjectSync {
     }
 
     public boolean canStart() {
-        validateStructure();
         return isStructureValid && reactionTemperature >= 2000
                 && fieldCharge >= maxFieldCharge / 2
                 && energySaturation >= maxEnergySaturation / 2
@@ -397,12 +396,10 @@ public class TileReactorCore extends TileObjectSync {
     }
 
     public boolean canCharge() {
-        validateStructure();
         return isStructureValid && reactorState != STATE_ONLINE && convertedFuel + reactorFuel + conversionUnit >= 144;
     }
 
     public boolean canStop() {
-        validateStructure();
         return isStructureValid && reactorState != STATE_OFFLINE;
     }
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorCore.java
@@ -47,7 +47,7 @@ public class TileReactorCore extends TileObjectSync {
         STOPPING,
         INVALID;
 
-        private static ReactorState[] Values = values();
+        private static final ReactorState[] Values = values();
 
         public static ReactorState getState(int ordinal) {
             return ordinal >= 0 && ordinal < Values.length ? Values[ordinal] : INVALID;
@@ -84,21 +84,6 @@ public class TileReactorCore extends TileObjectSync {
 
     @SideOnly(Side.CLIENT)
     private ReactorSound reactorSound;
-
-    // TODO DONT FORGET TO ACTUALLY FINISH ALL THESE THINGS!!!!
-    // Check //-Bounding box
-    // Check //-Custom player collision
-    // Check //-Finish stabilizer place and break mechanics
-    // Check //-Have the GUI tell you if the structure is invalid
-    // Check //-Config
-    // TODO things for later
-    // -GUI info (maby speed up gui sync via the container)
-    // -GUI warning red bars
-    // -Maby get around to setting the angle of the stabiliser elements
-    // Check //-SOUND!!!!!
-    // Check //-CC Integration
-    // Check //-Redstone
-    // -Add reactor and gates to tablet
 
     public List<TileLocation> stabilizerLocations = new ArrayList<>();
 
@@ -227,11 +212,6 @@ public class TileReactorCore extends TileObjectSync {
         // exponentially
         tempDrainFactor = reactionTemperature > 8000 ? 1 + (Math.pow(reactionTemperature - 8000, 2) * 0.0000025)
                 : reactionTemperature > 2000 ? 1 : reactionTemperature > 1000 ? (reactionTemperature - 1000) / 1000 : 0;
-        // todo add to guiInfo
-        // -temp drain factor
-        // -mass
-        // -generation
-        // -field drain
 
         // Field Drain Calculation
         // (baseMaxRFt/make smaller to increase field power drain)
@@ -437,7 +417,7 @@ public class TileReactorCore extends TileObjectSync {
         return Math.cbrt(volume / (4D / 3D * Math.PI));
     }
 
-    public double getCoreDiameter() { // todo adjust so the core dose not expand before 1000>2000c
+    public double getCoreDiameter() {
         return getCoreRadius() * 2;
     }
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorCore.java
@@ -20,6 +20,7 @@ import com.brandon3055.draconicevolution.client.ReactorSound;
 import com.brandon3055.draconicevolution.client.gui.GuiHandler;
 import com.brandon3055.draconicevolution.client.render.particle.Particles;
 import com.brandon3055.draconicevolution.common.blocks.multiblock.IReactorPart;
+import com.brandon3055.draconicevolution.common.blocks.multiblock.IReactorPart.ComparatorMode;
 import com.brandon3055.draconicevolution.common.blocks.multiblock.MultiblockHelper.TileLocation;
 import com.brandon3055.draconicevolution.common.handler.ConfigHandler;
 import com.brandon3055.draconicevolution.common.lib.References;
@@ -496,47 +497,47 @@ public class TileReactorCore extends TileObjectSync {
         }
     }
 
-    public int getComparatorOutput(int redstoneMode) {
-        switch (redstoneMode) {
-            case IReactorPart.RMODE_TEMP:
-                return toRedstoneStrength(reactionTemperature, maxReactTemperature, redstoneMode);
-            case IReactorPart.RMODE_TEMP_INV:
-                return 15 - toRedstoneStrength(reactionTemperature, maxReactTemperature, redstoneMode);
-            case IReactorPart.RMODE_FIELD:
-                return toRedstoneStrength(fieldCharge, maxFieldCharge, redstoneMode);
-            case IReactorPart.RMODE_FIELD_INV:
-                return 15 - toRedstoneStrength(fieldCharge, maxFieldCharge, redstoneMode);
-            case IReactorPart.RMODE_SAT:
-                return toRedstoneStrength(energySaturation, maxEnergySaturation, redstoneMode);
-            case IReactorPart.RMODE_SAT_INV:
-                return 15 - toRedstoneStrength(energySaturation, maxEnergySaturation, redstoneMode);
-            case IReactorPart.RMODE_FUEL:
-                return toRedstoneStrength(convertedFuel + conversionUnit, reactorFuel - conversionUnit, redstoneMode);
-            case IReactorPart.RMODE_FUEL_INV:
+    public int getComparatorOutput(ComparatorMode comparatorMode) {
+        switch (comparatorMode) {
+            case TEMPERATURE:
+                return toRedstoneStrength(reactionTemperature, maxReactTemperature, comparatorMode);
+            case TEMPERATURE_INVERTED:
+                return 15 - toRedstoneStrength(reactionTemperature, maxReactTemperature, comparatorMode);
+            case FIELD_CHARGE:
+                return toRedstoneStrength(fieldCharge, maxFieldCharge, comparatorMode);
+            case FIELD_CHARGE_INVERTED:
+                return 15 - toRedstoneStrength(fieldCharge, maxFieldCharge, comparatorMode);
+            case ENERGY_SATURATION:
+                return toRedstoneStrength(energySaturation, maxEnergySaturation, comparatorMode);
+            case ENERGY_SATURATION_INVERTED:
+                return 15 - toRedstoneStrength(energySaturation, maxEnergySaturation, comparatorMode);
+            case CONVERTED_FUEL:
+                return toRedstoneStrength(convertedFuel + conversionUnit, reactorFuel - conversionUnit, comparatorMode);
+            case CONVERTED_FUEL_INVERTED:
                 return 15 - toRedstoneStrength(
                         convertedFuel + conversionUnit,
                         reactorFuel - conversionUnit,
-                        redstoneMode);
+                        comparatorMode);
         }
         return 0;
     }
 
-    private int toRedstoneStrength(double value, double maxValue, int mode) {
+    private int toRedstoneStrength(double value, double maxValue, ComparatorMode comparatorMode) {
         if (maxValue == 0) {
             return 0;
         }
         double proportion = value / maxValue;
         int redstoneStrength = (int) (proportion * 15D);
-        switch (mode) {
-            case IReactorPart.RMODE_FIELD:
-            case IReactorPart.RMODE_FIELD_INV: {
+        switch (comparatorMode) {
+            case FIELD_CHARGE:
+            case FIELD_CHARGE_INVERTED: {
                 if (proportion < 0.1) {
                     redstoneStrength = 0;
                 }
                 break;
             }
-            case IReactorPart.RMODE_FUEL:
-            case IReactorPart.RMODE_FUEL_INV: {
+            case CONVERTED_FUEL:
+            case CONVERTED_FUEL_INVERTED: {
                 if (proportion > 0.9) {
                     redstoneStrength = 15;
                 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorEnergyInjector.java
@@ -46,11 +46,7 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
             int comparatorOutput = core.getComparatorOutput(comparatorMode);
             if (comparatorOutput != comparatorOutputCache) {
                 comparatorOutputCache = comparatorOutput;
-                worldObj.notifyBlocksOfNeighborChange(
-                        xCoord,
-                        yCoord,
-                        zCoord,
-                        worldObj.getBlock(xCoord, yCoord, zCoord));
+                worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, blockType);
             }
         }
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorEnergyInjector.java
@@ -78,7 +78,7 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
     @Override
     public TileReactorCore getMaster() {
         TileEntity tile = masterLocation.getTileEntity(worldObj);
-        return tile instanceof TileReactorCore ? (TileReactorCore) tile : null;
+        return tile instanceof TileReactorCore core ? core : null;
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorEnergyInjector.java
@@ -1,8 +1,5 @@
 package com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
@@ -12,11 +9,10 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import com.brandon3055.brandonscore.common.utills.Utills;
 import com.brandon3055.draconicevolution.DraconicEvolution;
 import com.brandon3055.draconicevolution.client.render.particle.ParticleReactorBeam;
 import com.brandon3055.draconicevolution.common.blocks.multiblock.IReactorPart;
-import com.brandon3055.draconicevolution.common.blocks.multiblock.MultiblockHelper;
+import com.brandon3055.draconicevolution.common.blocks.multiblock.MultiblockHelper.TileLocation;
 import com.brandon3055.draconicevolution.integration.computers.IDEPeripheral;
 
 import cofh.api.energy.IEnergyReceiver;
@@ -30,30 +26,32 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
 
     public float modelIllumination = 1F;
     public int facingDirection = ForgeDirection.UP.ordinal();
-    public MultiblockHelper.TileLocation masterLocation = new MultiblockHelper.TileLocation();
+    public TileLocation masterLocation = new TileLocation();
     public boolean isValid = false;
-    public int tick = 0;
 
     @SideOnly(Side.CLIENT)
     private ParticleReactorBeam beam;
 
-    private TileReactorCore core = null;
-    private int redstoneMode = 0;
-    private int rs = -1;
-    private int rsCach = -1;
+    private int redstoneMode = IReactorPart.RMODE_TEMP;
+    private int comparatorOutputCache = -1;
 
     @Override
     public void updateEntity() {
         if (worldObj.isRemote && isValid) {
             updateBeam();
+            return;
         }
 
-        TileEntity master = masterLocation.getTileEntity(worldObj);
-        if (!worldObj.isRemote && master instanceof TileReactorCore) {
-            rs = ((TileReactorCore) master).getComparatorOutput(redstoneMode);
-            if (rs != rsCach) {
-                rsCach = rs;
-                Utills.updateNeabourBlocks(worldObj, xCoord, yCoord, zCoord);
+        TileReactorCore core = getMaster();
+        if (core != null) {
+            int comparatorOutput = core.getComparatorOutput(redstoneMode);
+            if (comparatorOutput != comparatorOutputCache) {
+                comparatorOutputCache = comparatorOutput;
+                worldObj.notifyBlocksOfNeighborChange(
+                        xCoord,
+                        yCoord,
+                        zCoord,
+                        worldObj.getBlock(xCoord, yCoord, zCoord));
             }
         }
     }
@@ -64,30 +62,43 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
     }
 
     public void onPlaced() {
-        checkForMaster();
-    }
-
-    public boolean checkForMaster() {
-        for (int i = 1; i < 10; i++) {
-            ForgeDirection dir = ForgeDirection.getOrientation(facingDirection);
-            int x = xCoord + (dir.offsetX * i);
-            int y = yCoord + (dir.offsetY * i);
-            int z = zCoord + (dir.offsetZ * i);
-            if (!worldObj.isAirBlock(x, y, z)) {
-                TileEntity tile = worldObj.getTileEntity(x, y, z);
-                if (tile instanceof TileReactorCore) {
-                    masterLocation.set(x, y, z);
-                    isValid = true;
-                    worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
-                    return true;
-                } else {
-                    isValid = false;
-                    return false;
-                }
+        ForgeDirection facing = ForgeDirection.getOrientation(facingDirection);
+        for (int distance = 1; distance <= TileReactorCore.MAX_SLAVE_RANGE; distance++) {
+            int targetX = xCoord + facing.offsetX * distance;
+            int targetY = yCoord + facing.offsetY * distance;
+            int targetZ = zCoord + facing.offsetZ * distance;
+            TileEntity tile = worldObj.getTileEntity(targetX, targetY, targetZ);
+            if (tile instanceof TileReactorCore) {
+                setUp(new TileLocation(targetX, targetY, targetZ));
+                return;
             }
         }
+        shutDown();
+    }
+
+    @Override
+    public TileLocation getMasterLocation() {
+        return masterLocation;
+    }
+
+    @Override
+    public TileReactorCore getMaster() {
+        TileEntity tile = masterLocation.getTileEntity(worldObj);
+        return tile instanceof TileReactorCore ? (TileReactorCore) tile : null;
+    }
+
+    @Override
+    public void setUp(TileLocation masterLocation) {
+        this.masterLocation = masterLocation;
+        isValid = true;
+        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+    }
+
+    @Override
+    public void shutDown() {
+        masterLocation = new TileLocation();
         isValid = false;
-        return false;
+        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
     }
 
     @Override
@@ -96,14 +107,8 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
     }
 
     @Override
-    public String getRedstoneModeString() {
-        return StatCollector.translateToLocal("msg.de.reactorRSMode." + redstoneMode + ".txt");
-    }
-
-    @Override
-    public void changeRedstoneMode() {
-        if (redstoneMode == IReactorPart.RMODE_FUEL_INV) redstoneMode = 0;
-        else redstoneMode++;
+    public ForgeDirection getFacing() {
+        return ForgeDirection.getOrientation(facingDirection);
     }
 
     @Override
@@ -112,10 +117,17 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
     }
 
     @Override
-    public void shutDown() {
-        masterLocation = new MultiblockHelper.TileLocation();
-        isValid = false;
-        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+    public void changeRedstoneMode() {
+        if (redstoneMode == IReactorPart.RMODE_FUEL_INV) {
+            redstoneMode = IReactorPart.RMODE_TEMP;
+        } else {
+            redstoneMode++;
+        }
+    }
+
+    @Override
+    public String getRedstoneModeAsString() {
+        return StatCollector.translateToLocal("msg.de.reactorRSMode." + redstoneMode + ".txt");
     }
 
     @Override
@@ -134,15 +146,6 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
         facingDirection = compound.getInteger("Facing");
         isValid = compound.getBoolean("IsValid");
         super.onDataPacket(net, pkt);
-    }
-
-    public TileReactorCore getCore() {
-        if (core == null || core.isInvalid()) {
-            if (getMaster().getTileEntity(worldObj) instanceof TileReactorCore)
-                core = (TileReactorCore) getMaster().getTileEntity(worldObj);
-            else core = null;
-        }
-        return core;
     }
 
     @Override
@@ -164,19 +167,19 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
     }
 
     @Override
-    public MultiblockHelper.TileLocation getMaster() {
-        return masterLocation;
-    }
-
-    @Override
     public AxisAlignedBB getRenderBoundingBox() {
         return AxisAlignedBB.getBoundingBox(xCoord, yCoord, zCoord, xCoord + 1, yCoord + 1, zCoord + 1);
     }
 
     @Override
     public int receiveEnergy(ForgeDirection from, int maxReceive, boolean simulate) {
-        if (simulate) return Integer.MAX_VALUE;
-        else if (getCore() != null) return getCore().injectEnergy(maxReceive);
+        if (simulate) {
+            return Integer.MAX_VALUE;
+        }
+        TileReactorCore core = getMaster();
+        if (core != null) {
+            return core.injectEnergy(maxReceive);
+        }
         return 0;
     }
 
@@ -206,48 +209,8 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
     }
 
     @Override
-    public Object[] callMethod(String method, Object... args) {
-        if (!(getMaster().getTileEntity(worldObj) instanceof TileReactorCore)) return null;
-        TileReactorCore reactor = (TileReactorCore) getMaster().getTileEntity(worldObj);
-
-        if (args.length > 0) throw new IllegalArgumentException("This method dose not accept arguments");
-
-        if (method.equals("getReactorInfo")) {
-            Map<Object, Object> map = new HashMap<Object, Object>();
-            map.put("temperature", Utills.round(reactor.reactionTemperature, 100));
-            map.put("fieldStrength", Utills.round(reactor.fieldCharge, 100));
-            map.put("maxFieldStrength", Utills.round(reactor.maxFieldCharge, 100));
-            map.put("energySaturation", reactor.energySaturation);
-            map.put("maxEnergySaturation", reactor.maxEnergySaturation);
-            map.put("fuelConversion", Utills.round((double) reactor.convertedFuel + reactor.conversionUnit, 1000));
-            map.put("maxFuelConversion", reactor.reactorFuel + reactor.convertedFuel);
-            map.put("generationRate", (int) reactor.generationRate);
-            map.put("fieldDrainRate", reactor.fieldDrain);
-            map.put("fuelConversionRate", (int) Math.round(reactor.fuelUseRate * 1000000D));
-            map.put(
-                    "status",
-                    reactor.reactorState == 0 ? "offline"
-                            : reactor.reactorState == 1 && !reactor.canStart() ? "charging"
-                                    : reactor.reactorState == 1 && reactor.canStart() ? "charged"
-                                            : reactor.reactorState == 2 ? "online"
-                                                    : reactor.reactorState == 3 ? "stopping" : "invalid");
-            return new Object[] { map };
-        } else if (method.equals("chargeReactor")) {
-            if (reactor.canCharge()) {
-                reactor.reactorState = TileReactorCore.STATE_START;
-                return new Object[] { true };
-            } else return new Object[] { false };
-        } else if (method.equals("activateReactor")) {
-            if (reactor.canStart()) {
-                reactor.reactorState = TileReactorCore.STATE_ONLINE;
-                return new Object[] { true };
-            } else return new Object[] { false };
-        } else if (method.equals("stopReactor")) {
-            if (reactor.canStop()) {
-                reactor.reactorState = TileReactorCore.STATE_STOP;
-                return new Object[] { true };
-            } else return new Object[] { false };
-        }
-        return new Object[] {};
+    public Object[] callMethod(String methodName, Object... args) {
+        TileReactorCore core = getMaster();
+        return core != null ? core.callMethod(methodName, args) : null;
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorEnergyInjector.java
@@ -61,7 +61,7 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
     }
 
     public void onPlaced() {
-        for (int distance = 1; distance <= TileReactorCore.MAX_SLAVE_RANGE; distance++) {
+        for (int distance = 1; distance <= TileReactorCore.MAXIMUM_PART_DISTANCE; distance++) {
             int targetX = xCoord + facing.offsetX * distance;
             int targetY = yCoord + facing.offsetY * distance;
             int targetZ = zCoord + facing.offsetZ * distance;

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorEnergyInjector.java
@@ -6,7 +6,6 @@ import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
-import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.brandon3055.draconicevolution.DraconicEvolution;
@@ -32,7 +31,7 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
     @SideOnly(Side.CLIENT)
     private ParticleReactorBeam beam;
 
-    private int redstoneMode = IReactorPart.RMODE_TEMP;
+    private ComparatorMode comparatorMode = ComparatorMode.TEMPERATURE;
     private int comparatorOutputCache = -1;
 
     @Override
@@ -44,7 +43,7 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
 
         TileReactorCore core = getMaster();
         if (core != null) {
-            int comparatorOutput = core.getComparatorOutput(redstoneMode);
+            int comparatorOutput = core.getComparatorOutput(comparatorMode);
             if (comparatorOutput != comparatorOutputCache) {
                 comparatorOutputCache = comparatorOutput;
                 worldObj.notifyBlocksOfNeighborChange(
@@ -111,22 +110,13 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
     }
 
     @Override
-    public int getRedstoneMode() {
-        return redstoneMode;
+    public ComparatorMode getComparatorMode() {
+        return comparatorMode;
     }
 
     @Override
-    public void changeRedstoneMode() {
-        if (redstoneMode == IReactorPart.RMODE_FUEL_INV) {
-            redstoneMode = IReactorPart.RMODE_TEMP;
-        } else {
-            redstoneMode++;
-        }
-    }
-
-    @Override
-    public String getRedstoneModeAsString() {
-        return StatCollector.translateToLocal("msg.de.reactorRSMode." + redstoneMode + ".txt");
+    public void changeComparatorMode() {
+        comparatorMode = comparatorMode.next();
     }
 
     @Override
@@ -153,7 +143,7 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
         masterLocation.writeToNBT(compound, "Master");
         compound.setInteger("Facing", facing.ordinal());
         compound.setBoolean("IsValid", isValid);
-        compound.setInteger("RedstoneMode", redstoneMode);
+        compound.setInteger("RedstoneMode", comparatorMode.ordinal());
     }
 
     @Override
@@ -162,7 +152,7 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
         masterLocation.readFromNBT(compound, "Master");
         facing = ForgeDirection.getOrientation(compound.getInteger("Facing"));
         isValid = compound.getBoolean("IsValid");
-        redstoneMode = compound.getInteger("RedstoneMode");
+        comparatorMode = ComparatorMode.getMode(compound.getInteger("RedstoneMode"));
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorEnergyInjector.java
@@ -25,7 +25,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class TileReactorEnergyInjector extends TileEntity implements IReactorPart, IEnergyReceiver, IDEPeripheral {
 
     public float modelIllumination = 1F;
-    public int facingDirection = ForgeDirection.UP.ordinal();
+    public ForgeDirection facing = ForgeDirection.UP;
     public TileLocation masterLocation = new TileLocation();
     public boolean isValid = false;
 
@@ -62,7 +62,6 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
     }
 
     public void onPlaced() {
-        ForgeDirection facing = ForgeDirection.getOrientation(facingDirection);
         for (int distance = 1; distance <= TileReactorCore.MAX_SLAVE_RANGE; distance++) {
             int targetX = xCoord + facing.offsetX * distance;
             int targetY = yCoord + facing.offsetY * distance;
@@ -108,7 +107,7 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
 
     @Override
     public ForgeDirection getFacing() {
-        return ForgeDirection.getOrientation(facingDirection);
+        return facing;
     }
 
     @Override
@@ -134,7 +133,7 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
     public Packet getDescriptionPacket() {
         NBTTagCompound compound = new NBTTagCompound();
         masterLocation.writeToNBT(compound, "Master");
-        compound.setInteger("Facing", facingDirection);
+        compound.setInteger("Facing", facing.ordinal());
         compound.setBoolean("IsValid", isValid);
         return new S35PacketUpdateTileEntity(xCoord, yCoord, zCoord, 1, compound);
     }
@@ -143,7 +142,7 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
     public void onDataPacket(NetworkManager net, S35PacketUpdateTileEntity pkt) {
         NBTTagCompound compound = pkt.func_148857_g();
         masterLocation.readFromNBT(compound, "Master");
-        facingDirection = compound.getInteger("Facing");
+        facing = ForgeDirection.getOrientation(compound.getInteger("Facing"));
         isValid = compound.getBoolean("IsValid");
         super.onDataPacket(net, pkt);
     }
@@ -152,7 +151,7 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
     public void writeToNBT(NBTTagCompound compound) {
         super.writeToNBT(compound);
         masterLocation.writeToNBT(compound, "Master");
-        compound.setInteger("Facing", facingDirection);
+        compound.setInteger("Facing", facing.ordinal());
         compound.setBoolean("IsValid", isValid);
         compound.setInteger("RedstoneMode", redstoneMode);
     }
@@ -161,7 +160,7 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
     public void readFromNBT(NBTTagCompound compound) {
         super.readFromNBT(compound);
         masterLocation.readFromNBT(compound, "Master");
-        facingDirection = compound.getInteger("Facing");
+        facing = ForgeDirection.getOrientation(compound.getInteger("Facing"));
         isValid = compound.getBoolean("IsValid");
         redstoneMode = compound.getInteger("RedstoneMode");
     }
@@ -195,7 +194,7 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
 
     @Override
     public boolean canConnectEnergy(ForgeDirection from) {
-        return from == ForgeDirection.getOrientation(facingDirection).getOpposite();
+        return from == facing.getOpposite();
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorStabilizer.java
@@ -11,6 +11,7 @@ import com.brandon3055.draconicevolution.DraconicEvolution;
 import com.brandon3055.draconicevolution.client.render.particle.ParticleReactorBeam;
 import com.brandon3055.draconicevolution.common.blocks.multiblock.IReactorPart;
 import com.brandon3055.draconicevolution.common.blocks.multiblock.MultiblockHelper.TileLocation;
+import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.reactor.TileReactorCore.ReactorState;
 import com.brandon3055.draconicevolution.integration.computers.IDEPeripheral;
 
 import cofh.api.energy.IEnergyProvider;
@@ -49,7 +50,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
 
         TileReactorCore core = getMaster();
         if (core != null) {
-            if (core.reactorState == TileReactorCore.STATE_ONLINE) {
+            if (core.reactorState == ReactorState.ONLINE) {
                 ForgeDirection back = facing.getOpposite();
                 TileEntity tile = worldObj
                         .getTileEntity(xCoord + back.offsetX, yCoord + back.offsetY, zCoord + back.offsetZ);
@@ -96,7 +97,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
     }
 
     public void onPlaced() {
-        for (int distance = 1; distance <= TileReactorCore.MAX_SLAVE_RANGE; distance++) {
+        for (int distance = 1; distance <= TileReactorCore.MAXIMUM_PART_DISTANCE; distance++) {
             TileLocation location = new TileLocation(
                     xCoord + facing.offsetX * distance,
                     yCoord + facing.offsetY * distance,

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorStabilizer.java
@@ -29,7 +29,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
     public float coreSpeed = 1F;
     public float ringSpeed = 1F;
     public float modelIllumination = 0F;
-    public int facingDirection = ForgeDirection.UP.ordinal();
+    public ForgeDirection facing = ForgeDirection.UP;
     public TileLocation masterLocation = new TileLocation();
     public boolean isValid = false;
     public int tick = 0;
@@ -51,7 +51,6 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
         TileReactorCore core = getMaster();
         if (core != null) {
             if (core.reactorState == TileReactorCore.STATE_ONLINE) {
-                ForgeDirection facing = ForgeDirection.getOrientation(facingDirection);
                 ForgeDirection back = facing.getOpposite();
                 TileEntity tile = worldObj
                         .getTileEntity(xCoord + back.offsetX, yCoord + back.offsetY, zCoord + back.offsetZ);
@@ -98,7 +97,6 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
     }
 
     public void onPlaced() {
-        ForgeDirection facing = ForgeDirection.getOrientation(facingDirection);
         for (int distance = 1; distance <= TileReactorCore.MAX_SLAVE_RANGE; distance++) {
             TileLocation location = new TileLocation(
                     xCoord + facing.offsetX * distance,
@@ -148,7 +146,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
 
     @Override
     public ForgeDirection getFacing() {
-        return ForgeDirection.getOrientation(facingDirection);
+        return facing;
     }
 
     @Override
@@ -174,7 +172,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
     public Packet getDescriptionPacket() {
         NBTTagCompound compound = new NBTTagCompound();
         masterLocation.writeToNBT(compound, "Master");
-        compound.setInteger("Facing", facingDirection);
+        compound.setInteger("Facing", facing.ordinal());
         compound.setBoolean("IsValid", isValid);
         return new S35PacketUpdateTileEntity(xCoord, yCoord, zCoord, 1, compound);
     }
@@ -183,7 +181,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
     public void onDataPacket(NetworkManager net, S35PacketUpdateTileEntity pkt) {
         NBTTagCompound compound = pkt.func_148857_g();
         masterLocation.readFromNBT(compound, "Master");
-        facingDirection = compound.getInteger("Facing");
+        facing = ForgeDirection.getOrientation(compound.getInteger("Facing"));
         isValid = compound.getBoolean("IsValid");
         super.onDataPacket(net, pkt);
     }
@@ -192,7 +190,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
     public void writeToNBT(NBTTagCompound compound) {
         super.writeToNBT(compound);
         masterLocation.writeToNBT(compound, "Master");
-        compound.setInteger("Facing", facingDirection);
+        compound.setInteger("Facing", facing.ordinal());
         compound.setBoolean("IsValid", isValid);
         compound.setInteger("RedstoneMode", redstoneMode);
     }
@@ -201,7 +199,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
     public void readFromNBT(NBTTagCompound compound) {
         super.readFromNBT(compound);
         masterLocation.readFromNBT(compound, "Master");
-        facingDirection = compound.getInteger("Facing");
+        facing = ForgeDirection.getOrientation(compound.getInteger("Facing"));
         isValid = compound.getBoolean("IsValid");
         redstoneMode = compound.getInteger("RedstoneMode");
     }
@@ -223,7 +221,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
 
     @Override
     public boolean canConnectEnergy(ForgeDirection from) {
-        return from == ForgeDirection.getOrientation(facingDirection).getOpposite();
+        return from == facing.getOpposite();
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorStabilizer.java
@@ -65,11 +65,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
             int comparatorOutput = core.getComparatorOutput(comparatorMode);
             if (comparatorOutput != comparatorOutputCache) {
                 comparatorOutputCache = comparatorOutput;
-                worldObj.notifyBlocksOfNeighborChange(
-                        xCoord,
-                        yCoord,
-                        zCoord,
-                        worldObj.getBlock(xCoord, yCoord, zCoord));
+                worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, blockType);
             }
         }
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorStabilizer.java
@@ -5,7 +5,6 @@ import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.brandon3055.draconicevolution.DraconicEvolution;
@@ -33,7 +32,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
     public TileLocation masterLocation = new TileLocation();
     public boolean isValid = false;
     public int tick = 0;
-    private int redstoneMode = IReactorPart.RMODE_TEMP;
+    private ComparatorMode comparatorMode = ComparatorMode.TEMPERATURE;
     private int comparatorOutputCache = -1;
 
     @SideOnly(Side.CLIENT)
@@ -62,7 +61,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
                 }
             }
 
-            int comparatorOutput = core.getComparatorOutput(redstoneMode);
+            int comparatorOutput = core.getComparatorOutput(comparatorMode);
             if (comparatorOutput != comparatorOutputCache) {
                 comparatorOutputCache = comparatorOutput;
                 worldObj.notifyBlocksOfNeighborChange(
@@ -150,22 +149,13 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
     }
 
     @Override
-    public int getRedstoneMode() {
-        return redstoneMode;
+    public ComparatorMode getComparatorMode() {
+        return comparatorMode;
     }
 
     @Override
-    public void changeRedstoneMode() {
-        if (redstoneMode == IReactorPart.RMODE_FUEL_INV) {
-            redstoneMode = IReactorPart.RMODE_TEMP;
-        } else {
-            redstoneMode++;
-        }
-    }
-
-    @Override
-    public String getRedstoneModeAsString() {
-        return StatCollector.translateToLocal("msg.de.reactorRSMode." + redstoneMode + ".txt");
+    public void changeComparatorMode() {
+        comparatorMode = comparatorMode.next();
     }
 
     @Override
@@ -192,7 +182,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
         masterLocation.writeToNBT(compound, "Master");
         compound.setInteger("Facing", facing.ordinal());
         compound.setBoolean("IsValid", isValid);
-        compound.setInteger("RedstoneMode", redstoneMode);
+        compound.setInteger("RedstoneMode", comparatorMode.ordinal());
     }
 
     @Override
@@ -201,7 +191,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
         masterLocation.readFromNBT(compound, "Master");
         facing = ForgeDirection.getOrientation(compound.getInteger("Facing"));
         isValid = compound.getBoolean("IsValid");
-        redstoneMode = compound.getInteger("RedstoneMode");
+        comparatorMode = ComparatorMode.getMode(compound.getInteger("RedstoneMode"));
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorStabilizer.java
@@ -54,8 +54,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
                 ForgeDirection back = facing.getOpposite();
                 TileEntity tile = worldObj
                         .getTileEntity(xCoord + back.offsetX, yCoord + back.offsetY, zCoord + back.offsetZ);
-                if (tile instanceof IEnergyReceiver) {
-                    IEnergyReceiver receiver = (IEnergyReceiver) tile;
+                if (tile instanceof IEnergyReceiver receiver) {
                     int energyToReceive = Math.min(core.energySaturation, core.maxEnergySaturation / 100);
                     int energyReceived = receiver.receiveEnergy(facing, energyToReceive, false);
                     core.energySaturation -= energyReceived;
@@ -99,9 +98,8 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
                     yCoord + facing.offsetY * distance,
                     zCoord + facing.offsetZ * distance);
             TileEntity tile = location.getTileEntity(worldObj);
-            if (tile instanceof TileReactorCore) {
+            if (tile instanceof TileReactorCore core) {
                 setUp(location);
-                TileReactorCore core = (TileReactorCore) tile;
                 core.updateReactorParts(false);
                 core.validateStructure();
                 return;
@@ -118,7 +116,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
     @Override
     public TileReactorCore getMaster() {
         TileEntity tile = masterLocation.getTileEntity(worldObj);
-        return tile instanceof TileReactorCore ? (TileReactorCore) tile : null;
+        return tile instanceof TileReactorCore core ? core : null;
     }
 
     @Override

--- a/src/main/java/com/brandon3055/draconicevolution/common/utills/OreDictionaryHelper.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/utills/OreDictionaryHelper.java
@@ -1,0 +1,16 @@
+package com.brandon3055.draconicevolution.common.utills;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+public class OreDictionaryHelper {
+
+    public static Set<String> getOreNames(ItemStack stack) {
+        int[] oreIds = OreDictionary.getOreIDs(stack);
+        return Arrays.stream(oreIds).mapToObj(OreDictionary::getOreName).collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/brandon3055/draconicevolution/common/utills/PortalHelper.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/utills/PortalHelper.java
@@ -135,10 +135,9 @@ public class PortalHelper {
         public boolean scanPortal(World world, int x, int y, int z, boolean setPortalBlocks,
                 boolean checkPortalBlocks) {
             TileEntity tile = world.getTileEntity(x, y, z);
-            if (!(tile instanceof TileDislocatorReceptacle)) {
+            if (!(tile instanceof TileDislocatorReceptacle receptacle)) {
                 return false;
             }
-            TileDislocatorReceptacle receptacle = (TileDislocatorReceptacle) tile;
             if (setPortalBlocks) {
                 receptacle.updating = true;
             }
@@ -157,8 +156,7 @@ public class PortalHelper {
                     } else if (setPortalBlocks) {
                         world.setBlock(targetX, targetY, targetZ, ModBlocks.portal);
                         tile = world.getTileEntity(targetX, targetY, targetZ);
-                        if (tile instanceof TilePortalBlock) {
-                            TilePortalBlock portal = (TilePortalBlock) tile;
+                        if (tile instanceof TilePortalBlock portal) {
                             portal.masterX = x;
                             portal.masterY = y;
                             portal.masterZ = z;

--- a/src/main/java/com/brandon3055/draconicevolution/common/utills/PortalHelper.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/utills/PortalHelper.java
@@ -2,8 +2,8 @@ package com.brandon3055.draconicevolution.common.utills;
 
 import net.minecraft.block.Block;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
-import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.brandon3055.draconicevolution.common.ModBlocks;
@@ -15,7 +15,7 @@ import com.brandon3055.draconicevolution.common.tileentities.multiblocktiles.Til
  */
 public class PortalHelper {
 
-    static int iterationNow = 0;
+    public static final int MAXIMUM_PORTAL_SIZE = 150;
 
     public static boolean isFrame(Block block) {
         return block == ModBlocks.infusedObsidian;
@@ -30,13 +30,17 @@ public class PortalHelper {
     }
 
     public static PortalStructure getValidStructure(World world, int x, int y, int z) {
-        if (world.isRemote) return null;
+        if (world.isRemote) {
+            return null;
+        }
 
         for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
             for (ForgeDirection plane : ForgeDirection.VALID_DIRECTIONS) {
                 if (plane != direction && plane != direction.getOpposite()) {
                     PortalStructure structure = traceFrame(world, x, y, z, direction, plane);
-                    if (structure != null && structure.scanPortal(world, x, y, z, false, false)) return structure;
+                    if (structure != null && structure.scanPortal(world, x, y, z, false, false)) {
+                        return structure;
+                    }
                 }
             }
         }
@@ -46,67 +50,45 @@ public class PortalHelper {
 
     public static PortalStructure traceFrame(World world, int x, int y, int z, ForgeDirection startDir,
             ForgeDirection plane) {
-        int MAX_SIZE = 150;
         int startX = x + startDir.offsetX;
         int startY = y + startDir.offsetY;
         int startZ = z + startDir.offsetZ;
 
-        // Check that the trace is starting from a receptacle
-        if (!world.isAirBlock(startX, startY, startZ)) return null;
-
-        int xSize = 0;
-        int ySize = 0;
-        int yOffset = 0;
-
-        // Get X size
-        for (int i = 0; i <= MAX_SIZE; i++) {
-            Block block = world.getBlock(
-                    startX + i * startDir.offsetX,
-                    startY + i * startDir.offsetY,
-                    startZ + i * startDir.offsetZ);
-            if (isFrame(block)) {
-                xSize = i;
-                break;
-            } else if (!world.isAirBlock(
-                    startX + i * startDir.offsetX,
-                    startY + i * startDir.offsetY,
-                    startZ + i * startDir.offsetZ))
-                return null;
+        if (!world.isAirBlock(startX, startY, startZ)) {
+            return null;
         }
 
-        // Get Y size above receptacle
-        for (int i = 0; i <= MAX_SIZE; i++) {
-            Block block = world
-                    .getBlock(startX + i * plane.offsetX, startY + i * plane.offsetY, startZ + i * plane.offsetZ);
-            if (isFrame(block)) {
-                ySize = i;
-                break;
-            } else if (!world
-                    .isAirBlock(startX + i * plane.offsetX, startY + i * plane.offsetY, startZ + i * plane.offsetZ))
-                return null;
-        }
+        int xSize = findDistanceToFrame(world, startX, startY, startZ, startDir);
+        int ySize = findDistanceToFrame(world, startX, startY, startZ, plane);
+        int yOffset = findDistanceToFrame(world, startX, startY, startZ, plane.getOpposite());
+        ySize += yOffset - 1;
 
-        // Get Y size below receptacle and get y offset
-        for (int i = 0; i <= MAX_SIZE; i++) {
-            Block block = world
-                    .getBlock(startX - i * plane.offsetX, startY - i * plane.offsetY, startZ - i * plane.offsetZ);
-            if (isFrame(block)) {
-                ySize += i - 1;
-                yOffset = i;
-                break;
-            } else if (!world
-                    .isAirBlock(startX - i * plane.offsetX, startY - i * plane.offsetY, startZ - i * plane.offsetZ))
-                return null;
+        if (xSize == 0 || ySize == 0 || yOffset == 0 || ySize > PortalHelper.MAXIMUM_PORTAL_SIZE) {
+            return null;
         }
-
-        if (xSize == 0 || ySize == 0 || ySize > MAX_SIZE) return null;
 
         PortalStructure structure = new PortalStructure(xSize, ySize, yOffset, startDir, plane);
+        if (structure.checkFrameIsValid(world, x, y, z) && structure.scanPortal(world, x, y, z, false, false)) {
+            return structure;
+        }
+        return null;
 
-        if (!structure.checkFrameIsValid(world, x, y, z) || !structure.scanPortal(world, x, y, z, false, false))
-            return null;
+    }
 
-        return structure;
+    private static int findDistanceToFrame(World world, int startX, int startY, int startZ, ForgeDirection direction) {
+        for (int distance = 1; distance <= PortalHelper.MAXIMUM_PORTAL_SIZE; distance++) {
+            int targetX = startX + direction.offsetX * distance;
+            int targetY = startY + direction.offsetY * distance;
+            int targetZ = startZ + direction.offsetZ * distance;
+            Block block = world.getBlock(targetX, targetY, targetZ);
+            if (isFrame(block)) {
+                return distance;
+            }
+            if (!world.isAirBlock(targetX, targetY, targetZ)) {
+                return 0;
+            }
+        }
+        return 0;
     }
 
     public static class PortalStructure {
@@ -128,77 +110,68 @@ public class PortalHelper {
         }
 
         public boolean checkFrameIsValid(World world, int x, int y, int z) {
-
-            int startX = x + startDir.offsetX;
-            int startY = y + startDir.offsetY;
-            int startZ = z + startDir.offsetZ;
-
-            // Check structure for y size
-            for (int y1 = 1; y1 <= ySize; y1++) {
-                int y2 = y1 - yOffset;
-
-                int inX = startX + y2 * plane.offsetX - startDir.offsetX;
-                int inY = startY + y2 * plane.offsetY - startDir.offsetY;
-                int inZ = startZ + y2 * plane.offsetZ - startDir.offsetZ;
-
-                int outX = startX + y2 * plane.offsetX + (xSize) * startDir.offsetX;
-                int outY = startY + y2 * plane.offsetY + (xSize) * startDir.offsetY;
-                int outZ = startZ + y2 * plane.offsetZ + (xSize) * startDir.offsetZ;
-
-                if (!isFrame(world.getBlock(inX, inY, inZ)) && !(inX == x && inY == y && inZ == z)) return false;
-                if (!isFrame(world.getBlock(outX, outY, outZ))) return false;
+            for (int xDistance = 1; xDistance <= xSize; xDistance++) {
+                if (isFrameMissing(world, x, y, z, xDistance, -yOffset)
+                        || isFrameMissing(world, x, y, z, xDistance, ySize - yOffset + 1)) {
+                    return false;
+                }
             }
-
-            // Check structure for x size
-            for (int x1 = 0; x1 < xSize; x1++) {
-                int upX = startX + x1 * startDir.offsetX - yOffset * plane.offsetX;
-                int upY = startY + x1 * startDir.offsetY - yOffset * plane.offsetY;
-                int upZ = startZ + x1 * startDir.offsetZ - yOffset * plane.offsetZ;
-
-                int downX = startX + x1 * startDir.offsetX + (ySize - yOffset + 1) * plane.offsetX;
-                int downY = startY + x1 * startDir.offsetY + (ySize - yOffset + 1) * plane.offsetY;
-                int downZ = startZ + x1 * startDir.offsetZ + (ySize - yOffset + 1) * plane.offsetZ;
-
-                if (!isFrame(world.getBlock(upX, upY, upZ))) return false;
-                if (!isFrame(world.getBlock(downX, downY, downZ))) return false;
+            for (int yDistance = 1 - yOffset; yDistance <= ySize - yOffset; yDistance++) {
+                if (yDistance != 0 && isFrameMissing(world, x, y, z, 0, yDistance)
+                        || isFrameMissing(world, x, y, z, xSize + 1, yDistance)) {
+                    return false;
+                }
             }
-
             return true;
+        }
+
+        private boolean isFrameMissing(World world, int x, int y, int z, int xDistance, int yDistance) {
+            int targetX = x + startDir.offsetX * xDistance + plane.offsetX * yDistance;
+            int targetY = y + startDir.offsetY * xDistance + plane.offsetY * yDistance;
+            int targetZ = z + startDir.offsetZ * xDistance + plane.offsetZ * yDistance;
+            return !isFrame(world.getBlock(targetX, targetY, targetZ));
         }
 
         public boolean scanPortal(World world, int x, int y, int z, boolean setPortalBlocks,
                 boolean checkPortalBlocks) {
-            int startX = x + startDir.offsetX;
-            int startY = y + startDir.offsetY;
-            int startZ = z + startDir.offsetZ;
+            TileEntity tile = world.getTileEntity(x, y, z);
+            if (!(tile instanceof TileDislocatorReceptacle)) {
+                return false;
+            }
+            TileDislocatorReceptacle receptacle = (TileDislocatorReceptacle) tile;
+            if (setPortalBlocks) {
+                receptacle.updating = true;
+            }
 
-            TileDislocatorReceptacle receptacle = (TileDislocatorReceptacle) world.getTileEntity(x, y, z);
-            if (receptacle == null) return false;
-            if (setPortalBlocks) receptacle.updating = true;
-
-            for (int x1 = 0; x1 < xSize; x1++) {
-                for (int y1 = 1; y1 <= ySize; y1++) {
-                    int y2 = y1 - yOffset;
-                    int X = (startX + x1 * startDir.offsetX) + y2 * plane.offsetX;
-                    int Y = (startY + x1 * startDir.offsetY) + y2 * plane.offsetY;
-                    int Z = (startZ + x1 * startDir.offsetZ) + y2 * plane.offsetZ;
-
-                    Block block = world.getBlock(X, Y, Z);
+            for (int xDistance = 1; xDistance <= xSize; xDistance++) {
+                for (int yDistance = 1 - yOffset; yDistance <= ySize - yOffset; yDistance++) {
+                    int targetX = x + xDistance * startDir.offsetX + yDistance * plane.offsetX;
+                    int targetY = y + xDistance * startDir.offsetY + yDistance * plane.offsetY;
+                    int targetZ = z + xDistance * startDir.offsetZ + yDistance * plane.offsetZ;
+                    Block block = world.getBlock(targetX, targetY, targetZ);
 
                     if (checkPortalBlocks) {
-                        if (!isPortal(block)) return false;
+                        if (!isPortal(block)) {
+                            return false;
+                        }
                     } else if (setPortalBlocks) {
-                        world.setBlock(X, Y, Z, ModBlocks.portal);
-                        Chunk chunk = world.getChunkFromBlockCoords(X, Z);
-                        TilePortalBlock tile = (TilePortalBlock) chunk.func_150806_e(X & 15, Y, Z & 15);
-                        tile.masterX = x;
-                        tile.masterY = y;
-                        tile.masterZ = z;
-                    } else if (!world.isAirBlock(X, Y, Z)) return false;
+                        world.setBlock(targetX, targetY, targetZ, ModBlocks.portal);
+                        tile = world.getTileEntity(targetX, targetY, targetZ);
+                        if (tile instanceof TilePortalBlock) {
+                            TilePortalBlock portal = (TilePortalBlock) tile;
+                            portal.masterX = x;
+                            portal.masterY = y;
+                            portal.masterZ = z;
+                        }
+                    } else if (!world.isAirBlock(targetX, targetY, targetZ)) {
+                        return false;
+                    }
                 }
             }
 
-            if (setPortalBlocks) receptacle.updating = false;
+            if (setPortalBlocks) {
+                receptacle.updating = false;
+            }
 
             return true;
         }

--- a/src/main/resources/assets/draconicevolution/lang/en_US.lang
+++ b/src/main/resources/assets/draconicevolution/lang/en_US.lang
@@ -527,6 +527,44 @@ gui.de.genRate.name=Generation Rate
 gui.de.fieldInputRate.name=Field Input Rate
 gui.de.fuelConversion.name=Fuel Conversion Rate
 
+gui.de.particleGenerator.random.name=Random:
+gui.de.particleGenerator.red.name=Red:
+gui.de.particleGenerator.green.name=Green:
+gui.de.particleGenerator.blue.name=Blue:
+gui.de.particleGenerator.motionX.name=Motion X:
+gui.de.particleGenerator.motionY.name=Motion Y:
+gui.de.particleGenerator.motionZ.name=Motion Z:
+gui.de.particleGenerator.scale.name=Scale:
+gui.de.particleGenerator.life.name=Life (T):
+gui.de.particleGenerator.spawnX.name=Spawn X:
+gui.de.particleGenerator.spawnY.name=Spawn Y:
+gui.de.particleGenerator.spawnZ.name=Spawn Z:
+gui.de.particleGenerator.delay.name=Delay:
+gui.de.particleGenerator.fade.name=Fade:
+gui.de.particleGenerator.gravity.name=Gravity:
+gui.de.particleGenerator.pitch.name=Pitch:
+gui.de.particleGenerator.yaw.name=Yaw:
+gui.de.particleGenerator.rotation.name=Rotation:
+gui.de.particleGenerator.length.name=Length:
+
+gui.de.particleGenerator.info.name=i
+gui.de.particleGenerator.back.name=Back
+gui.de.particleGenerator.blockCollision.name=Block Collision: %s
+gui.de.particleGenerator.particleSelected.name=Particle Selected: %d
+gui.de.particleGenerator.enabled.name=Enabled: %s
+gui.de.particleGenerator.renderCore.name=Render Core: %s
+gui.de.particleGenerator.saveSettings.name=Take note of values
+
+gui.de.particleGenerator.info.1=  The Particle Generator is a decorative device that allows you to create your own custom particle effects.\n  It is fairly easy you use this device you simply adjust the fields (variables) in the interface to change how the generated particles look and behave.\n  This block is a work in progress and new features and particles are likely to be added in future versions.\n  The following is a list of all of the fields in the interface and what they do.
+gui.de.particleGenerator.info.2=  The first thing to note is that most fields have a random modifier which will add a random number between 0 and whatever max (or min) value you give it to the field.\n  - The first 3 fields (Red, Green & Blue) control the colour of the particle. Most people should be familiar with this colour system if not google RGB colours. Note: the max value for each colour can not go higher then 255 so the colour field limits the random modifier e.g. if the colour field is set to 255 and the random modifier is set to 20 the result will always be 255.
+gui.de.particleGenerator.info.3=  - The next 3 fields (Motion X, Y & Z) control the direction and speed of the particle.\n  - The "Life" field sets how long (in ticks) before the particle despawns.\n  - The "Scale" field sets the size of the particle.\n  - The next 3 fields (Spawn X, Y & Z) Sets the spawn location of the particle (relative to the location of the particle generator).
+gui.de.particleGenerator.info.4=  - The "Delay" field sets the delay (in ticks) between each particle spawn e.g. 1=20/s, 20=1/s, 100=1/5s.\n  - The "Fade" field sets how long (in ticks) it takes the particle to fade out of existance. Note: This adds to the life of the particle.\n  - The "Gravity" field sets how the particle is affected by gravity.\n  - "Block Collision" Toggles weather or not the particle will collide with blocks.\n  - "Particle Selected" switches between the different particles available.
+gui.de.particleGenerator.info.5.title=Redstone Control\n\n
+gui.de.particleGenerator.info.5=  By default a redstone signal is required for the generator to run.\n  However if you shift right click the generator with an empty hand it will switch to inverted mode.\n  The redstone mode is indicated by the 8 cubes at the corners of the block.
+gui.de.particleGenerator.info.6.title=Computer Control\n\n
+gui.de.particleGenerator.info.6=  The Generator can be controlled via a computer.\n  It exposes a relatively straight forward API:\n\n  setGeneratorProperty(property, value)\n  getGeneratorState()\n  resetGeneratorState()
+gui.de.particleGenerator.info.7=  Generator state is obtained as a whole from getGeneratorState, whereas properties are modified one at a time using setGeneratorProperty. Property names are strings and mostly correspond to button labels in the GUI.
+
 gui.de.insert.txt=Insert
 gui.de.extract.txt=Extract
 gui.de.fuel.txt=Fuel

--- a/src/main/resources/assets/draconicevolution/lang/en_US.lang
+++ b/src/main/resources/assets/draconicevolution/lang/en_US.lang
@@ -382,6 +382,7 @@ achievement.draconicevolution.manual=Knowledge to the Max!
 achievement.draconicevolution.manual.desc=Craft the Draconic Tablet
 
 //InfoHelper ----------------------------------------------------------------------------------------------------------------------------------------
+info.de.tier.txt=Tier
 info.de.charge.txt=Charge
 info.de.hold.txt=Hold
 info.de.shift.txt=Shift

--- a/src/main/resources/assets/draconicevolution/lang/en_US.lang
+++ b/src/main/resources/assets/draconicevolution/lang/en_US.lang
@@ -554,6 +554,7 @@ gui.de.particleGenerator.info.title=Information
 gui.de.particleGenerator.hold.name=Hold:
 gui.de.particleGenerator.info.name=i
 gui.de.particleGenerator.back.name=Back
+gui.de.particleGenerator.page.name=Page: %d
 gui.de.particleGenerator.blockCollision.name=Block Collision: %s
 gui.de.particleGenerator.particleSelected.name=Particle Selected: %d
 gui.de.particleGenerator.enabled.name=Enabled: %s

--- a/src/main/resources/assets/draconicevolution/lang/en_US.lang
+++ b/src/main/resources/assets/draconicevolution/lang/en_US.lang
@@ -547,6 +547,11 @@ gui.de.particleGenerator.yaw.name=Yaw:
 gui.de.particleGenerator.rotation.name=Rotation:
 gui.de.particleGenerator.length.name=Length:
 
+gui.de.particleGenerator.main.title=Particle Generator
+gui.de.particleGenerator.beam.title=Beam Generator
+gui.de.particleGenerator.info.title=Information
+
+gui.de.particleGenerator.hold.name=Hold:
 gui.de.particleGenerator.info.name=i
 gui.de.particleGenerator.back.name=Back
 gui.de.particleGenerator.blockCollision.name=Block Collision: %s


### PR DESCRIPTION
This PR aims to clean up code of multiblocks (and some related things).

### Summary

* Removed countless unnecessary calls of `world.getTileEntity` (Original code makes 3+ calls to get just one TileEntity).
* Removed unnecessary updates of neighbors of neighbor blocks (Yes, neighbors of neighbors).
* Reduced amount of duplicate code.
* Removed stale commented code occurrences.
* Simplified Energy Core structure check.
Removed most repeated checks of the same block.
* Simplified Reactor structure check.
Now Draconium Reactor doesn't attempt to rebuild on every tick with open UI.
* Fixed fuel and output dupe with Draconium Reactor.
* Now sided TileEntities (mainly Reactor parts) use ForgeDirection instead of integers.
