### PR TITLE
Remove RenderHelper.disableStandardItemLighting() from RenderParticleGen

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/client/render/block/RenderParticleGen.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/block/RenderParticleGen.java
@@ -1,6 +1,5 @@
 package com.brandon3055.draconicevolution.client.render.block;
 
-import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -34,7 +33,6 @@ public class RenderParticleGen implements IItemRenderer {
         GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
         if (type == IItemRenderer.ItemRenderType.ENTITY) GL11.glTranslatef(-0.5F, 0.0F, -0.5F);
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tile, 0.0D, 0.0D, 0.0D, 0.0F);
-        RenderHelper.disableStandardItemLighting();
         GL11.glPopAttrib();
         GL11.glPopMatrix();
     }


### PR DESCRIPTION
Was causing items lighting to be incorrect

Before
![image](https://github.com/user-attachments/assets/22af3faa-e503-45c1-bf91-b9b5e06dcba8)

After
![image](https://github.com/user-attachments/assets/6a68a59d-e835-4e56-988b-0b5f30d789fc)
