### PR TITLE
Replace all references of blockType with getBlockType to fix NPE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1505,3 +1505,22 @@ def getSecondaryArtifacts() {
     if (apiPackage) secondaryArtifacts += [apiJar]
     return secondaryArtifacts
 }
+
+def getURL(String main, String fallback) {
+    return pingURL(main, 10000) ? main : fallback
+}
+
+// credit: https://stackoverflow.com/a/3584332
+def pingURL(String url, int timeout) {
+    url = url.replaceFirst("^https", "http") // Otherwise an exception may be thrown on invalid SSL certificates.
+    try {
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection()
+        connection.setConnectTimeout(timeout)
+        connection.setReadTimeout(timeout)
+        connection.setRequestMethod("HEAD")
+        int responseCode = connection.getResponseCode()
+        return 200 <= responseCode && responseCode <= 399
+    } catch (IOException ignored) {
+        return false
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -546,15 +546,10 @@ repositories {
         }
         maven {
             name = "ic2"
-            url = "https://maven.ic2.player.to/"
-            metadataSources {
-                mavenPom()
-                artifact()
+            url = getURL("https://maven.ic2.player.to/", "https://maven2.ic2.player.to/")
+            content {
+                includeGroup "net.industrial-craft"
             }
-        }
-        maven {
-            name = "ic2-mirror"
-            url = "https://maven2.ic2.player.to/"
             metadataSources {
                 mavenPom()
                 artifact()

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TileCKeyStone.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TileCKeyStone.java
@@ -181,6 +181,6 @@ public class TileCKeyStone extends TileEntity {
 
     public void updateBlocks() {
         worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, blockType);
+        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, getBlockType());
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetector.java
@@ -63,13 +63,13 @@ public class TilePlayerDetector extends TileEntity {
 
     private void updateBlocks() {
         worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, blockType);
+        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, getBlockType());
         for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
             worldObj.notifyBlocksOfNeighborChange(
                     xCoord + direction.offsetX,
                     yCoord + direction.offsetY,
                     zCoord + direction.offsetZ,
-                    blockType,
+                    getBlockType(),
                     direction.getOpposite().ordinal());
         }
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetectorAdvanced.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlayerDetectorAdvanced.java
@@ -96,13 +96,13 @@ public class TilePlayerDetectorAdvanced extends TileEntity implements IInventory
 
     private void updateBlocks() {
         worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
-        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, blockType);
+        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, getBlockType());
         for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
             worldObj.notifyBlocksOfNeighborChange(
                     xCoord + direction.offsetX,
                     yCoord + direction.offsetY,
                     zCoord + direction.offsetZ,
-                    blockType,
+                    getBlockType(),
                     direction.getOpposite().ordinal());
         }
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileDislocatorReceptacle.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileDislocatorReceptacle.java
@@ -60,7 +60,7 @@ public class TileDislocatorReceptacle extends TileEntity implements IInventory {
         }
         if (structure == null) {
             isActive = false;
-            worldObj.notifyBlockChange(xCoord, yCoord, zCoord, blockType);
+            worldObj.notifyBlockChange(xCoord, yCoord, zCoord, getBlockType());
             worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
             return;
         }
@@ -80,7 +80,7 @@ public class TileDislocatorReceptacle extends TileEntity implements IInventory {
             }
         }
         if (isActive != isActiveBeforeUpdate) {
-            worldObj.notifyBlockChange(xCoord, yCoord, zCoord, blockType);
+            worldObj.notifyBlockChange(xCoord, yCoord, zCoord, getBlockType());
             worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
         }
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/TileEnergyPylon.java
@@ -65,7 +65,7 @@ public class TileEnergyPylon extends TileObjectSync implements IEnergyHandler, I
         if (tick % 20 == 0) {
             int comparatorOut = (int) (getEnergyStored() / getMaxEnergyStored() * 15D);
             if (comparatorOut != lastCheckCompOverride) {
-                worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, blockType);
+                worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, getBlockType());
                 lastCheckCompOverride = comparatorOut;
             }
         }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorEnergyInjector.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorEnergyInjector.java
@@ -46,7 +46,7 @@ public class TileReactorEnergyInjector extends TileEntity implements IReactorPar
             int comparatorOutput = core.getComparatorOutput(comparatorMode);
             if (comparatorOutput != comparatorOutputCache) {
                 comparatorOutputCache = comparatorOutput;
-                worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, blockType);
+                worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, getBlockType());
             }
         }
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorStabilizer.java
@@ -64,7 +64,7 @@ public class TileReactorStabilizer extends TileEntity implements IReactorPart, I
             int comparatorOutput = core.getComparatorOutput(comparatorMode);
             if (comparatorOutput != comparatorOutputCache) {
                 comparatorOutputCache = comparatorOutput;
-                worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, blockType);
+                worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, getBlockType());
             }
         }
     }


### PR DESCRIPTION
Context: We have been experiencing multiple crashes with Maliss Doors and Advanced Detectors.  After looking through PR #39, I discovered that the PR code was changed to use the blockType variable instead of getting the TE from the world.  However, as we discovered, this variable is null and according to the vanilla code, it is not set until getBlockType() is called.

As a result, calls to notifyBlocksOfNeighborChange() pass a null block and cause a crash downstream with MalisDoors.
https://github.com/GTNewHorizons/MalisisDoors/blob/master/src/main/java/net/malisis/doors/door/block/Door.java#L254

To fix, I replaced calls to `blockType` with the method wrapper since that has a null check and if the block object is null, it fetches the object from the world.