### PR TITLE
Add config to disable earth block

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/client/ClientProxy.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/ClientProxy.java
@@ -180,7 +180,7 @@ public class ClientProxy extends CommonProxy {
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.reactorStabilizer), new RenderReactorStabilizer());
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.reactorEnergyInjector), new RenderReactorEnergyInjector());
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.reactorCore), new RenderReactorCore());
-        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.earthBlock), new RenderEarthItem());
+        if (ModBlocks.earthBlock != null) MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.earthBlock), new RenderEarthItem());
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.chaosCrystal), new RenderChaosShard());
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.upgradeModifier), new RenderUpgradeModifier());
 
@@ -194,7 +194,7 @@ public class ClientProxy extends CommonProxy {
         ClientRegistry.bindTileEntitySpecialRenderer(TileCustomSpawner.class, new RenderTileCustomSpawner());
         // ClientRegistry.bindTileEntitySpecialRenderer(TileTestBlock.class, new RenderTileCrystal());
         ClientRegistry.bindTileEntitySpecialRenderer(TileEnergyStorageCore.class, new RenderTileEnergyStorageCore());
-        ClientRegistry.bindTileEntitySpecialRenderer(TileEarth.class, new RenderTileEarth());
+        if (ModBlocks.earthBlock != null) ClientRegistry.bindTileEntitySpecialRenderer(TileEarth.class, new RenderTileEarth());
         ClientRegistry.bindTileEntitySpecialRenderer(TileEnergyPylon.class, new RenderTileEnergyPylon());
         ClientRegistry.bindTileEntitySpecialRenderer(TilePlacedItem.class, new RenderTilePlacedItem());
         ClientRegistry.bindTileEntitySpecialRenderer(TileDissEnchanter.class, new RenderTileDissEnchanter());

--- a/src/main/java/com/brandon3055/draconicevolution/client/ClientProxy.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/ClientProxy.java
@@ -139,6 +139,7 @@ public class ClientProxy extends CommonProxy {
     }
 
     public void registerRendering() {
+        // spotless:off
         // Item Renderers
         MinecraftForgeClient.registerItemRenderer(ModItems.wyvernBow, new RenderBow());
         MinecraftForgeClient.registerItemRenderer(ModItems.draconicBow, new RenderBow());
@@ -159,84 +160,29 @@ public class ClientProxy extends CommonProxy {
         }
 
         if (!ConfigHandler.useOldD2DToolTextures) {
-            MinecraftForgeClient.registerItemRenderer(
-                    ModItems.draconicSword,
-                    new RenderTool(
-                            "models/tools/DraconicSword.obj",
-                            "textures/models/tools/DraconicSword.png",
-                            (IRenderTweak) ModItems.draconicSword));
-            MinecraftForgeClient.registerItemRenderer(
-                    ModItems.wyvernPickaxe,
-                    new RenderTool(
-                            "models/tools/Pickaxe.obj",
-                            "textures/models/tools/Pickaxe.png",
-                            (IRenderTweak) ModItems.wyvernPickaxe));
-            MinecraftForgeClient.registerItemRenderer(
-                    ModItems.draconicPickaxe,
-                    new RenderTool(
-                            "models/tools/DraconicPickaxe.obj",
-                            "textures/models/tools/DraconicPickaxe.png",
-                            (IRenderTweak) ModItems.draconicPickaxe));
-            MinecraftForgeClient.registerItemRenderer(
-                    ModItems.draconicAxe,
-                    new RenderTool(
-                            "models/tools/DraconicLumberAxe.obj",
-                            "textures/models/tools/DraconicLumberAxe.png",
-                            (IRenderTweak) ModItems.draconicAxe));
-            MinecraftForgeClient.registerItemRenderer(
-                    ModItems.wyvernShovel,
-                    new RenderTool(
-                            "models/tools/Shovel.obj",
-                            "textures/models/tools/Shovel.png",
-                            (IRenderTweak) ModItems.wyvernShovel));
-            MinecraftForgeClient.registerItemRenderer(
-                    ModItems.draconicShovel,
-                    new RenderTool(
-                            "models/tools/DraconicShovel.obj",
-                            "textures/models/tools/DraconicShovel.png",
-                            (IRenderTweak) ModItems.draconicShovel));
-            MinecraftForgeClient.registerItemRenderer(
-                    ModItems.wyvernSword,
-                    new RenderTool(
-                            "models/tools/Sword.obj",
-                            "textures/models/tools/Sword.png",
-                            (IRenderTweak) ModItems.wyvernSword));
-            MinecraftForgeClient.registerItemRenderer(
-                    ModItems.draconicDestructionStaff,
-                    new RenderTool(
-                            "models/tools/DraconicStaffOfPower.obj",
-                            "textures/models/tools/DraconicStaffOfPower.png",
-                            (IRenderTweak) ModItems.draconicDestructionStaff));
-            MinecraftForgeClient.registerItemRenderer(
-                    ModItems.draconicHoe,
-                    new RenderTool(
-                            "models/tools/DraconicHoe.obj",
-                            "textures/models/tools/DraconicHoe.png",
-                            (IRenderTweak) ModItems.draconicHoe));
+            MinecraftForgeClient.registerItemRenderer(ModItems.draconicSword, new RenderTool("models/tools/DraconicSword.obj", "textures/models/tools/DraconicSword.png", (IRenderTweak) ModItems.draconicSword));
+            MinecraftForgeClient.registerItemRenderer(ModItems.wyvernPickaxe, new RenderTool("models/tools/Pickaxe.obj", "textures/models/tools/Pickaxe.png", (IRenderTweak) ModItems.wyvernPickaxe));
+            MinecraftForgeClient.registerItemRenderer(ModItems.draconicPickaxe, new RenderTool("models/tools/DraconicPickaxe.obj", "textures/models/tools/DraconicPickaxe.png", (IRenderTweak) ModItems.draconicPickaxe));
+            MinecraftForgeClient.registerItemRenderer(ModItems.draconicAxe, new RenderTool("models/tools/DraconicLumberAxe.obj", "textures/models/tools/DraconicLumberAxe.png", (IRenderTweak) ModItems.draconicAxe));
+            MinecraftForgeClient.registerItemRenderer(ModItems.wyvernShovel, new RenderTool("models/tools/Shovel.obj", "textures/models/tools/Shovel.png", (IRenderTweak) ModItems.wyvernShovel));
+            MinecraftForgeClient.registerItemRenderer(ModItems.draconicShovel, new RenderTool("models/tools/DraconicShovel.obj", "textures/models/tools/DraconicShovel.png", (IRenderTweak) ModItems.draconicShovel));
+            MinecraftForgeClient.registerItemRenderer(ModItems.wyvernSword, new RenderTool("models/tools/Sword.obj", "textures/models/tools/Sword.png", (IRenderTweak) ModItems.wyvernSword));
+            MinecraftForgeClient.registerItemRenderer(ModItems.draconicDestructionStaff, new RenderTool("models/tools/DraconicStaffOfPower.obj", "textures/models/tools/DraconicStaffOfPower.png", (IRenderTweak) ModItems.draconicDestructionStaff));
+            MinecraftForgeClient.registerItemRenderer(ModItems.draconicHoe, new RenderTool("models/tools/DraconicHoe.obj", "textures/models/tools/DraconicHoe.png", (IRenderTweak) ModItems.draconicHoe));
             MinecraftForgeClient.registerItemRenderer(ModItems.draconicBow, new RenderBowModel(true));
             MinecraftForgeClient.registerItemRenderer(ModItems.wyvernBow, new RenderBowModel(false));
         }
 
-        MinecraftForgeClient
-                .registerItemRenderer(Item.getItemFromBlock(ModBlocks.draconiumChest), new RenderDraconiumChest());
-        MinecraftForgeClient
-                .registerItemRenderer(Item.getItemFromBlock(ModBlocks.particleGenerator), new RenderParticleGen());
-        MinecraftForgeClient
-                .registerItemRenderer(Item.getItemFromBlock(ModBlocks.energyInfuser), new RenderEnergyInfuser());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.draconiumChest), new RenderDraconiumChest());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.particleGenerator), new RenderParticleGen());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.energyInfuser), new RenderEnergyInfuser());
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.energyCrystal), new RenderCrystal());
-        MinecraftForgeClient.registerItemRenderer(
-                Item.getItemFromBlock(ModBlocks.reactorStabilizer),
-                new RenderReactorStabilizer());
-        MinecraftForgeClient.registerItemRenderer(
-                Item.getItemFromBlock(ModBlocks.reactorEnergyInjector),
-                new RenderReactorEnergyInjector());
-        MinecraftForgeClient
-                .registerItemRenderer(Item.getItemFromBlock(ModBlocks.reactorCore), new RenderReactorCore());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.reactorStabilizer), new RenderReactorStabilizer());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.reactorEnergyInjector), new RenderReactorEnergyInjector());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.reactorCore), new RenderReactorCore());
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.earthBlock), new RenderEarthItem());
-        MinecraftForgeClient
-                .registerItemRenderer(Item.getItemFromBlock(ModBlocks.chaosCrystal), new RenderChaosShard());
-        MinecraftForgeClient
-                .registerItemRenderer(Item.getItemFromBlock(ModBlocks.upgradeModifier), new RenderUpgradeModifier());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.chaosCrystal), new RenderChaosShard());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(ModBlocks.upgradeModifier), new RenderUpgradeModifier());
 
         // ISimpleBlockRendering
         RenderingRegistry.registerBlockHandler(new RenderTeleporterStand());
