### PR TITLE
Add block blacklist for magnets

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
@@ -428,8 +428,14 @@ public class ConfigHandler {
             itemDislocatorBlacklistMap.clear();
             for (String s : itemDislocatorBlacklist) {
                 if (s.contains("|")) {
-                    itemDislocatorBlacklistMap
-                            .put(s.substring(0, s.indexOf("|")), Integer.parseInt(s.substring(s.indexOf("|") + 1)));
+                    try {
+                        itemDislocatorBlacklistMap
+                                .put(s.substring(0, s.indexOf("|")), Integer.parseInt(s.substring(s.indexOf("|") + 1)));
+                    } catch (NumberFormatException e) {
+                        LogHelper.error("Error while loading dislocator blacklist.");
+                        LogHelper.error("Could not parse meta (damage) for \"" + s + "\"");
+                        e.printStackTrace();
+                    }
                 } else {
                     itemDislocatorBlacklistMap.put(s, -1);
                 }
@@ -438,8 +444,14 @@ public class ConfigHandler {
             itemDislocatorBlockBlacklistMap.clear();
             for (String s : itemDislocatorBlockBlacklist) {
                 if (s.contains("|")) {
-                    itemDislocatorBlockBlacklistMap
-                            .put(s.substring(0, s.indexOf("|")), Integer.parseInt(s.substring(s.indexOf("|") + 1)));
+                    try {
+                        itemDislocatorBlockBlacklistMap
+                                .put(s.substring(0, s.indexOf("|")), Integer.parseInt(s.substring(s.indexOf("|") + 1)));
+                    } catch (NumberFormatException e) {
+                        LogHelper.error("Error while loading dislocator block blacklist.");
+                        LogHelper.error("Could not parse meta (damage) for \"" + s + "\"");
+                        e.printStackTrace();
+                    }
                 } else {
                     itemDislocatorBlockBlacklistMap.put(s, -1);
                 }

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
@@ -55,6 +55,8 @@ public class ConfigHandler {
     public static boolean enableFlight;
     private static String[] itemDislocatorBlacklist;
     public static Map<String, Integer> itemDislocatorBlacklistMap = new HashMap<String, Integer>();
+    private static String[] itemDislocatorBlockBlacklist;
+    public static Map<String, Integer> itemDislocatorBlockBlacklistMap = new HashMap<String, Integer>();
     public static boolean itemDislocatorDisableSound;
 
     // spawner
@@ -303,7 +305,12 @@ public class ConfigHandler {
                     "Item Dislocator Blacklist",
                     Configuration.CATEGORY_GENERAL,
                     new String[] { "appliedenergistics2:item.ItemCrystalSeed" },
-                    "A list of items of items that should be ignored by the item dislocator. Use the items registry name e.g. minecraft:apple you can also add a meta value like so minecraft:wool|4");
+                    "A list of items that should be ignored by the item dislocator. Use the items registry name e.g. minecraft:apple you can also add a meta value like so minecraft:wool|4");
+            itemDislocatorBlockBlacklist = config.getStringList(
+                    "Item Dislocator Block Blacklist",
+                    Configuration.CATEGORY_GENERAL,
+                    new String[] { "Thaumcraft:blockAlchemyFurnace|0", "Botania:pool" },
+                    "A list of blocks that will cause items above or inside of them to be ignored by the item dislocator. Use the items registry name e.g. minecraft:apple you can also add a meta value like so minecraft:wool|4");
             itemDislocatorDisableSound = config.get(
                     Configuration.CATEGORY_GENERAL,
                     "Item Dislocator Disable Sound",
@@ -425,6 +432,16 @@ public class ConfigHandler {
                             .put(s.substring(0, s.indexOf("|")), Integer.parseInt(s.substring(s.indexOf("|") + 1)));
                 } else {
                     itemDislocatorBlacklistMap.put(s, -1);
+                }
+            }
+
+            itemDislocatorBlockBlacklistMap.clear();
+            for (String s : itemDislocatorBlockBlacklist) {
+                if (s.contains("|")) {
+                    itemDislocatorBlockBlacklistMap
+                            .put(s.substring(0, s.indexOf("|")), Integer.parseInt(s.substring(s.indexOf("|") + 1)));
+                } else {
+                    itemDislocatorBlockBlacklistMap.put(s, -1);
                 }
             }
 

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
@@ -152,25 +152,19 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
             int y = (int) Math.floor(item.posY);
             int z = (int) Math.floor(item.posZ);
 
-            Block block = world.getBlock(x, y, z);
-            String blockName = Item.itemRegistry.getNameForObject(Item.getItemFromBlock(block));
-            int meta = world.getBlockMetadata(x, y, z);
-            if (ConfigHandler.itemDislocatorBlockBlacklistMap.containsKey(blockName)
-                    && (ConfigHandler.itemDislocatorBlockBlacklistMap.get(blockName) == -1
-                            || ConfigHandler.itemDislocatorBlockBlacklistMap.get(blockName) == meta)) {
-                continue;
+            boolean skip = false;
+            for (int i = 0; i < 2; i++) {
+                Block block = world.getBlock(x, y - i, z);
+                String blockName = Item.itemRegistry.getNameForObject(Item.getItemFromBlock(block));
+                int meta = world.getBlockMetadata(x, y - i, z);
+                if (ConfigHandler.itemDislocatorBlockBlacklistMap.containsKey(blockName)
+                        && (ConfigHandler.itemDislocatorBlockBlacklistMap.get(blockName) == -1
+                                || ConfigHandler.itemDislocatorBlockBlacklistMap.get(blockName) == meta)) {
+                    skip = true;
+                }
             }
 
-            y--;
-
-            block = world.getBlock(x, y, z);
-            blockName = Item.itemRegistry.getNameForObject(Item.getItemFromBlock(block));
-            meta = world.getBlockMetadata(x, y, z);
-            if (ConfigHandler.itemDislocatorBlockBlacklistMap.containsKey(blockName)
-                    && (ConfigHandler.itemDislocatorBlockBlacklistMap.get(blockName) == -1
-                            || ConfigHandler.itemDislocatorBlockBlacklistMap.get(blockName) == meta)) {
-                continue;
-            }
+            if (skip) continue;
 
             if (!skipPlayerCheck) {
                 EntityPlayer closestPlayer = world.getClosestPlayerToEntity(item, range);

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
@@ -3,6 +3,7 @@ package com.brandon3055.draconicevolution.common.items.tools;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -144,6 +145,30 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
                     && (ConfigHandler.itemDislocatorBlacklistMap.get(name) == -1
                             || ConfigHandler.itemDislocatorBlacklistMap.get(name)
                                     == item.getEntityItem().getItemDamage())) {
+                continue;
+            }
+
+            int x = (int) Math.floor(item.posX);
+            int y = (int) Math.floor(item.posY);
+            int z = (int) Math.floor(item.posZ);
+
+            Block block = world.getBlock(x, y, z);
+            String blockName = Item.itemRegistry.getNameForObject(Item.getItemFromBlock(block));
+            int meta = world.getBlockMetadata(x, y, z);
+            if (ConfigHandler.itemDislocatorBlockBlacklistMap.containsKey(blockName)
+                    && (ConfigHandler.itemDislocatorBlockBlacklistMap.get(blockName) == -1
+                            || ConfigHandler.itemDislocatorBlockBlacklistMap.get(blockName) == meta)) {
+                continue;
+            }
+
+            y--;
+
+            block = world.getBlock(x, y, z);
+            blockName = Item.itemRegistry.getNameForObject(Item.getItemFromBlock(block));
+            meta = world.getBlockMetadata(x, y, z);
+            if (ConfigHandler.itemDislocatorBlockBlacklistMap.containsKey(blockName)
+                    && (ConfigHandler.itemDislocatorBlockBlacklistMap.get(blockName) == -1
+                            || ConfigHandler.itemDislocatorBlockBlacklistMap.get(blockName) == meta)) {
                 continue;
             }
 


### PR DESCRIPTION
I was getting annoyed my item dislocator giving me items that I threw into the mana pool and advanced alchemical furnace so I added this.
I thought about adding the crucible to this as well but since it instantly consumes all items you throw into it I found the dislocator ended up being more of a failsafe for me rather than an inconvenience.

This method's comments say
```
    // This method uses the same algorithm as the magnet from AE2 Fluid Crafting
    // if changes are ever made, they should be made on both
```
But the [section](https://github.com/GTNewHorizons/Draconic-Evolution/blob/0937d7b2d648977db7311eaabb156d111df6c7e6/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java#L143) implementing draconic evolution's item blacklist is [missing](https://github.com/GTNewHorizons/AE2FluidCraft-Rework/blob/03140c9d9a7eee0b64f2630814f2d463a90096c4/src/main/java/com/glodblock/github/inventory/item/WirelessMagnet.java#L86) in AE2 Fluid Crafting, so I'm not implementing this there either.

"Thaumcraft:blockAlchemyFurnace|0" is the advanced alchemical furnace.
"Botania:pool" is the botania mana pools