### PR TITLE
Fix gregtech loader checks, and change Optional hazmat decorators to check if gtnh's gt5 is loaded

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/common/items/armor/DraconicArmor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/armor/DraconicArmor.java
@@ -71,7 +71,7 @@ import thaumcraft.api.nodes.IRevealer;
                 @Interface(iface = "thaumcraft.api.nodes.IRevealer", modid = "Thaumcraft"),
                 @Interface(iface = "forestry.api.apiculture.IArmorApiarist", modid = "Forestry"),
                 @Interface(iface = "forestry.api.core.IArmorNaturalist", modid = "Forestry"),
-                @Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "dreamcraft") })
+                @Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtechNH") })
 public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigurableItem, IInventoryTool, IGoggles,
         IVisDiscountGear, IRevealer, IUpgradableItem, ICustomArmor, IArmorNaturalist, IArmorApiarist, IHazardProtector {
 
@@ -657,7 +657,7 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
     }
 
     @Override
-    @Method(modid = "dreamcraft")
+    @Method(modid = "gregtechNH")
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return IConfigurableItem.ProfileHelper.getBoolean(itemStack, ModHelper.getHazmatArmorConfigKey(hazard), true);
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/armor/DraconicArmor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/armor/DraconicArmor.java
@@ -71,7 +71,7 @@ import thaumcraft.api.nodes.IRevealer;
                 @Interface(iface = "thaumcraft.api.nodes.IRevealer", modid = "Thaumcraft"),
                 @Interface(iface = "forestry.api.apiculture.IArmorApiarist", modid = "Forestry"),
                 @Interface(iface = "forestry.api.core.IArmorNaturalist", modid = "Forestry"),
-                @Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtech") })
+                @Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "dreamcraft") })
 public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigurableItem, IInventoryTool, IGoggles,
         IVisDiscountGear, IRevealer, IUpgradableItem, ICustomArmor, IArmorNaturalist, IArmorApiarist, IHazardProtector {
 
@@ -377,7 +377,7 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
                 list.add(new ItemConfigField(References.BOOLEAN_ID, slot, "ApiaristArmor").readFromItem(stack, true));
             }
         }
