### PR TITLE
Magnet client-server desync fix.

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/common/network/MagnetToggleAckPacket.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/network/MagnetToggleAckPacket.java
@@ -46,9 +46,9 @@ public final class MagnetToggleAckPacket implements IMessage {
             Optional<ItemStack> magnetOptional = InventoryUtils.getItemInAnyPlayerInventory(player, Magnet.class);
 
             if (magnetOptional.isPresent()) {
-                ItemStack itemStack = magnetOptional.get().copy();
+                ItemStack itemStack = magnetOptional.get();
                 Magnet.setStatus(itemStack, message.status);
-                ClientEventHandler.statusDisplayManager.startDrawing(itemStack);
+                ClientEventHandler.statusDisplayManager.startDrawing(itemStack.copy());
             }
 
             return null;


### PR DESCRIPTION
While toggling magnet - item stack wasn't effectively updated in MagnetToggleAckPacket.Handler (only copy - i assume needed for GUI notification purpose - was synced with current state).