### PR TITLE
Fix nullPointerException

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorStabilizer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/tileentities/multiblocktiles/reactor/TileReactorStabilizer.java
@@ -314,7 +314,11 @@ public class TileReactorStabilizer extends TileEntity
     @Override
     public int getInventoryStackLimit() {
         TileReactorCore core = getMaster();
-        return core.getInventoryStackLimit();
+        if (core != null) {
+            return core.getInventoryStackLimit();
+        } else {
+            return 0;
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes the crash I've experienced, seems like it happens when the master got removed. There are a couple more places that don't have null check, (setInventorySlotContents and decrStackSize), so that might also need to be handled.
[crash-2026-01-29_17.33.47-server.txt](https://github.com/user-attachments/files/24947343/crash-2026-01-29_17.33.47-server.txt)
