### PR TITLE
Magnet improvements

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
@@ -111,6 +111,7 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
                             player.posY,
                             player.posZ).expand(range, range, range));
 
+            final boolean skipPlayerCheck = world.playerEntities.size() < 2;
             boolean playSound = false;
 
             for (EntityItem item : items) {
@@ -126,6 +127,12 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
                                         == item.getEntityItem().getItemDamage())) {
                     continue;
                 }
+
+                if (!skipPlayerCheck) {
+                    EntityPlayer closestPlayer = world.getClosestPlayerToEntity(item, range);
+                    if (closestPlayer == null || closestPlayer != player) continue;
+                }
+
                 playSound = true;
 
                 if (item.delayBeforeCanPickup > 0) {
@@ -162,6 +169,10 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
                                 player.posZ).expand(4, 4, 4));
                 for (EntityXPOrb orb : xp) {
                     if (orb.field_70532_c == 0 && orb.isEntityAlive()) {
+                        if (!skipPlayerCheck) {
+                            EntityPlayer closestPlayer = world.getClosestPlayerToEntity(orb, range);
+                            if (closestPlayer == null || closestPlayer != player) continue;
+                        }
                         if (MinecraftForge.EVENT_BUS.post(new PlayerPickupXpEvent(player, orb))) continue;
                         world.playSoundAtEntity(
                                 player,

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
@@ -104,12 +104,12 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
             List<EntityItem> items = world.getEntitiesWithinAABB(
                     EntityItem.class,
                     AxisAlignedBB.getBoundingBox(
-                            entity.posX,
-                            entity.posY,
-                            entity.posZ,
-                            entity.posX,
-                            entity.posY,
-                            entity.posZ).expand(range, range, range));
+                            player.posX,
+                            player.posY,
+                            player.posZ,
+                            player.posX,
+                            player.posY,
+                            player.posZ).expand(range, range, range));
 
             boolean playSound = false;
 
@@ -134,14 +134,17 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
                 item.motionX = 0;
                 item.motionY = 0;
                 item.motionZ = 0;
+                // account for the server/client desync
+                double playerEyesPos = player.posY
+                        + (world.isRemote ? player.getEyeHeight() - player.getDefaultEyeHeight() : player.getEyeHeight());
                 item.setPosition(
-                        entity.posX - 0.2 + (world.rand.nextDouble() * 0.4),
-                        entity.posY - 0.6,
-                        entity.posZ - 0.2 + (world.rand.nextDouble() * 0.4));
+                        player.posX - 0.2 + (world.rand.nextDouble() * 0.4),
+                        playerEyesPos - 0.62,
+                        player.posZ - 0.2 + (world.rand.nextDouble() * 0.4));
             }
             if (playSound && !ConfigHandler.itemDislocatorDisableSound) {
                 world.playSoundAtEntity(
-                        entity,
+                        player,
                         "random.orb",
                         0.1F,
                         0.5F * ((world.rand.nextFloat() - world.rand.nextFloat()) * 0.7F + 2F));
@@ -151,12 +154,12 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
                 List<EntityXPOrb> xp = world.getEntitiesWithinAABB(
                         EntityXPOrb.class,
                         AxisAlignedBB.getBoundingBox(
-                                entity.posX,
-                                entity.posY,
-                                entity.posZ,
-                                entity.posX,
-                                entity.posY,
-                                entity.posZ).expand(4, 4, 4));
+                                player.posX,
+                                player.posY,
+                                player.posZ,
+                                player.posX,
+                                player.posY,
+                                player.posZ).expand(4, 4, 4));
                 for (EntityXPOrb orb : xp) {
                     if (orb.field_70532_c == 0 && orb.isEntityAlive()) {
                         if (MinecraftForge.EVENT_BUS.post(new PlayerPickupXpEvent(player, orb))) continue;

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
@@ -115,6 +115,10 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
 
             final boolean skipPlayerCheck = world.playerEntities.size() < 2;
             boolean playSound = false;
+            // account for the server/client desync
+            double playerEyesPos = player.posY
+                    + (world.isRemote ? player.getEyeHeight() - player.getDefaultEyeHeight()
+                    : player.getEyeHeight());
 
             for (EntityItem item : items) {
                 if (item.getEntityItem() == null || ModHelper.isAE2EntityFloatingItem(item)
@@ -143,10 +147,6 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
                 item.motionX = 0;
                 item.motionY = 0;
                 item.motionZ = 0;
-                // account for the server/client desync
-                double playerEyesPos = player.posY
-                        + (world.isRemote ? player.getEyeHeight() - player.getDefaultEyeHeight()
-                                : player.getEyeHeight());
                 item.setPosition(
                         player.posX - 0.2 + (world.rand.nextDouble() * 0.4),
                         playerEyesPos - 0.62,

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
@@ -89,6 +89,8 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
         return isEnabled(stack);
     }
 
+    // This method uses the same algorithm as the magnet from AE2 Fluid Crafting
+    // if changes are ever made, they should be made on both
     @Override
     public void onUpdate(ItemStack stack, World world, Entity entity, int slot, boolean hotbar) {
         if (entity.ticksExisted % 5 != 0 || !isEnabled(stack)) {
@@ -143,7 +145,8 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
                 item.motionZ = 0;
                 // account for the server/client desync
                 double playerEyesPos = player.posY
-                        + (world.isRemote ? player.getEyeHeight() - player.getDefaultEyeHeight() : player.getEyeHeight());
+                        + (world.isRemote ? player.getEyeHeight() - player.getDefaultEyeHeight()
+                                : player.getEyeHeight());
                 item.setPosition(
                         player.posX - 0.2 + (world.rand.nextDouble() * 0.4),
                         playerEyesPos - 0.62,

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
@@ -117,8 +117,7 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
             boolean playSound = false;
             // account for the server/client desync
             double playerEyesPos = player.posY
-                    + (world.isRemote ? player.getEyeHeight() - player.getDefaultEyeHeight()
-                    : player.getEyeHeight());
+                    + (world.isRemote ? player.getEyeHeight() - player.getDefaultEyeHeight() : player.getEyeHeight());
 
             for (EntityItem item : items) {
                 if (item.getEntityItem() == null || ModHelper.isAE2EntityFloatingItem(item)

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
@@ -166,7 +166,7 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
                                 player.posZ,
                                 player.posX,
                                 player.posY,
-                                player.posZ).expand(4, 4, 4));
+                                player.posZ).expand(range, range, range));
                 for (EntityXPOrb orb : xp) {
                     if (orb.field_70532_c == 0 && orb.isEntityAlive()) {
                         if (!skipPlayerCheck) {


### PR DESCRIPTION
The values of player.posY are different wheter you are on the client or on the server. Therefore when teleporting the items to posY it was spreading the desync to the item positions as well.

Made the magnet not teleport items to you if said item is closer to another player.

Fix magnet not respecting the range when attracting experience.