### PR TITLE
Render Placed Item Fix

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTilePlacedItem.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTilePlacedItem.java
@@ -72,12 +72,11 @@ public class RenderTilePlacedItem extends TileEntitySpecialRenderer {
             GL11.glTranslatef(0.0F, -0.18F, 0.0F);
         }
 
-        GL11.glEnable(GL11.GL_BLEND);
-        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        GL11.glPushAttrib(GL11.GL_COLOR_BUFFER_BIT);
         RenderItem.renderInFrame = true;
         RenderManager.instance.renderEntityWithPosYaw(itemEntity, 0.0D, 0.0D, 0.0D, 0.0F, 0.0F);
         RenderItem.renderInFrame = false;
-        GL11.glDisable(GL11.GL_BLEND);
+        GL11.glPopAttrib();
     }
 
     private void metaAdjustItemTool(int meta) {


### PR DESCRIPTION
I've had chests become semi-transparent when they were near an enchanted placed object.

I seem to have solved it without crashing by copying the changes made in this post.

[link](https://github.com/SlimeKnights/TinkersConstruct/commit/08af51fab375584ca2b68f12adf36eec691d3e1c)

 I'm not an expert in programming, I can't do more than that.