### PR TITLE
Block certain GT materials from being disenchanted

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,14 +4,14 @@ dependencies {
     api("com.github.GTNewHorizons:BrandonsCore:1.2.0-GTNH:dev")
     api("curse.maven:cofh-lib-220333:2388748")
 
-    compileOnly("com.github.GTNewHorizons:ForestryMC:4.10.14:api") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:OpenComputers:1.11.16-GTNH:api") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.7.64-GTNH:dev") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:CodeChickenCore:1.4.3:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.10.17:api") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:OpenComputers:1.11.18-GTNH:api") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.7.80-GTNH:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:CodeChickenCore:1.4.7:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:inventory-tweaks:1.7.1:dev") {transitive = false}
-    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.1.9-GTNH:dev') {transitive = false}
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.395:dev") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:GTNHLib:0.6.38:dev") {transitive = false}
+    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.1.13-GTNH:dev') {transitive = false}
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.446:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:GTNHLib:0.6.39:dev") {transitive = false}
 
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") {transitive = false}
     compileOnly("curse.maven:computercraft-67504:2269339") {transitive = false}

--- a/src/main/java/com/brandon3055/draconicevolution/common/container/ContainerDissEnchanter.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/container/ContainerDissEnchanter.java
@@ -12,6 +12,7 @@ import net.minecraft.item.ItemStack;
 import com.brandon3055.brandonscore.common.utills.ItemNBTHelper;
 import com.brandon3055.draconicevolution.common.inventory.SlotOutput;
 import com.brandon3055.draconicevolution.common.tileentities.TileDissEnchanter;
+import com.brandon3055.draconicevolution.integration.ModHelper;
 
 public class ContainerDissEnchanter extends Container {
 
@@ -110,8 +111,9 @@ public class ContainerDissEnchanter extends Container {
 
         @Override
         public boolean isItemValid(ItemStack stack) {
-            return EnchantmentHelper.getEnchantments(stack).size() > 0
-                    || ItemNBTHelper.getInteger(stack, "RepairCost", 0) > 0;
+            return (EnchantmentHelper.getEnchantments(stack).size() > 0
+                    || ItemNBTHelper.getInteger(stack, "RepairCost", 0) > 0)
+                    && (!ModHelper.isGregTechEnchantmentItem(stack));
         }
 
         @Override

--- a/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
@@ -3,6 +3,8 @@ package com.brandon3055.draconicevolution.integration;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 
@@ -12,7 +14,9 @@ import com.brandon3055.draconicevolution.common.utills.LogHelper;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.registry.GameRegistry;
+import gregtech.api.enums.Materials;
 import gregtech.api.hazards.Hazard;
+import gregtech.api.items.MetaGeneratedTool;
 
 /**
  * Created by brandon3055 on 29/9/2015.
@@ -107,6 +111,23 @@ public class ModHelper {
 
     public static boolean isGregTechTileEntityOre(TileEntity te) {
         return isGregTechInstalled && GTores.isInstance(te) || isBartworkdsInstalled && bwores.isInstance(te);
+    }
+
+    public static boolean isGregTechEnchantmentItem(ItemStack stack) {
+        if (!isGregTechInstalled) return false;
+
+        if (stack.getItem() instanceof MetaGeneratedTool) {
+            Materials material = null;
+            NBTTagCompound aNBT = stack.getTagCompound();
+            if (aNBT != null) {
+                aNBT = aNBT.getCompoundTag("GT.ToolStats");
+                if (aNBT != null) material = Materials.getRealMaterial(aNBT.getString("PrimaryMaterial"));
+            }
+            if (material == null) return false;
+            return material.mEnchantmentTools != null || material.mEnchantmentArmors != null;
+        }
+
+        return false;
     }
 
     public static boolean isAE2EntityFloatingItem(EntityItem item) {

--- a/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/ModHelper.java
@@ -4,7 +4,6 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 
@@ -14,7 +13,6 @@ import com.brandon3055.draconicevolution.common.utills.LogHelper;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.registry.GameRegistry;
-import gregtech.api.enums.Materials;
 import gregtech.api.hazards.Hazard;
 import gregtech.api.items.MetaGeneratedTool;
 
@@ -114,20 +112,11 @@ public class ModHelper {
     }
 
     public static boolean isGregTechEnchantmentItem(ItemStack stack) {
+        if (stack == null) return false;
+        if (stack.getItem() == null) return false;
         if (!isGregTechInstalled) return false;
 
-        if (stack.getItem() instanceof MetaGeneratedTool) {
-            Materials material = null;
-            NBTTagCompound aNBT = stack.getTagCompound();
-            if (aNBT != null) {
-                aNBT = aNBT.getCompoundTag("GT.ToolStats");
-                if (aNBT != null) material = Materials.getRealMaterial(aNBT.getString("PrimaryMaterial"));
-            }
-            if (material == null) return false;
-            return material.mEnchantmentTools != null || material.mEnchantmentArmors != null;
-        }
-
-        return false;
+        return stack.getItem() instanceof MetaGeneratedTool;
     }
 
     public static boolean isAE2EntityFloatingItem(EntityItem item) {


### PR DESCRIPTION
Certain tool materials can grant enchantments which allows them to be infinitely farmed using the disenchanter