-        if (Loader.isModLoaded("gregtech")) {
+        if (Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi")) {
             for (Hazard value : Hazard.values()) {
                 list.add(
                         new ItemConfigField(References.BOOLEAN_ID, slot, ModHelper.getHazmatArmorConfigKey(value))
@@ -657,7 +657,7 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
     }
 
     @Override
-    @Method(modid = "gregtech")
+    @Method(modid = "dreamcraft")
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return IConfigurableItem.ProfileHelper.getBoolean(itemStack, ModHelper.getHazmatArmorConfigKey(hazard), true);
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/armor/DraconicArmor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/armor/DraconicArmor.java
@@ -71,7 +71,7 @@ import thaumcraft.api.nodes.IRevealer;
                 @Interface(iface = "thaumcraft.api.nodes.IRevealer", modid = "Thaumcraft"),
                 @Interface(iface = "forestry.api.apiculture.IArmorApiarist", modid = "Forestry"),
                 @Interface(iface = "forestry.api.core.IArmorNaturalist", modid = "Forestry"),
-                @Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtechNH") })
+                @Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtech_nh") })
 public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigurableItem, IInventoryTool, IGoggles,
         IVisDiscountGear, IRevealer, IUpgradableItem, ICustomArmor, IArmorNaturalist, IArmorApiarist, IHazardProtector {
 
@@ -657,7 +657,7 @@ public class DraconicArmor extends ItemArmor implements ISpecialArmor, IConfigur
     }
 
     @Override
-    @Method(modid = "gregtechNH")
+    @Method(modid = "gregtech_nh")
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return IConfigurableItem.ProfileHelper.getBoolean(itemStack, ModHelper.getHazmatArmorConfigKey(hazard), true);
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/armor/WyvernArmor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/armor/WyvernArmor.java
@@ -59,7 +59,7 @@ import thaumcraft.api.aspects.Aspect;
 @Optional.InterfaceList(
         value = { @Optional.Interface(iface = "thaumcraft.api.IVisDiscountGear", modid = "Thaumcraft"),
                 @Optional.Interface(iface = "thaumcraft.api.IWarpingGear", modid = "Thaumcraft"),
-                @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtechNH") })
+                @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtech_nh") })
 public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurableItem, IInventoryTool, IUpgradableItem,
         ICustomArmor, IVisDiscountGear, IWarpingGear, IHazardProtector {
 
@@ -513,7 +513,7 @@ public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurab
     }
 
     @Override
-    @Optional.Method(modid = "gregtechNH")
+    @Optional.Method(modid = "gregtech_nh")
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return IConfigurableItem.ProfileHelper.getBoolean(itemStack, ModHelper.getHazmatArmorConfigKey(hazard), true);
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/armor/WyvernArmor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/armor/WyvernArmor.java
@@ -59,7 +59,7 @@ import thaumcraft.api.aspects.Aspect;
 @Optional.InterfaceList(
         value = { @Optional.Interface(iface = "thaumcraft.api.IVisDiscountGear", modid = "Thaumcraft"),
                 @Optional.Interface(iface = "thaumcraft.api.IWarpingGear", modid = "Thaumcraft"),
-                @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtech") })
+                @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "dreamcraft") })
 public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurableItem, IInventoryTool, IUpgradableItem,
         ICustomArmor, IVisDiscountGear, IWarpingGear, IHazardProtector {
 
@@ -273,7 +273,7 @@ public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurab
                             .readFromItem(stack, 0f).setModifier("PLUSPERCENT"));
             list.add(new ItemConfigField(References.BOOLEAN_ID, slot, "ArmorSprintOnly").readFromItem(stack, false));
         }
-        if (Loader.isModLoaded("gregtech")) {
+        if (Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi")) {
             for (Hazard value : Hazard.values()) {
                 list.add(
                         new ItemConfigField(References.BOOLEAN_ID, slot, ModHelper.getHazmatArmorConfigKey(value))
@@ -513,7 +513,7 @@ public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurab
     }
 
     @Override
-    @Optional.Method(modid = "gregtech")
+    @Optional.Method(modid = "dreamcraft")
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return IConfigurableItem.ProfileHelper.getBoolean(itemStack, ModHelper.getHazmatArmorConfigKey(hazard), true);
     }

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/armor/WyvernArmor.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/armor/WyvernArmor.java
@@ -59,7 +59,7 @@ import thaumcraft.api.aspects.Aspect;
 @Optional.InterfaceList(
         value = { @Optional.Interface(iface = "thaumcraft.api.IVisDiscountGear", modid = "Thaumcraft"),
                 @Optional.Interface(iface = "thaumcraft.api.IWarpingGear", modid = "Thaumcraft"),
-                @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "dreamcraft") })
+                @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtechNH") })
 public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurableItem, IInventoryTool, IUpgradableItem,
         ICustomArmor, IVisDiscountGear, IWarpingGear, IHazardProtector {
 
@@ -513,7 +513,7 @@ public class WyvernArmor extends ItemArmor implements ISpecialArmor, IConfigurab
     }
 
     @Override
-    @Optional.Method(modid = "dreamcraft")
+    @Optional.Method(modid = "gregtechNH")
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return IConfigurableItem.ProfileHelper.getBoolean(itemStack, ModHelper.getHazmatArmorConfigKey(hazard), true);
     }

--- a/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
@@ -38,7 +38,7 @@ public class ModHelper {
         isTConInstalled = Loader.isModLoaded("TConstruct");
         isAvaritiaInstalled = Loader.isModLoaded("Avaritia");
         // isRotaryCraftInstalled = Loader.isModLoaded("RotaryCraft");
-        isGregTechInstalled = Loader.isModLoaded("gregtech");
+        isGregTechInstalled = Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi");
         isBartworkdsInstalled = Loader.isModLoaded("bartworks");
         isAE2Installed = Loader.isModLoaded("appliedenergistics2");
         final String GT_ORE_CLASS = "gregtech.common.blocks.TileEntityOres";
@@ -129,7 +129,7 @@ public class ModHelper {
         return isAE2Installed && AE2FItem.isInstance(item);
     }
 
-    @Optional.Method(modid = "gregtech")
+    @Optional.Method(modid = "dreamcraft")
     public static String getHazmatArmorConfigKey(Hazard hazard) {
         return switch (hazard) {
             case ELECTRICAL -> "HazmatElectrical";

--- a/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
@@ -129,7 +129,7 @@ public class ModHelper {
         return isAE2Installed && AE2FItem.isInstance(item);
     }
 
-    @Optional.Method(modid = "gregtechNH")
+    @Optional.Method(modid = "gregtech_nh")
     public static String getHazmatArmorConfigKey(Hazard hazard) {
         return switch (hazard) {
             case ELECTRICAL -> "HazmatElectrical";

--- a/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
@@ -129,7 +129,7 @@ public class ModHelper {
         return isAE2Installed && AE2FItem.isInstance(item);
     }
 
-    @Optional.Method(modid = "dreamcraft")
+    @Optional.Method(modid = "gregtechNH")
     public static String getHazmatArmorConfigKey(Hazard hazard) {
         return switch (hazard) {
             case ELECTRICAL -> "HazmatElectrical";


### PR DESCRIPTION
This PR has both fixes for gregtech recognition (Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi")) as well as changing Optional decorators as a temp fix to avoid crashes