@@ -259,8 +205,7 @@ public class ClientProxy extends CommonProxy {
         ClientRegistry.bindTileEntitySpecialRenderer(TileWirelessEnergyTransceiver.class, new RenderTileCrystal());
         ClientRegistry.bindTileEntitySpecialRenderer(TileReactorCore.class, new RenderTileReactorCore());
         ClientRegistry.bindTileEntitySpecialRenderer(TileReactorStabilizer.class, new RenderTileReactorStabilizer());
-        ClientRegistry
-                .bindTileEntitySpecialRenderer(TileReactorEnergyInjector.class, new RenderTileReactorEnergyInjector());
+        ClientRegistry.bindTileEntitySpecialRenderer(TileReactorEnergyInjector.class, new RenderTileReactorEnergyInjector());
         ClientRegistry.bindTileEntitySpecialRenderer(TileChaosShard.class, new RenderTileChaosShard());
         ClientRegistry.bindTileEntitySpecialRenderer(TileUpgradeModifier.class, new RenderTileUpgradeModifier());
 
@@ -272,6 +217,7 @@ public class ClientProxy extends CommonProxy {
         RenderingRegistry.registerEntityRenderingHandler(EntityChaosCrystal.class, new RenderChaosCrystal());
         RenderingRegistry.registerEntityRenderingHandler(EntityChaosVortex.class, new RenderEntityChaosVortex());
         RenderingRegistry.registerEntityRenderingHandler(EntityCustomArrow.class, new RenderEntityCustomArrow());
+        // spotless:on
     }
 
     public void registerRenderIDs() {

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileEarth.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/tile/RenderTileEarth.java
@@ -32,9 +32,8 @@ public class RenderTileEarth extends TileEntitySpecialRenderer {
 
     @Override
     public void renderTileEntityAt(TileEntity tile, double x, double y, double z, float timeSinceLastTick) {
-        if (!(tile instanceof TileEarth)) return;
+        if (!(tile instanceof TileEarth tileEarth)) return;
 
-        TileEarth tileEarth = (TileEarth) tile;
         float scale = 0.01f * tileEarth.getSize();
 
         GL11.glPushMatrix();

--- a/src/main/java/com/brandon3055/draconicevolution/common/CommonProxy.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/CommonProxy.java
@@ -191,7 +191,7 @@ public class CommonProxy {
         GameRegistry.registerTileEntity(TileCustomSpawner.class, References.RESOURCESPREFIX + "TileCustomSpawner");
         GameRegistry.registerTileEntity(TileGenerator.class, References.RESOURCESPREFIX + "TileGenerator");
         GameRegistry.registerTileEntity(TileEnergyStorageCore.class, References.RESOURCESPREFIX + "TileEnergyStorageCore");
-        GameRegistry.registerTileEntity(TileEarth.class, References.RESOURCESPREFIX + "TileEarth");
+        if (ModBlocks.earthBlock != null) GameRegistry.registerTileEntity(TileEarth.class, References.RESOURCESPREFIX + "TileEarth");
         GameRegistry.registerTileEntity(TileInvisibleMultiblock.class, References.RESOURCESPREFIX + "TileInvisibleMultiblock");
         GameRegistry.registerTileEntity(TileEnergyPylon.class, References.RESOURCESPREFIX + "TileEnergyPylon");
         GameRegistry.registerTileEntity(TileEnderResurrection.class, References.RESOURCESPREFIX + "TileEnderResurrection");

--- a/src/main/java/com/brandon3055/draconicevolution/common/ModBlocks.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/ModBlocks.java
@@ -110,7 +110,7 @@ public class ModBlocks {
         customSpawner = new CustomSpawner();
         generator = new Generator();
         energyStorageCore = new EnergyStorageCore();
-        earthBlock = new Earth();
+        if (!ConfigHandler.disableEarthBlock) earthBlock = new Earth();
         draconiumBlock = new DraconiumBlock();
         invisibleMultiblock = new InvisibleMultiblock();
         energyPylon = new EnergyPylon();

--- a/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/handler/ConfigHandler.java
@@ -15,6 +15,7 @@ public class ConfigHandler {
     public static Configuration config;
 
     // GENERAL
+    public static boolean disableEarthBlock;
     public static int teleporterUsesPerPearl;
     public static int soulDropChance;
     public static int passiveSoulDropChance;
@@ -104,6 +105,9 @@ public class ConfigHandler {
             // 0:Default, 1:Disable recipe, 2:Disable completely").getInt(0);
             // disableXrayBlock = config.get(Configuration.CATEGORY_GENERAL, "Disable Xray Block", 0, "Disable
             // Distortion Flame 0:Default, 1:Disable recipe, 2:Disable completely").getInt(0);
+            disableEarthBlock = config
+                    .get(Configuration.CATEGORY_GENERAL, "Disable Earth block", false, "Disables the Earth block")
+                    .getBoolean(false);
             teleporterUsesPerPearl = config.get(
                     Configuration.CATEGORY_GENERAL,
                     "Teleporter Uses PerPearl",


### PR DESCRIPTION
The renderer for this block takes 3.8Mo of RAM but it has no uses in the pack. Currently I just added a config but I did not disable it.
<img width="652" height="231" alt="image" src="https://github.com/user-attachments/assets/42062e03-3089-4cb3-9468-b25eefd71e68" />
