### PR TITLE
Add API to get nearby ChaosIsland coordinate

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/api/GeneratorOverride.java
+++ b/src/main/java/com/brandon3055/draconicevolution/api/GeneratorOverride.java
@@ -2,8 +2,12 @@ package com.brandon3055.draconicevolution.api;
 
 import java.util.Random;
 
+import javax.annotation.Nullable;
+
+import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.world.World;
 
+import com.brandon3055.draconicevolution.common.handler.ConfigHandler;
 import com.brandon3055.draconicevolution.common.utils.DataUtils;
 import com.brandon3055.draconicevolution.common.world.ChaosWorldGenHandler;
 import com.brandon3055.draconicevolution.common.world.DraconicWorldGenerator;
@@ -66,5 +70,26 @@ public class GeneratorOverride {
      */
     public static void setOreEnabledInEnd(boolean cometsEnabled) {
         DraconicWorldGenerator.oreEnabledInEnd = cometsEnabled;
+    }
+
+    /**
+     * Returns coordinates of the nearest chaos island for the given chunk, or {@code null}
+     * <p>
+     * This is for mods who need to know where chaos islands generate, for example to avoid overlapping their own world
+     * features.
+     *
+     * @param chunkX chunk X position
+     * @param chunkZ chunk Z position
+     * @return Chaos Island Center coordinates, or {@code null} if none generates for that cell
+     */
+    public static @Nullable ChunkCoordinates getNearestChaosIslandCenter(int chunkX, int chunkZ) {
+        if (!DraconicWorldGenerator.chaosIslandsEnabled || !ConfigHandler.generateChaosIslands) return null;
+
+        DataUtils.XZPair<Integer, Integer> center = ChaosWorldGenHandler.getClosestChaosSpawn(chunkX, chunkZ);
+
+        // tHe island in (0, 0) is never generated
+        if (center.x == 0 && center.z == 0) return null;
+
+        return new ChunkCoordinates(center.x, 80, center.z);
     }
 }


### PR DESCRIPTION
Add an API way to get nearest chaos island.

Purpose is right now the GT world gen spawn asteroids everywhere on those and I want to create an "exclusion zone" to make things overlap less.
Since it's not fully hard coded and can be configured (range + disable) this would be the cleanest way to deal with it.