### PR TITLE
Prevent creating a placed item tile entity if the associated item is null

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlacedItem.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/TilePlacedItem.java
@@ -6,6 +6,7 @@ import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.Vec3;
 
 import com.brandon3055.draconicevolution.common.ModBlocks;
 
@@ -52,7 +53,9 @@ public class TilePlacedItem extends TileEntity {
         super.writeToNBT(compound);
         NBTTagCompound[] tag = new NBTTagCompound[1];
         tag[0] = new NBTTagCompound();
-        if (stack != null) tag[0] = stack.writeToNBT(tag[0]);
+        if (stack != null) {
+            stack.writeToNBT(tag[0]);
+        }
         compound.setTag("Item" + 0, tag[0]);
         compound.setFloat("Rotation", rotation);
     }
@@ -63,6 +66,12 @@ public class TilePlacedItem extends TileEntity {
         NBTTagCompound[] tag = new NBTTagCompound[1];
         tag[0] = compound.getCompoundTag("Item" + 0);
         stack = ItemStack.loadItemStackFromNBT(tag[0]);
+        if (stack == null) {
+            throw new NullPointerException(
+                    "Cannot load the Placed Item at location "
+                            + Vec3.createVectorHelper(this.xCoord, this.yCoord, this.zCoord)
+                            + " because the associated item is null!");
+        }
         rotation = compound.getFloat("Rotation");
     }
 }


### PR DESCRIPTION
Doing this to remove the PlacedItem in the world if the associated item got removed from the game, for example when you remove a mod

I am not familiar with tile entities but from looking at the vanilla code it seems that throwing an exception in the readFromNBT method is the right way to not load a certain tile entity