### PR TITLE
Fix memory leak

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/client/render/item/RenderMobSoul.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/item/RenderMobSoul.java
@@ -15,11 +15,10 @@ import com.brandon3055.draconicevolution.common.utills.LogHelper;
 
 public class RenderMobSoul implements IItemRenderer {
 
-    private Minecraft mc;
-    private Entity randomEntity = null;
-    private String[] randomEntitys = new String[] { "Pig", "Sheep", "Enderman", "Zombie", "Creeper", "Cow", "Chicken",
-            "Ozelot", "Witch", "Wolf", "MushroomCow", "Squid", "EntityHorse", "Spider", "Skeleton", "Blaze", "Bat",
-            "Villager", "Silverfish" };
+    private final Minecraft mc;
+    private final String[] randomEntities = new String[] { "Pig", "Sheep", "Enderman", "Zombie", "Creeper", "Cow",
+            "Chicken", "Ozelot", "Witch", "Wolf", "MushroomCow", "Squid", "EntityHorse", "Spider", "Skeleton", "Blaze",
+            "Bat", "Villager", "Silverfish" };
 
     public RenderMobSoul() {
         this.mc = Minecraft.getMinecraft();
@@ -40,8 +39,8 @@ public class RenderMobSoul implements IItemRenderer {
     @Override
     public void renderItem(ItemRenderType type, ItemStack item, Object... data) {
         Entity mob = EntityList.createEntityByName(ItemNBTHelper.getString(item, "Name", "Pig"), mc.theWorld);
-        randomEntity = EntityList
-                .createEntityByName(randomEntitys[(int) ((Minecraft.getSystemTime() / 1000) % 18)], mc.theWorld);
+        Entity randomEntity = EntityList
+                .createEntityByName(randomEntities[(int) ((Minecraft.getSystemTime() / 1000) % 18)], mc.theWorld);
         if (ItemNBTHelper.getString(item, "Name", "Pig").equals("Any")) mob = randomEntity;
         if (mob instanceof EntitySkeleton)
             ((EntitySkeleton) mob).setSkeletonType(ItemNBTHelper.getInteger(item, "SkeletonType", 0));


### PR DESCRIPTION
Converted the `randomEntity` field into a local to prevent it from leaking the world object. 

![image](https://github.com/GTNewHorizons/Draconic-Evolution/assets/45769595/500e20e8-8266-4ffb-a374-2e82ec8b68c4)
