### PR TITLE
Add a dimension whitelist setting for draconic ore

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
@@ -196,7 +196,7 @@ public class ConfigHandler {
                     "Add the id's of dimensions you do not want draconium ore to spawn in").getIntList();
             oreGenDimensionWhitelist = config.get(
                     Configuration.CATEGORY_GENERAL,
-                    "Ore gen dimension blacklist",
+                    "Ore gen dimension whitelist",
                     new int[0],
                     "Add the id's of dimensions you do want draconium ore to spawn in (if empty, uses only the blacklist)")
                     .getIntList();

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
@@ -34,6 +34,7 @@ public class ConfigHandler {
     public static boolean sumonRitualAccelerated;
     public static int[] dragonEggSpawnLocation;
     public static int[] oreGenDimentionBlacklist;
+    public static int[] oreGenDimensionWhitelist;
     public static int[] hudSettings;
     private static String[] disabledBlocksItems;
     public static List<String> disabledNamesList = new ArrayList<String>();
@@ -193,6 +194,12 @@ public class ConfigHandler {
                     "Ore gen dimension blacklist",
                     new int[0],
                     "Add the id's of dimensions you do not want draconium ore to spawn in").getIntList();
+            oreGenDimensionWhitelist = config.get(
+                    Configuration.CATEGORY_GENERAL,
+                    "Ore gen dimension blacklist",
+                    new int[0],
+                    "Add the id's of dimensions you do want draconium ore to spawn in (if empty, uses only the blacklist)")
+                    .getIntList();
             disabledBlocksItems = config.getStringList(
                     "Disabled Blocks & Items",
                     Configuration.CATEGORY_GENERAL,

--- a/src/main/java/com/brandon3055/draconicevolution/common/world/DraconicWorldGenerator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/world/DraconicWorldGenerator.java
@@ -33,8 +33,22 @@ public class DraconicWorldGenerator implements IWorldGenerator {
                 generateNether(random, chunkX * 16, chunkZ * 16, world);
                 break;
             default:
-                for (Integer i : ConfigHandler.oreGenDimentionBlacklist) {
-                    if (i == world.provider.dimensionId) return;
+                if (ConfigHandler.oreGenDimensionWhitelist.length > 0) {
+                    boolean isWhitelisted = false;
+                    for (Integer dim : ConfigHandler.oreGenDimensionWhitelist) {
+                        if (dim == world.provider.dimensionId) {
+                            isWhitelisted = true;
+                            break;
+                        }
+                    }
+                    if (!isWhitelisted) {
+                        return;
+                    }
+                }
+                for (Integer dim : ConfigHandler.oreGenDimentionBlacklist) {
+                    if (dim == world.provider.dimensionId) {
+                        return;
+                    }
                 }
                 addOreSpawn(ModBlocks.draconiumOre, world, random, chunkX * 16, chunkZ * 16, 3, 4, 2, 2, 8);
                 break;


### PR DESCRIPTION
Apart from the blacklist, adds a whitelist which will let us block ores from spawning in all dimensions except the ones listed. This can be used to fix the issue of draconium ore spawning in personal dimensions with a simple config change.