### PR TITLE
Cache enum `.values()`

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
@@ -60,9 +60,11 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
         ALWAYS,
         DELAY,
         NEVER;
+        
+        public static final SelfPickUpMode[] VALUES = values();
 
         public SelfPickUpMode next() {
-            final SelfPickUpMode[] values = SelfPickUpMode.values();
+            final SelfPickUpMode[] values = SelfPickUpMode.VALUES;
             return values[(this.ordinal() + 1) % values.length];
         }
     }
@@ -265,7 +267,7 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
 
     private static SelfPickUpMode getSelfPickupStatus(ItemStack itemStack) {
         final short mode = getSelfPickupStatusShort(itemStack);
-        return SelfPickUpMode.values()[mode];
+        return SelfPickUpMode.VALUES[mode];
     }
 
     public static void toggleSelfPickupStatus(ItemStack itemStack) {

--- a/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
+++ b/src/main/java/com/brandon3055/draconicevolution/common/items/tools/Magnet.java
@@ -60,7 +60,7 @@ public class Magnet extends ItemDE implements IBauble, IConfigurableItem {
         ALWAYS,
         DELAY,
         NEVER;
-        
+
         public static final SelfPickUpMode[] VALUES = values();
 
         public SelfPickUpMode next() {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
caching enum values() calls that got called more than 500 times during my little playtest.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
