### PR TITLE
Changes for the ore refactor PR

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,13 +5,13 @@ dependencies {
     api("curse.maven:cofh-lib-220333:2388748")
 
     compileOnly("com.github.GTNewHorizons:ForestryMC:4.10.17:api") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:OpenComputers:1.11.19-GTNH:api") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.7.87-GTNH:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:OpenComputers:1.12.0-GTNH:api") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.8.9-GTNH:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:CodeChickenCore:1.4.7:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:inventory-tweaks:1.7.1:dev") {transitive = false}
-    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.1.14-GTNH:dev') {transitive = false}
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.457:dev") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:GTNHLib:0.6.39:dev") {transitive = false}
+    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.0-GTNH:dev') {transitive = false}
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.31:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:GTNHLib:0.7.0:dev") {transitive = false}
 
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") {transitive = false}
     compileOnly("curse.maven:computercraft-67504:2269339") {transitive = false}

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.42'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.43'
 }
 
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/baseclasses/MiningTool.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/baseclasses/MiningTool.java
@@ -37,7 +37,6 @@ import com.brandon3055.draconicevolution.common.lib.References;
 import com.brandon3055.draconicevolution.common.utills.IConfigurableItem;
 import com.brandon3055.draconicevolution.common.utills.IUpgradableItem;
 import com.brandon3055.draconicevolution.common.utills.ItemConfigField;
-import com.brandon3055.draconicevolution.integration.ModHelper;
 
 /**
  * Created by Brandon on 2/01/2015. Modified by bartimaeusnek on 23/05/2018
@@ -176,11 +175,13 @@ public abstract class MiningTool extends ToolBase implements IUpgradableItem {
                 for (int yPos = y + yOffset - yMin; yPos <= y + yOffset + yMax; yPos++) {
                     for (int zPos = z - zMin; zPos <= z + zMax; zPos++) {
                         TileEntity te = player.worldObj.getTileEntity(xPos, yPos, zPos);
-                        if (te != null && !ModHelper.isGregTechTileEntityOre(te)) {
+                        if (te != null) {
                             if (player.worldObj.isRemote) {
                                 player.addChatComponentMessage(new ChatComponentTranslation("msg.de.baseSafeAOW.txt"));
-                            } else((EntityPlayerMP) player).playerNetServerHandler
-                                    .sendPacket(new S23PacketBlockChange(x, y, z, ((EntityPlayerMP) player).worldObj));
+                            } else {
+                                ((EntityPlayerMP) player).playerNetServerHandler
+                                        .sendPacket(new S23PacketBlockChange(x, y, z, player.worldObj));
+                            }
                             return true;
                         }
                     }

--- a/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
@@ -23,6 +23,7 @@ public class ModHelper {
 
     private static final boolean isTConInstalled;
     private static final boolean isAvaritiaInstalled;
+    private static final boolean isGregTechInstalled;
     private static final boolean isAE2Installed;
 
     public static boolean isGTNHLibLoaded;
@@ -36,6 +37,7 @@ public class ModHelper {
     static {
         isTConInstalled = Loader.isModLoaded("TConstruct");
         isAvaritiaInstalled = Loader.isModLoaded("Avaritia");
+        isGregTechInstalled = Loader.isModLoaded("gregtech_nh");
         isAE2Installed = Loader.isModLoaded("appliedenergistics2");
         isGTNHLibLoaded = Loader.isModLoaded("gtnhlib");
         isHodgepodgeLoaded = Loader.isModLoaded("hodgepodge");
@@ -88,10 +90,6 @@ public class ModHelper {
         }
 
         return event.ammount;
-    }
-
-    public static boolean isGregTechTileEntityOre(TileEntity te) {
-        return isGregTechInstalled && GTores.isInstance(te) || isBartworkdsInstalled && bwores.isInstance(te);
     }
 
     public static boolean isGregTechEnchantmentItem(ItemStack stack) {

--- a/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
@@ -4,7 +4,6 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 
 import com.brandon3055.draconicevolution.common.items.armor.CustomArmorHandler.ArmorSummery;

--- a/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
@@ -3,7 +3,6 @@ package com.brandon3055.draconicevolution.integration;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 
 import com.brandon3055.draconicevolution.common.items.armor.CustomArmorHandler.ArmorSummery;
@@ -21,8 +20,6 @@ public class ModHelper {
 
     private static final boolean isTConInstalled;
     private static final boolean isAvaritiaInstalled;
-    private static final boolean isGregTechInstalled;
-    private static final boolean isBartworkdsInstalled;
     private static final boolean isAE2Installed;
 
     public static boolean isGTNHLibLoaded;
@@ -31,32 +28,17 @@ public class ModHelper {
     private static Item cleaver;
     private static Item avaritiaSword;
 
-    private static Class<?> bwores;
-    private static Class<?> GTores;
     private static Class<?> AE2FItem;
 
     static {
         isTConInstalled = Loader.isModLoaded("TConstruct");
         isAvaritiaInstalled = Loader.isModLoaded("Avaritia");
-        isGregTechInstalled = Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi");
-        isBartworkdsInstalled = Loader.isModLoaded("bartworks");
         isAE2Installed = Loader.isModLoaded("appliedenergistics2");
         isGTNHLibLoaded = Loader.isModLoaded("gtnhlib");
         isHodgepodgeLoaded = Loader.isModLoaded("hodgepodge");
 
-        final String GT_ORE_CLASS = "gregtech.common.blocks.TileEntityOres";
-        final String BW_ORE_CLASS = "bartworks.system.material.BWMetaGeneratedOres";
         final String AE2_FITEM_CLASS = "appeng.entity.EntityFloatingItem";
-        if (isGregTechInstalled) try {
-            GTores = Class.forName(GT_ORE_CLASS);
-        } catch (ClassNotFoundException e) {
-            LogHelper.error("Couldn't reflect class " + GT_ORE_CLASS);
-        }
-        if (isBartworkdsInstalled) try {
-            bwores = Class.forName(BW_ORE_CLASS);
-        } catch (ClassNotFoundException e) {
-            LogHelper.error("Couldn't reflect class " + BW_ORE_CLASS);
-        }
+
         if (isAE2Installed) try {
             AE2FItem = Class.forName(AE2_FITEM_CLASS);
         } catch (ClassNotFoundException e) {
@@ -103,10 +85,6 @@ public class ModHelper {
         }
 
         return event.ammount;
-    }
-
-    public static boolean isGregTechTileEntityOre(TileEntity te) {
-        return isGregTechInstalled && GTores.isInstance(te) || isBartworkdsInstalled && bwores.isInstance(te);
     }
 
     public static boolean isAE2EntityFloatingItem(EntityItem item) {


### PR DESCRIPTION
Removes the GT ore TE check since GT ores don't have tile entities anymore.

loosely depends on: https://github.com/GTNewHorizons/GT5-Unofficial/pull/3662 (doesn't have a hard dependency/need a specific tag order, but they do need to be put in the same release)